### PR TITLE
feat(1340): choose plan or plan+apply by button, and offer it on a drifted run

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -413,6 +413,7 @@ All workspace responses (show and list) include a `permissions` object reflectin
     "can-update": true,
     "can-destroy": true,
     "can-queue-run": true,
+    "can-queue-apply": true,
     "can-read-state-versions": true,
     "can-create-state-versions": true,
     "can-read-variable": true,

--- a/docs/drift-detection.md
+++ b/docs/drift-detection.md
@@ -103,6 +103,27 @@ The status is updated after each drift run completes. The mapping from run outco
 | `errored` | — | `errored` |
 | `canceled` / `discarded` | — | No update |
 
+### Remediating drift
+
+When you open a drift run that found changes, the run page offers a **Plan + apply**
+button: it queues an ordinary plan-and-apply run against the workspace's current
+configuration, with default plan options.
+
+Drift runs are plan-only and never apply, by design — a scheduled job must not
+change infrastructure on its own. But that leaves the operator on a page that
+reports a problem and offers nothing to do about it; reconciling meant navigating
+back to the workspace and queuing a run by hand. The button is that same run, one
+press from the evidence.
+
+It appears only when the run is a drift run that found changes, and only for a user
+with `run:apply` on the workspace (`can-queue-apply`) — see
+[RBAC](rbac.md#permissions-block-in-api-responses). It is hidden while the workspace
+is locked.
+
+Applying is not the only answer: drift can equally mean the configuration should be
+updated to match what is actually deployed. The button offers the first; the choice
+is yours.
+
 ### Dismissing drift
 
 When a workspace shows `drifted` or `errored` status — for example after you've acknowledged the drift and plan to reconcile it through a real apply — you can clear the reported state without disabling scheduled drift detection.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -482,6 +482,7 @@ Included in workspace show/list responses:
     "can-update": true,
     "can-destroy": true,
     "can-queue-run": true,
+    "can-queue-apply": true,
     "can-read-state-versions": true,
     "can-create-state-versions": true,
     "can-read-variable": true,
@@ -529,6 +530,7 @@ Included in provider show/list responses (same shape as modules):
 | `can-update` | `admin` | `admin` |
 | `can-destroy` | `admin` | `admin` |
 | `can-queue-run` | `plan` | — |
+| `can-queue-apply` | `write` | — |
 | `can-lock` / `can-unlock` | `plan` | — |
 | `can-force-unlock` | `admin` | — |
 | `can-update-variable` | `write` | — |
@@ -544,6 +546,7 @@ The web UI hides or disables controls based on these permission flags:
 | Delete Workspace/Module/Provider | `can-destroy` | Hidden |
 | Lock/Unlock button | `can-lock` | Hidden |
 | Queue Plan button | `can-queue-run` | Hidden |
+| Plan + apply button | `can-queue-apply` | Hidden |
 | Add/Edit/Delete Variable | `can-update-variable` | Hidden |
 | Settings edit fields | `can-update` | Read-only |
 | Add/Edit/Delete Notification | `can-update` | Hidden |

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -88,6 +88,24 @@ test.describe('Responsive harness (phone viewport)', () => {
     }
   })
 
+  test('both queue buttons are reachable at phone width (#1340)', async ({ page }) => {
+    const token = getStoredToken()
+    const wsId = await createWorkspace(token, uniqueName('e2eresp-queue'))
+
+    await page.goto(`/workspaces/${wsId}?tab=runs`)
+
+    // Plan-vs-apply is the decision that matters every time, so neither button
+    // may be hidden behind a breakpoint — a phone must be able to make the
+    // same choice a desktop can.
+    await expect(page.getByRole('button', { name: 'Plan', exact: true })).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(page.getByRole('button', { name: 'Plan + apply', exact: true })).toBeVisible()
+
+    // Four buttons on one row is where a phone starts scrolling sideways.
+    await expectNoHorizontalPageScroll(page)
+  })
+
   test('runs at a phone viewport', async ({ page }) => {
     const vp = page.viewportSize();
     expect(vp, 'responsive project must set a viewport').not.toBeNull();

--- a/e2e/tests/runs.spec.ts
+++ b/e2e/tests/runs.spec.ts
@@ -15,7 +15,8 @@
  * not here — the E2E stack has no runner pool. We exercise the UI
  * surfaces with API-seeded runs.
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Route } from '@playwright/test';
+import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api';
 
 test.describe('Run lifecycle UI', () => {
   test('workspace runs tab renders empty state cleanly', async ({ page }) => {
@@ -55,4 +56,85 @@ test.describe('Run lifecycle UI', () => {
     const runsBtn = page.getByRole('button', { name: 'Runs' });
     await expect(runsBtn).toBeVisible();
   });
+
+  // ── Plan vs plan+apply is chosen by button, not a hidden checkbox (#1340) ──
+
+  test('both queue buttons are offered, and Plan is unchanged', async ({ page }) => {
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('e2e-queue-buttons'));
+
+    await page.goto(`/workspaces/${wsId}?tab=runs`);
+
+    // The decision that matters is on the surface, not behind "Options".
+    const plan = page.getByRole('button', { name: 'Plan', exact: true });
+    const planApply = page.getByRole('button', { name: 'Plan + apply', exact: true });
+    await expect(plan).toBeVisible({ timeout: 15_000 });
+    await expect(planApply).toBeVisible();
+
+    // The checkbox it replaced must be gone — if it lingered, the two
+    // mechanisms could disagree about what the next run is.
+    await page.getByRole('button', { name: /Options/ }).click();
+    await expect(page.getByText('Plan Only', { exact: true })).toHaveCount(0);
+  });
+
+  test('Plan queues a plan-only run', async ({ page }) => {
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('e2e-queue-plan'));
+
+    // Assert on what is actually sent: "plan-only" true is the behaviour the
+    // issue promised to leave untouched, and a label alone cannot prove it.
+    let body: string | null = null;
+    await page.route('**/api/v2/runs', async (route: Route) => {
+      if (route.request().method() === 'POST') body = route.request().postData();
+      await route.continue();
+    });
+
+    await page.goto(`/workspaces/${wsId}?tab=runs`);
+    await page.getByRole('button', { name: 'Plan', exact: true }).click();
+
+    await expect.poll(() => body, { timeout: 15_000 }).not.toBeNull();
+    expect(JSON.parse(body!).data.attributes['plan-only']).toBe(true);
+  });
+
+  test('a drift run that found drift offers plan + apply', async ({ page }) => {
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('e2e-drift-remediate'));
+
+    // The API cannot create a drift run — only the drift checker does, and the
+    // E2E stack has no runner. So the run payload is stubbed: this pins the UI
+    // gate (drift + has-changes ⇒ offer), not the detection itself.
+    await page.route('**/api/v2/runs/run-*', async (route: Route) => {
+      const res = await route.fetch();
+      const json = await res.json().catch(() => null);
+      if (!json?.data?.attributes) return route.fulfill({ response: res });
+      json.data.attributes['is-drift-detection'] = true;
+      json.data.attributes['has-changes'] = true;
+      await route.fulfill({ response: res, json });
+    });
+
+    const runId = await seedDriftShapedRun(token, wsId);
+    await page.goto(`/workspaces/${wsId}/runs/${runId}`);
+
+    await expect(page.getByRole('button', { name: 'Plan + apply', exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
 });
+
+/** A plan-only run whose payload the test then reshapes into a drift run. */
+async function seedDriftShapedRun(token: string, workspaceId: string): Promise<string> {
+  const API_URL = process.env.API_URL || 'http://localhost:8000';
+  const res = await fetch(`${API_URL}/api/v2/runs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/vnd.api+json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      data: {
+        type: 'runs',
+        attributes: { 'plan-only': true },
+        relationships: { workspace: { data: { type: 'workspaces', id: workspaceId } } },
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`seed run failed: ${res.status} ${await res.text()}`);
+  return (await res.json()).data.id as string;
+}

--- a/e2e/tests/runs.spec.ts
+++ b/e2e/tests/runs.spec.ts
@@ -16,7 +16,7 @@
  * surfaces with API-seeded runs.
  */
 import { test, expect, type Route } from '@playwright/test';
-import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api';
+import { getStoredToken, createWorkspace, seedRun, uniqueName } from '../helpers/api';
 
 test.describe('Run lifecycle UI', () => {
   test('workspace runs tab renders empty state cleanly', async ({ page }) => {
@@ -112,7 +112,9 @@ test.describe('Run lifecycle UI', () => {
       await route.fulfill({ response: res, json });
     });
 
-    const runId = await seedDriftShapedRun(token, wsId);
+    // Plain plan-only run (config version and all) — the route mock above is
+    // what makes it read as a drift run.
+    const runId = await seedRun(token, wsId);
     await page.goto(`/workspaces/${wsId}/runs/${runId}`);
 
     await expect(page.getByRole('button', { name: 'Plan + apply', exact: true })).toBeVisible({
@@ -120,21 +122,3 @@ test.describe('Run lifecycle UI', () => {
     });
   });
 });
-
-/** A plan-only run whose payload the test then reshapes into a drift run. */
-async function seedDriftShapedRun(token: string, workspaceId: string): Promise<string> {
-  const API_URL = process.env.API_URL || 'http://localhost:8000';
-  const res = await fetch(`${API_URL}/api/v2/runs`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/vnd.api+json', Authorization: `Bearer ${token}` },
-    body: JSON.stringify({
-      data: {
-        type: 'runs',
-        attributes: { 'plan-only': true },
-        relationships: { workspace: { data: { type: 'workspaces', id: workspaceId } } },
-      },
-    }),
-  });
-  if (!res.ok) throw new Error(`seed run failed: ${res.status} ${await res.text()}`);
-  return (await res.json()).data.id as string;
-}

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -831,6 +831,11 @@ def _workspace_json(
                     "can-update": has_capability(caps, cap.WORKSPACE_SETTINGS),
                     "can-destroy": has_capability(caps, cap.WORKSPACE_DELETE),
                     "can-queue-run": has_capability(caps, cap.RUN_PLAN),
+                    # Distinct from can-queue-run, which is plan-only. Without
+                    # it a UI cannot tell whether to offer an apply, so it either
+                    # hides the capability from people who have it or shows a
+                    # control that 403s on press (#1340).
+                    "can-queue-apply": has_capability(caps, cap.RUN_APPLY),
                     "can-read-state-versions": has_capability(caps, cap.STATE_READ_METADATA),
                     "can-create-state-versions": has_capability(caps, cap.STATE_WRITE),
                     "can-read-variable": has_capability(caps, cap.VAR_READ),

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -698,6 +698,10 @@ class TestPermissionsBlock:
         assert perms["can-destroy"] is False
         assert perms["can-queue-run"] is False
         assert perms["can-lock"] is False
+        # Plan and apply are separate grants (#1340). A read-only caller must
+        # not be told it may apply — the UI decides whether to offer the button
+        # from this, so a wrong value here becomes a control that 403s.
+        assert perms["can-queue-apply"] is False
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -722,6 +726,34 @@ class TestPermissionsBlock:
         assert perms["can-queue-run"] is True
         assert perms["can-lock"] is True
         assert perms["can-force-unlock"] is True
+        assert perms["can-queue-apply"] is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_plan_without_apply_is_expressible(self, mock_resolve, *mocks):
+        """The case the two flags exist for: may plan, may not apply.
+
+        `plan` grants run:plan but not run:apply. Before they were separate the
+        UI saw one "can queue a run" flag and had to either hide the apply from
+        everyone or offer it to people the API would refuse.
+        """
+        mock_resolve.return_value = caps_for_level("plan")
+        ws = _mock_workspace()
+        app, mock_db = _make_app(_user())
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run_result = MagicMock()
+        no_run_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run_result]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+
+        perms = resp.json()["data"]["attributes"]["permissions"]
+        assert perms["can-queue-run"] is True, "plan level must be able to queue a plan"
+        assert perms["can-queue-apply"] is False, "plan level must NOT be offered an apply"
 
 
 # ── Tag bindings (terraform key-value tag support probe) ───────────────

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -1863,7 +1863,8 @@
       "discarding": "جارٍ التجاهل…",
       "cancelShort": "إلغاء",
       "cancelFull": "إلغاء التشغيل",
-      "canceling": "جارٍ الإلغاء…"
+      "canceling": "جارٍ الإلغاء…",
+      "queuing": "جارٍ الإضافة إلى قائمة الانتظار…"
     },
     "confirm": {
       "apply": "تطبيق هذا التشغيل؟ يؤدي ذلك إلى تطبيق الخطة وتغيير البنية التحتية.",
@@ -2160,6 +2161,13 @@
         "sendError": "تعذّر إرسال رسالتك."
       },
       "translatedNote": "تُرجم من الأصل عند العرض."
+    },
+    "drift": {
+      "remediate": "خطة + تطبيق",
+      "remediateTitle": "إضافة تشغيل خطة + تطبيق لإعادة مواءمة البنية التحتية مع الإعداد",
+      "remediateConfirm": "هل تريد إضافة تشغيل خطة + تطبيق لمساحة العمل هذه؟",
+      "remediateMessage": "أُضيف إلى قائمة الانتظار من فحص الانحراف",
+      "remediateFailed": "تعذّرت إضافة تشغيل الإصلاح إلى قائمة الانتظار"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "الخيارات",
       "hideOptions": "إخفاء الخيارات",
-      "queueDestroy": "إضافة الحذف إلى قائمة الانتظار",
+      "queueDestroy": "تدمير",
       "queueDestroyTitle": "إضافة خطة حذف إلى قائمة الانتظار",
       "destroyAllConfirm": "هل تريد حذف جميع الموارد؟",
       "confirmDestroy": "تأكيد الحذف",
-      "queuePlan": "إضافة خطة إلى قائمة الانتظار",
-      "queueRun": "إضافة تشغيل إلى قائمة الانتظار",
+      "queuePlan": "خطة",
+      "queueRun": "خطة + تطبيق",
       "queuePlanConfirm": "هل تريد إضافة خطة تخمينية لمساحة العمل هذه إلى قائمة الانتظار؟",
       "queueApplyConfirm": "هل تريد إضافة تشغيل خطة + تطبيق إلى قائمة الانتظار؟ قد يؤدي هذا إلى تغيير البنية التحتية.",
       "planOptions": "خيارات الخطة",
       "targetResources": "الموارد المستهدفة",
       "replaceResources": "استبدال الموارد",
       "commaSeparated": "(مفصولة بفواصل)",
-      "planOnly": "خطة فقط",
       "refreshOnly": "تحديث فقط",
       "skipRefresh": "تخطي التحديث",
       "allowEmptyApply": "السماح بتطبيق فارغ",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "خطة فقط",
       "typePlanApply": "خطة + تطبيق",
       "sourceModuleTest": "اختبار الوحدة",
-      "sourceModulePublish": "نشر الوحدة"
+      "sourceModulePublish": "نشر الوحدة",
+      "queueApplyTitle": "إضافة تشغيل خطة + تطبيق إلى قائمة الانتظار",
+      "queueApplyRefBlocked": "التطبيق غير متاح أثناء تحديد فرع أو وسم أو التزام — تلك التشغيلات تكون دائمًا خطة فقط"
     },
     "state": {
       "deleteConfirm": "هل تريد حذف نسخة الحالة رقم #{serial}؟ لا يمكن التراجع عن هذا.",

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -1863,7 +1863,8 @@
       "discarding": "Zahazování…",
       "cancelShort": "Zrušit",
       "cancelFull": "Zrušit běh",
-      "canceling": "Rušení…"
+      "canceling": "Rušení…",
+      "queuing": "Zařazuje se…"
     },
     "confirm": {
       "apply": "Aplikovat tento běh? Toto aplikuje plán a změní infrastrukturu.",
@@ -2160,6 +2161,13 @@
         "sendError": "Nepodařilo se odeslat zprávu."
       },
       "translatedNote": "Přeloženo z originálu při zobrazení."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Zařadit běh plan + apply, aby se infrastruktura opět shodovala s konfigurací",
+      "remediateConfirm": "Zařadit běh plan + apply pro tento pracovní prostor?",
+      "remediateMessage": "Zařazeno z kontroly odchylek",
+      "remediateFailed": "Nápravný běh se nepodařilo zařadit"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Možnosti",
       "hideOptions": "Skrýt možnosti",
-      "queueDestroy": "Zařadit zničení",
+      "queueDestroy": "Zničit",
       "queueDestroyTitle": "Zařadit destroy plán do fronty",
       "destroyAllConfirm": "Zničit všechny prostředky?",
       "confirmDestroy": "Potvrdit zničení",
-      "queuePlan": "Zařadit plán",
-      "queueRun": "Zařadit běh",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Zařadit spekulativní plán pro tento pracovní prostor?",
       "queueApplyConfirm": "Zařadit běh plan + apply? Toto může změnit infrastrukturu.",
       "planOptions": "Možnosti plánu",
       "targetResources": "Cílové prostředky",
       "replaceResources": "Nahradit prostředky",
       "commaSeparated": "(oddělené čárkou)",
-      "planOnly": "Pouze plán",
       "refreshOnly": "Pouze refresh",
       "skipRefresh": "Přeskočit refresh",
       "allowEmptyApply": "Povolit prázdný apply",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "pouze plán",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "test modulu",
-      "sourceModulePublish": "publikace modulu"
+      "sourceModulePublish": "publikace modulu",
+      "queueApplyTitle": "Zařadit běh plan + apply",
+      "queueApplyRefBlocked": "Apply není dostupné, pokud je vybrána větev, značka nebo commit — takové běhy jsou vždy pouze plan"
     },
     "state": {
       "deleteConfirm": "Smazat verzi stavu #{serial}? Toto nelze vrátit zpět.",

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -1863,7 +1863,8 @@
       "discarding": "Wrthi'n taflu…",
       "cancelShort": "Canslo",
       "cancelFull": "Canslo'r Rhediad",
-      "canceling": "Wrthi'n canslo…"
+      "canceling": "Wrthi'n canslo…",
+      "queuing": "Yn ciwio…"
     },
     "confirm": {
       "apply": "Gweithredu'r rhediad hwn? Mae hyn yn gweithredu'r cynllun ac yn newid seilwaith.",
@@ -2160,6 +2161,13 @@
         "sendError": "Methwyd anfon eich neges."
       },
       "translatedNote": "Cyfieithwyd o''r gwreiddiol wrth ei weld."
+    },
+    "drift": {
+      "remediate": "Cynllun + gweithredu",
+      "remediateTitle": "Ciwio rhediad cynllun + gweithredu i ailalinio''r seilwaith â''r ffurfweddiad",
+      "remediateConfirm": "Ciwio rhediad cynllun + gweithredu ar gyfer y gweithle hwn?",
+      "remediateMessage": "Wedii giwio o wiriad drifft",
+      "remediateFailed": "Methwyd â chiwio''r rhediad cywiro"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opsiynau",
       "hideOptions": "Cuddio Opsiynau",
-      "queueDestroy": "Ciwio Dinistrio",
+      "queueDestroy": "Dinistrio",
       "queueDestroyTitle": "Ciwio cynllun dinistrio",
       "destroyAllConfirm": "Dinistrio pob adnodd?",
       "confirmDestroy": "Cadarnhau Dinistrio",
-      "queuePlan": "Ciwio Cynllun",
-      "queueRun": "Ciwio Rhediad",
+      "queuePlan": "Cynllun",
+      "queueRun": "Cynllun + gweithredu",
       "queuePlanConfirm": "Ciwio cynllun tybiannol ar gyfer y weithfan hon?",
       "queueApplyConfirm": "Ciwio rhediad cynllun + gweithredu? Gall hyn newid seilwaith.",
       "planOptions": "Opsiynau Cynllun",
       "targetResources": "Adnoddau targed",
       "replaceResources": "Amnewid adnoddau",
       "commaSeparated": "(wedi'u gwahanu â choma)",
-      "planOnly": "Cynllun yn Unig",
       "refreshOnly": "Adnewyddu'n Unig",
       "skipRefresh": "Hepgor Adnewyddu",
       "allowEmptyApply": "Caniatáu Gweithredu Gwag",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "cynllun yn unig",
       "typePlanApply": "cynllun + gweithredu",
       "sourceModuleTest": "prawf modiwl",
-      "sourceModulePublish": "cyhoeddi modiwl"
+      "sourceModulePublish": "cyhoeddi modiwl",
+      "queueApplyTitle": "Ciwio rhediad cynllun + gweithredu",
+      "queueApplyRefBlocked": "Nid yw gweithredu ar gael tra bo cangen, tag neu ymrwymiad wedii ddewis — maer rhediadau hynny bob amser yn gynllun yn unig"
     },
     "state": {
       "deleteConfirm": "Dileu fersiwn cyflwr #{serial}? Ni ellir dadwneud hyn.",

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -1863,7 +1863,8 @@
       "discarding": "Kasserer…",
       "cancelShort": "Annuller",
       "cancelFull": "Annuller kørsel",
-      "canceling": "Annullerer…"
+      "canceling": "Annullerer…",
+      "queuing": "Sætter i kø…"
     },
     "confirm": {
       "apply": "Anvend denne kørsel? Dette anvender planen og ændrer infrastrukturen.",
@@ -2160,6 +2161,13 @@
         "sendError": "Din besked kunne ikke sendes."
       },
       "translatedNote": "Oversat fra originalen ved visning."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Sæt en plan + apply-kørsel i kø for at bringe infrastrukturen på linje med konfigurationen igen",
+      "remediateConfirm": "Sæt en plan + apply-kørsel i kø for dette workspace?",
+      "remediateMessage": "Sat i kø fra et afvigelsestjek",
+      "remediateFailed": "Kunne ikke sætte rettelseskørslen i kø"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Indstillinger",
       "hideOptions": "Skjul indstillinger",
-      "queueDestroy": "Sæt nedrivning i kø",
+      "queueDestroy": "Destruér",
       "queueDestroyTitle": "Sæt en nedrivningsplan i kø",
       "destroyAllConfirm": "Nedriv alle ressourcer?",
       "confirmDestroy": "Bekræft nedrivning",
-      "queuePlan": "Sæt plan i kø",
-      "queueRun": "Sæt kørsel i kø",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Sæt en spekulativ plan i kø for dette arbejdsområde?",
       "queueApplyConfirm": "Sæt en plan + apply-kørsel i kø? Dette kan ændre infrastrukturen.",
       "planOptions": "Planindstillinger",
       "targetResources": "Målressourcer",
       "replaceResources": "Erstat ressourcer",
       "commaSeparated": "(kommasepareret)",
-      "planOnly": "Kun plan",
       "refreshOnly": "Kun refresh",
       "skipRefresh": "Spring refresh over",
       "allowEmptyApply": "Tillad tom apply",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "kun plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "modultest",
-      "sourceModulePublish": "modulpublicering"
+      "sourceModulePublish": "modulpublicering",
+      "queueApplyTitle": "Sæt en plan + apply-kørsel i kø",
+      "queueApplyRefBlocked": "Apply er utilgængelig, mens en branch, et tag eller et commit er valgt — de kørsler er altid kun plan"
     },
     "state": {
       "deleteConfirm": "Slet tilstandsversion #{serial}? Dette kan ikke fortrydes.",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1863,7 +1863,8 @@
       "discarding": "Wird verworfen…",
       "cancelShort": "Abbrechen",
       "cancelFull": "Ausführung abbrechen",
-      "canceling": "Wird abgebrochen…"
+      "canceling": "Wird abgebrochen…",
+      "queuing": "Wird eingereiht…"
     },
     "confirm": {
       "apply": "Diese Ausführung anwenden? Dadurch wird der Plan angewendet und die Infrastruktur verändert.",
@@ -2160,6 +2161,13 @@
         "sendError": "Ihre Nachricht konnte nicht gesendet werden."
       },
       "translatedNote": "Beim Anzeigen aus dem Original übersetzt."
+    },
+    "drift": {
+      "remediate": "Plan + Apply",
+      "remediateTitle": "Einen Plan-+-Apply-Lauf einreihen, um die Infrastruktur wieder mit der Konfiguration in Einklang zu bringen",
+      "remediateConfirm": "Einen Plan-+-Apply-Lauf für diesen Workspace einreihen?",
+      "remediateMessage": "Aus einer Abweichungsprüfung eingereiht",
+      "remediateFailed": "Der Behebungslauf konnte nicht eingereiht werden"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Optionen",
       "hideOptions": "Optionen ausblenden",
-      "queueDestroy": "Destroy einreihen",
+      "queueDestroy": "Zerstören",
       "queueDestroyTitle": "Einen Destroy-Plan einreihen",
       "destroyAllConfirm": "Alle Ressourcen zerstören?",
       "confirmDestroy": "Destroy bestätigen",
-      "queuePlan": "Plan einreihen",
-      "queueRun": "Ausführung einreihen",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + Apply",
       "queuePlanConfirm": "Einen spekulativen Plan für diesen Arbeitsbereich einreihen?",
       "queueApplyConfirm": "Eine plan + apply-Ausführung einreihen? Dies kann die Infrastruktur verändern.",
       "planOptions": "Plan-Optionen",
       "targetResources": "Zielressourcen",
       "replaceResources": "Ressourcen ersetzen",
       "commaSeparated": "(durch Kommas getrennt)",
-      "planOnly": "Nur Plan",
       "refreshOnly": "Nur Refresh",
       "skipRefresh": "Refresh überspringen",
       "allowEmptyApply": "Leeres Apply erlauben",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "nur Plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "Modul-Test",
-      "sourceModulePublish": "Modul-Veröffentlichung"
+      "sourceModulePublish": "Modul-Veröffentlichung",
+      "queueApplyTitle": "Einen Plan-+-Apply-Lauf einreihen",
+      "queueApplyRefBlocked": "Apply ist nicht verfügbar, solange ein Branch, Tag oder Commit ausgewählt ist – solche Läufe sind immer Plan-only"
     },
     "state": {
       "deleteConfirm": "Zustandsversion #{serial} löschen? Dies kann nicht rückgängig gemacht werden.",

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -1863,7 +1863,8 @@
       "discarding": "D15c4rd1ng…",
       "cancelShort": "C4nc3l",
       "cancelFull": "C4nc3l Run",
-      "canceling": "C4nc3l1ng…"
+      "canceling": "C4nc3l1ng…",
+      "queuing": "Qu3u31ng…"
     },
     "confirm": {
       "apply": "4pply 7h15 run? 7h15 4ppl135 7h3 pl4n 4nd ch4ng35 1nfr457ruc7ur3.",
@@ -2160,6 +2161,13 @@
         "sendError": "F41l3d 70 53nd y0ur m3554g3."
       },
       "translatedNote": "7r4n5l473d fr0m 7h3 0r1g1n4l 0n v13w."
+    },
+    "drift": {
+      "remediate": "Pl4n + 4pply",
+      "remediateTitle": "Qu3u3 4 pl4n + 4pply run 70 br1ng 1nfr457ruc7ur3 b4ck 1n l1n3 w17h 7h3 c0nf1gur4710n",
+      "remediateConfirm": "Qu3u3 4 pl4n + 4pply run f0r 7h15 w0rk5p4c3?",
+      "remediateMessage": "Qu3u3d fr0m 4 dr1f7 ch3ck",
+      "remediateFailed": "C0uld n07 qu3u3 7h3 r3m3d14710n run"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "0p710n5",
       "hideOptions": "H1d3 0p710n5",
-      "queueDestroy": "Qu3u3 D357r0y",
+      "queueDestroy": "D357r0y",
       "queueDestroyTitle": "Qu3u3 4 d357r0y pl4n",
       "destroyAllConfirm": "D357r0y 4ll r350urc35?",
       "confirmDestroy": "C0nf1rm D357r0y",
-      "queuePlan": "Qu3u3 Pl4n",
-      "queueRun": "Qu3u3 Run",
+      "queuePlan": "Pl4n",
+      "queueRun": "Pl4n + 4pply",
       "queuePlanConfirm": "Qu3u3 4 5p3cul471v3 pl4n f0r 7h15 w0rk5p4c3?",
       "queueApplyConfirm": "Qu3u3 4 pl4n + 4pply run? 7h15 c4n ch4ng3 1nfr457ruc7ur3.",
       "planOptions": "Pl4n 0p710n5",
       "targetResources": "74rg37 r350urc35",
       "replaceResources": "R3pl4c3 r350urc35",
       "commaSeparated": "(c0mm4-53p4r473d)",
-      "planOnly": "Pl4n 0nly",
       "refreshOnly": "R3fr35h 0nly",
       "skipRefresh": "5k1p R3fr35h",
       "allowEmptyApply": "4ll0w 3mp7y 4pply",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "pl4n 0nly",
       "typePlanApply": "pl4n + 4pply",
       "sourceModuleTest": "m0dul3 7357",
-      "sourceModulePublish": "m0dul3 publ15h"
+      "sourceModulePublish": "m0dul3 publ15h",
+      "queueApplyTitle": "Qu3u3 4 pl4n + 4pply run",
+      "queueApplyRefBlocked": "4pply 15 un4v41l4bl3 wh1l3 4 br4nch, 74g 0r c0mm17 15 53l3c73d — 7h053 run5 4r3 4lw4y5 pl4n-0nly"
     },
     "state": {
       "deleteConfirm": "D3l373 57473 v3r510n #{serial}? 7h15 c4nn07 b3 und0n3.",

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -1863,7 +1863,8 @@
       "discarding": "Discardin…",
       "cancelShort": "Cancul",
       "cancelFull": "Cancel Run",
-      "canceling": "Cancelin…"
+      "canceling": "Cancelin…",
+      "queuing": "Queuein…"
     },
     "confirm": {
       "apply": "Apply dis run? Dis applys teh plan an changez infrastrukchur.",
@@ -2160,6 +2161,13 @@
         "sendError": "Cudnt send yer messij."
       },
       "translatedNote": "Translaytd from teh orijinal on vew."
+    },
+    "drift": {
+      "remediate": "Plan + do it",
+      "remediateTitle": "Queue a plan + do-it runz so teh infrastruktur matchiz teh config agin",
+      "remediateConfirm": "Queue a plan + do-it runz for dis wurkspase?",
+      "remediateMessage": "Queued from a driftz chek",
+      "remediateFailed": "Culd not queue teh fixin runz"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opshunz",
       "hideOptions": "Hide Opshunz",
-      "queueDestroy": "Queue Destroy",
+      "queueDestroy": "Destroyz",
       "queueDestroyTitle": "Queue a destroy plan",
       "destroyAllConfirm": "Destroy all resorcez?",
       "confirmDestroy": "Confirm Destroy",
-      "queuePlan": "Queue Plan",
-      "queueRun": "Queue Run",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + do it",
       "queuePlanConfirm": "Queue a speculativ plan fer dis workspace?",
       "queueApplyConfirm": "Queue a plan + apply run? Dis can change infrastruckchure.",
       "planOptions": "Plan Opshunz",
       "targetResources": "Targit resorcez",
       "replaceResources": "Replace resorcez",
       "commaSeparated": "(comma-separaytd)",
-      "planOnly": "Plan Only",
       "refreshOnly": "Refresh Only",
       "skipRefresh": "Skip Refresh",
       "allowEmptyApply": "Allo Empty Apply",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "plan only",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "module test",
-      "sourceModulePublish": "module publish"
+      "sourceModulePublish": "module publish",
+      "queueApplyTitle": "Queue a plan + do-it runz",
+      "queueApplyRefBlocked": "No do-it while u picked a branch, tag or commit — dose runz iz alwayz plan only, srsly"
     },
     "state": {
       "deleteConfirm": "Delete state vershun #{serial}? Dis cannot be undun.",

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -1863,7 +1863,8 @@
       "discarding": "Discarding…",
       "cancelShort": "Cancel",
       "cancelFull": "Cancel Marklar",
-      "canceling": "Canceling…"
+      "canceling": "Canceling…",
+      "queuing": "Marklaring…"
     },
     "confirm": {
       "apply": "Apply this marklar? This applies the marklar and changes marklar.",
@@ -2160,6 +2161,13 @@
         "sendError": "Failed to send your marklar."
       },
       "translatedNote": "Translated from the marklar on view."
+    },
+    "drift": {
+      "remediate": "Marklar + marklar",
+      "remediateTitle": "Queue a marklar + marklar marklar to bring marklar back in line with the marklar",
+      "remediateConfirm": "Queue a marklar + marklar marklar for this marklar?",
+      "remediateMessage": "Queued from a marklar marklar",
+      "remediateFailed": "Could not queue the marklar marklar"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Marklars",
       "hideOptions": "Hide Marklars",
-      "queueDestroy": "Queue Marklar",
+      "queueDestroy": "Destroy",
       "queueDestroyTitle": "Queue a destroy marklar",
       "destroyAllConfirm": "Destroy all marklars?",
       "confirmDestroy": "Confirm Marklar",
-      "queuePlan": "Queue Marklar",
-      "queueRun": "Queue Marklar",
+      "queuePlan": "Marklar",
+      "queueRun": "Marklar + marklar",
       "queuePlanConfirm": "Queue a speculative marklar for this marklar?",
       "queueApplyConfirm": "Queue a marklar + marklar marklar? This can change marklar.",
       "planOptions": "Marklar Marklars",
       "targetResources": "Target marklars",
       "replaceResources": "Replace marklars",
       "commaSeparated": "(comma-separated)",
-      "planOnly": "Marklar Only",
       "refreshOnly": "Refresh Only",
       "skipRefresh": "Skip Marklar",
       "allowEmptyApply": "Allow Empty Marklar",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "marklar only",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "marklar marklar",
-      "sourceModulePublish": "marklar marklar"
+      "sourceModulePublish": "marklar marklar",
+      "queueApplyTitle": "Queue a marklar + marklar marklar",
+      "queueApplyRefBlocked": "Marklar is unavailable while a marklar, marklar or marklar is selected — those marklars are always marklar-only"
     },
     "state": {
       "deleteConfirm": "Delete marklar marklar #{serial}? This cannot be undone.",

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -1863,7 +1863,8 @@
       "discarding": "Discardin''…",
       "cancelShort": "Belay",
       "cancelFull": "Cancel Run",
-      "canceling": "Cancelin''…"
+      "canceling": "Cancelin''…",
+      "queuing": "Loggin…"
     },
     "confirm": {
       "apply": "Apply this run? This applies th'' plan and changes yer infrastructure.",
@@ -2160,6 +2161,13 @@
         "sendError": "Couldn''t send yer message."
       },
       "translatedNote": "Translated from th'' original on view."
+    },
+    "drift": {
+      "remediate": "Chart + commit",
+      "remediateTitle": "Queue a chart + commit voyage to bring the works back in line with the articles",
+      "remediateConfirm": "Queue a chart + commit voyage for this berth?",
+      "remediateMessage": "Logged from a drift watch",
+      "remediateFailed": "Could not queue the mendin'' voyage"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Options",
       "hideOptions": "Hide Options",
-      "queueDestroy": "Queue Destroy",
+      "queueDestroy": "Scuttle",
       "queueDestroyTitle": "Queue a destroy plan",
       "destroyAllConfirm": "Destroy all resources?",
       "confirmDestroy": "Confirm Destroy",
-      "queuePlan": "Queue Plan",
-      "queueRun": "Queue Voyage",
+      "queuePlan": "Chart",
+      "queueRun": "Chart + commit",
       "queuePlanConfirm": "Queue a speculative plan fer this work-deck?",
       "queueApplyConfirm": "Queue a plan + apply voyage? This can change yer infrastructure.",
       "planOptions": "Plan Options",
       "targetResources": "Target resources",
       "replaceResources": "Replace resources",
       "commaSeparated": "(comma-separated)",
-      "planOnly": "Plan Only",
       "refreshOnly": "Refresh Only",
       "skipRefresh": "Skip Refresh",
       "allowEmptyApply": "Allow Empty Apply",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "plan only",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "module test",
-      "sourceModulePublish": "module publish"
+      "sourceModulePublish": "module publish",
+      "queueApplyTitle": "Queue a chart + commit voyage",
+      "queueApplyRefBlocked": "No committin while a branch, tag or commit be chosen — them voyages be chartin only"
     },
     "state": {
       "deleteConfirm": "Send state version #{serial} t'' Davy Jones? This cannot be undone.",

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -1863,7 +1863,8 @@
       "discarding": "Discarding, we are…",
       "cancelShort": "Cancel",
       "cancelFull": "Run, Cancel",
-      "canceling": "Canceling, we are…"
+      "canceling": "Canceling, we are…",
+      "queuing": "Queued, it is being…"
     },
     "confirm": {
       "apply": "This run, apply? The plan this applies, and infrastructure changes it.",
@@ -2160,6 +2161,13 @@
         "sendError": "Send your message, I could not."
       },
       "translatedNote": "From the original on view, translated."
+    },
+    "drift": {
+      "remediate": "Plan and apply",
+      "remediateTitle": "A plan + apply run, queue — back in line with the configuration, the infrastructure it brings",
+      "remediateConfirm": "For this workspace, a plan + apply run queue?",
+      "remediateMessage": "From a drift check, queued it was",
+      "remediateFailed": "Queued, the remediation run could not be"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Options",
       "hideOptions": "Options, Hide",
-      "queueDestroy": "Destroy, Queue",
+      "queueDestroy": "Destroy",
       "queueDestroyTitle": "A destroy plan, queue",
       "destroyAllConfirm": "All resources, destroy?",
       "confirmDestroy": "Destroy, Confirm",
-      "queuePlan": "Plan, Queue",
-      "queueRun": "Run, Queue",
+      "queuePlan": "Plan",
+      "queueRun": "Plan and apply",
       "queuePlanConfirm": "For this workspace, a speculative plan queue?",
       "queueApplyConfirm": "A plan + apply run, queue? Infrastructure, this can change.",
       "planOptions": "Options, Plan",
       "targetResources": "resources, Target",
       "replaceResources": "resources, Replace",
       "commaSeparated": "(comma-separated)",
-      "planOnly": "Only, Plan",
       "refreshOnly": "Only, Refresh",
       "skipRefresh": "Refresh, Skip",
       "allowEmptyApply": "Apply, Allow Empty",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "plan only",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "module test",
-      "sourceModulePublish": "module publish"
+      "sourceModulePublish": "module publish",
+      "queueApplyTitle": "A plan + apply run, queue",
+      "queueApplyRefBlocked": "Unavailable apply is, while selected a branch, tag or commit is — plan-only always, those runs are"
     },
     "state": {
       "deleteConfirm": "State version #{serial}, delete? Undone, this cannot be.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1863,7 +1863,8 @@
       "discarding": "Discarding…",
       "cancelShort": "Cancel",
       "cancelFull": "Cancel Run",
-      "canceling": "Canceling…"
+      "canceling": "Canceling…",
+      "queuing": "Queueing…"
     },
     "confirm": {
       "apply": "Apply this run? This applies the plan and changes infrastructure.",
@@ -2160,6 +2161,13 @@
       "errors": {
         "status": "Failed to load AI cost estimate (HTTP {status})."
       }
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Queue a plan + apply run to bring infrastructure back in line with the configuration",
+      "remediateConfirm": "Queue a plan + apply run for this workspace?",
+      "remediateMessage": "Queued from a drift check",
+      "remediateFailed": "Could not queue the remediation run"
     }
   },
   "workspaceDetail": {
@@ -2405,19 +2413,18 @@
     "runs": {
       "options": "Options",
       "hideOptions": "Hide Options",
-      "queueDestroy": "Queue Destroy",
+      "queueDestroy": "Destroy",
       "queueDestroyTitle": "Queue a destroy plan",
       "destroyAllConfirm": "Destroy all resources?",
       "confirmDestroy": "Confirm Destroy",
-      "queuePlan": "Queue Plan",
-      "queueRun": "Queue Run",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Queue a speculative plan for this workspace?",
       "queueApplyConfirm": "Queue a plan + apply run? This can change infrastructure.",
       "planOptions": "Plan Options",
       "targetResources": "Target resources",
       "replaceResources": "Replace resources",
       "commaSeparated": "(comma-separated)",
-      "planOnly": "Plan Only",
       "refreshOnly": "Refresh Only",
       "skipRefresh": "Skip Refresh",
       "allowEmptyApply": "Allow Empty Apply",
@@ -2439,7 +2446,9 @@
       "typePlanOnly": "plan only",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "module test",
-      "sourceModulePublish": "module publish"
+      "sourceModulePublish": "module publish",
+      "queueApplyTitle": "Queue a plan + apply run",
+      "queueApplyRefBlocked": "Apply is unavailable while a branch, tag or commit is selected — those runs are always plan-only"
     },
     "state": {
       "deleteConfirm": "Delete state version #{serial}? This cannot be undone.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1863,7 +1863,8 @@
       "discarding": "Descartando…",
       "cancelShort": "Cancelar",
       "cancelFull": "Cancelar ejecución",
-      "canceling": "Cancelando…"
+      "canceling": "Cancelando…",
+      "queuing": "Poniendo en cola…"
     },
     "confirm": {
       "apply": "¿Aplicar esta ejecución? Esto aplica el plan y cambia la infraestructura.",
@@ -2160,6 +2161,13 @@
         "sendError": "No se pudo enviar el mensaje."
       },
       "translatedNote": "Traducido del original al visualizar."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Poner en cola una ejecución plan + apply para volver a alinear la infraestructura con la configuración",
+      "remediateConfirm": "¿Poner en cola una ejecución plan + apply para este espacio de trabajo?",
+      "remediateMessage": "Puesto en cola desde una comprobación de desviación",
+      "remediateFailed": "No se pudo poner en cola la ejecución de corrección"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opciones",
       "hideOptions": "Ocultar opciones",
-      "queueDestroy": "Poner destrucción en cola",
+      "queueDestroy": "Destruir",
       "queueDestroyTitle": "Poner en cola un plan de destrucción",
       "destroyAllConfirm": "¿Destruir todos los recursos?",
       "confirmDestroy": "Confirmar destrucción",
-      "queuePlan": "Poner plan en cola",
-      "queueRun": "Poner ejecución en cola",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "¿Poner en cola un plan especulativo para este espacio de trabajo?",
       "queueApplyConfirm": "¿Poner en cola una ejecución de plan + apply? Esto puede cambiar la infraestructura.",
       "planOptions": "Opciones del plan",
       "targetResources": "Recursos objetivo",
       "replaceResources": "Reemplazar recursos",
       "commaSeparated": "(separados por comas)",
-      "planOnly": "Solo plan",
       "refreshOnly": "Solo actualizar",
       "skipRefresh": "Omitir actualización",
       "allowEmptyApply": "Permitir apply vacío",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "solo plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "prueba de módulo",
-      "sourceModulePublish": "publicación de módulo"
+      "sourceModulePublish": "publicación de módulo",
+      "queueApplyTitle": "Poner en cola una ejecución de plan + apply",
+      "queueApplyRefBlocked": "Apply no está disponible mientras haya una rama, etiqueta o commit seleccionado: esas ejecuciones son siempre solo de plan"
     },
     "state": {
       "deleteConfirm": "¿Eliminar la versión de estado n.º {serial}? Esto no se puede deshacer.",

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -1863,7 +1863,8 @@
       "discarding": "در حال کنار گذاشتن…",
       "cancelShort": "لغو",
       "cancelFull": "لغو اجرا",
-      "canceling": "در حال لغو…"
+      "canceling": "در حال لغو…",
+      "queuing": "در حال افزودن به صف…"
     },
     "confirm": {
       "apply": "این اجرا اعمال شود؟ این کار برنامه را اعمال کرده و زیرساخت را تغییر می‌دهد.",
@@ -2160,6 +2161,13 @@
         "sendError": "ارسال پیام شما ناموفق بود."
       },
       "translatedNote": "هنگام مشاهده از نسخهٔ اصلی ترجمه شد."
+    },
+    "drift": {
+      "remediate": "طرح + اعمال",
+      "remediateTitle": "افزودن اجرای طرح + اعمال به صف برای هم‌راستا کردن دوبارهٔ زیرساخت با پیکربندی",
+      "remediateConfirm": "اجرای طرح + اعمال برای این فضای کاری به صف افزوده شود؟",
+      "remediateMessage": "از بررسی انحراف به صف افزوده شد",
+      "remediateFailed": "افزودن اجرای اصلاح به صف ممکن نشد"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "گزینه‌ها",
       "hideOptions": "پنهان کردن گزینه‌ها",
-      "queueDestroy": "افزودن نابودی به صف",
+      "queueDestroy": "تخریب",
       "queueDestroyTitle": "افزودن یک طرح نابودی به صف",
       "destroyAllConfirm": "همهٔ منابع نابود شوند؟",
       "confirmDestroy": "تأیید نابودی",
-      "queuePlan": "افزودن طرح به صف",
-      "queueRun": "افزودن اجرا به صف",
+      "queuePlan": "طرح",
+      "queueRun": "طرح + اعمال",
       "queuePlanConfirm": "یک طرح احتمالی برای این فضای کاری به صف افزوده شود؟",
       "queueApplyConfirm": "یک اجرای طرح + اعمال به صف افزوده شود؟ این کار می‌تواند زیرساخت را تغییر دهد.",
       "planOptions": "گزینه‌های طرح",
       "targetResources": "منابع هدف",
       "replaceResources": "جایگزینی منابع",
       "commaSeparated": "(با کاما جدا شده)",
-      "planOnly": "فقط طرح",
       "refreshOnly": "فقط تازه‌سازی",
       "skipRefresh": "رد کردن تازه‌سازی",
       "allowEmptyApply": "اجازهٔ اعمال خالی",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "فقط طرح",
       "typePlanApply": "طرح + اعمال",
       "sourceModuleTest": "آزمون ماژول",
-      "sourceModulePublish": "انتشار ماژول"
+      "sourceModulePublish": "انتشار ماژول",
+      "queueApplyTitle": "افزودن اجرای طرح + اعمال به صف",
+      "queueApplyRefBlocked": "تا زمانی که شاخه، برچسب یا کامیت انتخاب شده باشد اعمال در دسترس نیست — این اجراها همیشه فقط طرح هستند"
     },
     "state": {
       "deleteConfirm": "نسخهٔ وضعیت #{serial} حذف شود؟ این کار قابل‌بازگشت نیست.",

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -1863,7 +1863,8 @@
       "discarding": "Hylätään…",
       "cancelShort": "Peruuta",
       "cancelFull": "Peruuta ajo",
-      "canceling": "Perutaan…"
+      "canceling": "Perutaan…",
+      "queuing": "Lisätään jonoon…"
     },
     "confirm": {
       "apply": "Otetaanko tämä ajo käyttöön? Tämä ottaa suunnitelman käyttöön ja muuttaa infrastruktuuria.",
@@ -2160,6 +2161,13 @@
         "sendError": "Viestisi lähettäminen epäonnistui."
       },
       "translatedNote": "Käännetty alkuperäisestä katselun yhteydessä."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Lisää plan + apply -ajo jonoon, jotta infrastruktuuri saadaan taas vastaamaan konfiguraatiota",
+      "remediateConfirm": "Lisätäänkö plan + apply -ajo jonoon tälle työtilalle?",
+      "remediateMessage": "Lisätty jonoon poikkeamatarkistuksesta",
+      "remediateFailed": "Korjausajoa ei voitu lisätä jonoon"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Vaihtoehdot",
       "hideOptions": "Piilota vaihtoehdot",
-      "queueDestroy": "Aseta tuhoaminen jonoon",
+      "queueDestroy": "Tuhoa",
       "queueDestroyTitle": "Aseta tuhosuunnitelma jonoon",
       "destroyAllConfirm": "Tuhotaanko kaikki resurssit?",
       "confirmDestroy": "Vahvista tuhoaminen",
-      "queuePlan": "Aseta suunnitelma jonoon",
-      "queueRun": "Aseta ajo jonoon",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Asetetaanko spekulatiivinen suunnitelma jonoon tälle työtilalle?",
       "queueApplyConfirm": "Asetetaanko suunnittelu- + käyttöönottoajo jonoon? Tämä voi muuttaa infrastruktuuria.",
       "planOptions": "Suunnitelman vaihtoehdot",
       "targetResources": "Kohderesurssit",
       "replaceResources": "Korvaa resurssit",
       "commaSeparated": "(pilkuin eroteltuna)",
-      "planOnly": "Vain suunnittelu",
       "refreshOnly": "Vain päivitys",
       "skipRefresh": "Ohita päivitys",
       "allowEmptyApply": "Salli tyhjä käyttöönotto",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "vain suunnittelu",
       "typePlanApply": "suunnittelu + käyttöönotto",
       "sourceModuleTest": "moduulitesti",
-      "sourceModulePublish": "moduulijulkaisu"
+      "sourceModulePublish": "moduulijulkaisu",
+      "queueApplyTitle": "Lisää plan + apply -ajo jonoon",
+      "queueApplyRefBlocked": "Apply ei ole käytettävissä, kun haara, tunniste tai commit on valittuna — nämä ajot ovat aina vain plan"
     },
     "state": {
       "deleteConfirm": "Poistetaanko tilaversio #{serial}? Tätä ei voi kumota.",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1863,7 +1863,8 @@
       "discarding": "Abandon…",
       "cancelShort": "Annuler",
       "cancelFull": "Annuler l'exécution",
-      "canceling": "Annulation…"
+      "canceling": "Annulation…",
+      "queuing": "Mise en file…"
     },
     "confirm": {
       "apply": "Appliquer cette exécution ? Cela applique le plan et modifie l'infrastructure.",
@@ -2160,6 +2161,13 @@
         "sendError": "Impossible d''envoyer votre message."
       },
       "translatedNote": "Traduit de l''original à l''affichage."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Mettre en file un run plan + apply pour réaligner l''infrastructure sur la configuration",
+      "remediateConfirm": "Mettre en file un run plan + apply pour cet espace de travail ?",
+      "remediateMessage": "Mis en file depuis un contrôle de dérive",
+      "remediateFailed": "Impossible de mettre en file le run de correction"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Options",
       "hideOptions": "Masquer les options",
-      "queueDestroy": "Mettre en file d'attente une destruction",
+      "queueDestroy": "Détruire",
       "queueDestroyTitle": "Mettre en file d'attente un plan de destruction",
       "destroyAllConfirm": "Détruire toutes les ressources ?",
       "confirmDestroy": "Confirmer la destruction",
-      "queuePlan": "Mettre en file d'attente un plan",
-      "queueRun": "Mettre en file d'attente une exécution",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Mettre en file d'attente un plan spéculatif pour cet espace de travail ?",
       "queueApplyConfirm": "Mettre en file d'attente une exécution plan + apply ? Cela peut modifier l'infrastructure.",
       "planOptions": "Options du plan",
       "targetResources": "Ressources ciblées",
       "replaceResources": "Ressources à remplacer",
       "commaSeparated": "(séparées par des virgules)",
-      "planOnly": "Plan uniquement",
       "refreshOnly": "Actualisation uniquement",
       "skipRefresh": "Ignorer l'actualisation",
       "allowEmptyApply": "Autoriser une application vide",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "plan uniquement",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "test de module",
-      "sourceModulePublish": "publication de module"
+      "sourceModulePublish": "publication de module",
+      "queueApplyTitle": "Mettre en file un run plan + apply",
+      "queueApplyRefBlocked": "Apply est indisponible tant quune branche, une étiquette ou un commit est sélectionné — ces runs sont toujours plan-only"
     },
     "state": {
       "deleteConfirm": "Supprimer la version d'état n° {serial} ? Cette action est irréversible.",

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -1863,7 +1863,8 @@
       "discarding": "דוחה…",
       "cancelShort": "בטל",
       "cancelFull": "בטל הרצה",
-      "canceling": "מבטל…"
+      "canceling": "מבטל…",
+      "queuing": "מוסיף לתור…"
     },
     "confirm": {
       "apply": "להחיל את ההרצה הזו? פעולה זו מחילה את התכנון ומשנה את התשתית.",
@@ -2160,6 +2161,13 @@
         "sendError": "שליחת ההודעה שלך נכשלה."
       },
       "translatedNote": "תורגם מהמקור בעת הצפייה."
+    },
+    "drift": {
+      "remediate": "תכנון + החלה",
+      "remediateTitle": "הוספת הרצת תכנון + החלה לתור כדי ליישר מחדש את התשתית עם התצורה",
+      "remediateConfirm": "להוסיף הרצת תכנון + החלה לתור עבור סביבת עבודה זו?",
+      "remediateMessage": "נוסף לתור מבדיקת סטייה",
+      "remediateFailed": "לא ניתן היה להוסיף את הרצת התיקון לתור"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "אפשרויות",
       "hideOptions": "הסתרת אפשרויות",
-      "queueDestroy": "הוספת השמדה לתור",
+      "queueDestroy": "השמדה",
       "queueDestroyTitle": "הוספת תוכנית השמדה לתור",
       "destroyAllConfirm": "להשמיד את כל המשאבים?",
       "confirmDestroy": "אישור השמדה",
-      "queuePlan": "הוספת תוכנית לתור",
-      "queueRun": "הוספת הרצה לתור",
+      "queuePlan": "תכנון",
+      "queueRun": "תכנון + החלה",
       "queuePlanConfirm": "להוסיף תוכנית ספקולטיבית לתור עבור סביבת עבודה זו?",
       "queueApplyConfirm": "להוסיף הרצת תכנון + יישום לתור? זה עשוי לשנות תשתית.",
       "planOptions": "אפשרויות תוכנית",
       "targetResources": "משאבי יעד",
       "replaceResources": "החלפת משאבים",
       "commaSeparated": "(מופרד בפסיקים)",
-      "planOnly": "תוכנית בלבד",
       "refreshOnly": "רענון בלבד",
       "skipRefresh": "דילוג על רענון",
       "allowEmptyApply": "אפשר החלה ריקה",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "תוכנית בלבד",
       "typePlanApply": "תכנון + יישום",
       "sourceModuleTest": "בדיקת מודול",
-      "sourceModulePublish": "פרסום מודול"
+      "sourceModulePublish": "פרסום מודול",
+      "queueApplyTitle": "הוספת הרצת תכנון + החלה לתור",
+      "queueApplyRefBlocked": "החלה אינה זמינה כאשר נבחרו ענף, תגית או קומיט — הרצות אלה הן תמיד תכנון בלבד"
     },
     "state": {
       "deleteConfirm": "למחוק את גרסת המצב #{serial}? לא ניתן לבטל זאת.",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1863,7 +1863,8 @@
       "discarding": "Scartamento in corso…",
       "cancelShort": "Annulla",
       "cancelFull": "Annulla esecuzione",
-      "canceling": "Annullamento in corso…"
+      "canceling": "Annullamento in corso…",
+      "queuing": "In accodamento…"
     },
     "confirm": {
       "apply": "Applicare questa esecuzione? Questo applica il plan e modifica l''infrastruttura.",
@@ -2160,6 +2161,13 @@
         "sendError": "Impossibile inviare il messaggio."
       },
       "translatedNote": "Tradotto dall''originale alla visualizzazione."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Accoda una esecuzione plan + apply per riallineare l''infrastruttura alla configurazione",
+      "remediateConfirm": "Accodare una esecuzione plan + apply per questo workspace?",
+      "remediateMessage": "Accodato da un controllo di deriva",
+      "remediateFailed": "Impossibile accodare l''esecuzione di correzione"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opzioni",
       "hideOptions": "Nascondi opzioni",
-      "queueDestroy": "Accoda distruzione",
+      "queueDestroy": "Distruggi",
       "queueDestroyTitle": "Accoda un plan di distruzione",
       "destroyAllConfirm": "Distruggere tutte le risorse?",
       "confirmDestroy": "Conferma distruzione",
-      "queuePlan": "Accoda plan",
-      "queueRun": "Accoda esecuzione",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Accodare un plan speculativo per questo workspace?",
       "queueApplyConfirm": "Accodare un''esecuzione plan + apply? Questo può modificare l''infrastruttura.",
       "planOptions": "Opzioni del plan",
       "targetResources": "Risorse target",
       "replaceResources": "Risorse da sostituire",
       "commaSeparated": "(separate da virgola)",
-      "planOnly": "Solo plan",
       "refreshOnly": "Solo refresh",
       "skipRefresh": "Salta refresh",
       "allowEmptyApply": "Consenti apply vuoto",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "solo plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "test del modulo",
-      "sourceModulePublish": "pubblicazione del modulo"
+      "sourceModulePublish": "pubblicazione del modulo",
+      "queueApplyTitle": "Accoda una esecuzione plan + apply",
+      "queueApplyRefBlocked": "Apply non è disponibile mentre è selezionato un branch, tag o commit: quelle esecuzioni sono sempre solo plan"
     },
     "state": {
       "deleteConfirm": "Eliminare la versione dello stato #{serial}? Questa azione non può essere annullata.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1863,7 +1863,8 @@
       "discarding": "破棄中…",
       "cancelShort": "キャンセル",
       "cancelFull": "実行をキャンセル",
-      "canceling": "キャンセル中…"
+      "canceling": "キャンセル中…",
+      "queuing": "キューに追加中…"
     },
     "confirm": {
       "apply": "この実行を適用しますか？プランが適用され、インフラが変更されます。",
@@ -2160,6 +2161,13 @@
         "sendError": "メッセージの送信に失敗しました。"
       },
       "translatedNote": "表示時に原文から翻訳されています。"
+    },
+    "drift": {
+      "remediate": "プラン + 適用",
+      "remediateTitle": "インフラを構成に一致させるためプラン + 適用の実行をキューに追加します",
+      "remediateConfirm": "このワークスペースでプラン + 適用の実行をキューに追加しますか?",
+      "remediateMessage": "差分チェックからキューに追加",
+      "remediateFailed": "修正の実行をキューに追加できませんでした"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "オプション",
       "hideOptions": "オプションを非表示",
-      "queueDestroy": "破棄をキューに追加",
+      "queueDestroy": "破棄",
       "queueDestroyTitle": "破棄プランをキューに追加",
       "destroyAllConfirm": "すべてのリソースを破棄しますか？",
       "confirmDestroy": "破棄の確認",
-      "queuePlan": "プランをキューに追加",
-      "queueRun": "実行をキューに追加",
+      "queuePlan": "プラン",
+      "queueRun": "プラン + 適用",
       "queuePlanConfirm": "このワークスペースの投機的プランをキューに追加しますか？",
       "queueApplyConfirm": "plan + apply の実行をキューに追加しますか？これによりインフラが変更される可能性があります。",
       "planOptions": "プランオプション",
       "targetResources": "対象リソース",
       "replaceResources": "置換リソース",
       "commaSeparated": "（カンマ区切り）",
-      "planOnly": "プランのみ",
       "refreshOnly": "リフレッシュのみ",
       "skipRefresh": "リフレッシュをスキップ",
       "allowEmptyApply": "空の適用を許可",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "プランのみ",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "モジュールテスト",
-      "sourceModulePublish": "モジュール公開"
+      "sourceModulePublish": "モジュール公開",
+      "queueApplyTitle": "プラン + 適用の実行をキューに追加",
+      "queueApplyRefBlocked": "ブランチ・タグ・コミットを選択している間は適用できません。これらの実行は常にプランのみです"
     },
     "state": {
       "deleteConfirm": "状態バージョン #{serial} を削除しますか？この操作は元に戻せません。",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1863,7 +1863,8 @@
       "discarding": "폐기 중…",
       "cancelShort": "취소",
       "cancelFull": "실행 취소",
-      "canceling": "취소 중…"
+      "canceling": "취소 중…",
+      "queuing": "대기열에 추가 중…"
     },
     "confirm": {
       "apply": "이 실행을 적용하시겠습니까? 계획을 적용하고 인프라를 변경합니다.",
@@ -2160,6 +2161,13 @@
         "sendError": "메시지를 전송하지 못했습니다."
       },
       "translatedNote": "보기 시 원문에서 번역되었습니다."
+    },
+    "drift": {
+      "remediate": "플랜 + 적용",
+      "remediateTitle": "인프라를 구성에 다시 맞추기 위해 플랜 + 적용 실행을 대기열에 추가합니다",
+      "remediateConfirm": "이 워크스페이스에 대해 플랜 + 적용 실행을 대기열에 추가할까요?",
+      "remediateMessage": "드리프트 검사에서 대기열에 추가됨",
+      "remediateFailed": "수정 실행을 대기열에 추가하지 못했습니다"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "옵션",
       "hideOptions": "옵션 숨기기",
-      "queueDestroy": "삭제 대기",
+      "queueDestroy": "파기",
       "queueDestroyTitle": "삭제 계획 대기",
       "destroyAllConfirm": "모든 리소스를 삭제하시겠습니까?",
       "confirmDestroy": "삭제 확인",
-      "queuePlan": "계획 대기",
-      "queueRun": "실행 대기",
+      "queuePlan": "플랜",
+      "queueRun": "플랜 + 적용",
       "queuePlanConfirm": "이 워크스페이스에 대한 예상 계획을 대기하시겠습니까?",
       "queueApplyConfirm": "계획 + 적용 실행을 대기하시겠습니까? 인프라가 변경될 수 있습니다.",
       "planOptions": "계획 옵션",
       "targetResources": "대상 리소스",
       "replaceResources": "교체 리소스",
       "commaSeparated": "(쉼표로 구분)",
-      "planOnly": "계획 전용",
       "refreshOnly": "새로 고침 전용",
       "skipRefresh": "새로 고침 건너뛰기",
       "allowEmptyApply": "빈 적용 허용",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "계획 전용",
       "typePlanApply": "계획 + 적용",
       "sourceModuleTest": "모듈 테스트",
-      "sourceModulePublish": "모듈 게시"
+      "sourceModulePublish": "모듈 게시",
+      "queueApplyTitle": "플랜 + 적용 실행을 대기열에 추가",
+      "queueApplyRefBlocked": "브랜치, 태그 또는 커밋이 선택된 동안에는 적용할 수 없습니다. 해당 실행은 항상 플랜 전용입니다"
     },
     "state": {
       "deleteConfirm": "상태 버전 #{serial}을(를) 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -1863,7 +1863,8 @@
       "discarding": "Reicitur…",
       "cancelShort": "Abrogare",
       "cancelFull": "Exsecutionem Abrogare",
-      "canceling": "Abrogatur…"
+      "canceling": "Abrogatur…",
+      "queuing": "In ordinem mittitur…"
     },
     "confirm": {
       "apply": "Hanc exsecutionem applicare? Hoc consilium applicat et infrastructuram mutat.",
@@ -2160,6 +2161,13 @@
         "sendError": "Nuntius tuus mitti non potuit."
       },
       "translatedNote": "Ex originali in conspectu translatum."
+    },
+    "drift": {
+      "remediate": "Consilium + exsecutio",
+      "remediateTitle": "Cursum consilii + exsecutionis in ordinem mittere ut infrastructura configurationi rursus congruat",
+      "remediateConfirm": "Cursum consilii + exsecutionis pro hoc loco operis in ordinem mittere?",
+      "remediateMessage": "Ex inspectione discrepantiae in ordinem missum",
+      "remediateFailed": "Cursus correctionis in ordinem mitti non potuit"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Optiones",
       "hideOptions": "Optiones Celare",
-      "queueDestroy": "Destructionem In Ordinem Ponere",
+      "queueDestroy": "Destruere",
       "queueDestroyTitle": "Consilium destructionis in ordinem pone",
       "destroyAllConfirm": "Omnes facultates destruere?",
       "confirmDestroy": "Destructionem Confirmare",
-      "queuePlan": "Consilium In Ordinem Ponere",
-      "queueRun": "Exsecutionem In Ordinem Ponere",
+      "queuePlan": "Consilium",
+      "queueRun": "Consilium + exsecutio",
       "queuePlanConfirm": "Consilium speculativum huic loco operis in ordinem ponere?",
       "queueApplyConfirm": "Exsecutionem plan + apply in ordinem ponere? Hoc infrastructuram mutare potest.",
       "planOptions": "Optiones Consilii",
       "targetResources": "Facultates destinatas",
       "replaceResources": "Facultates substituere",
       "commaSeparated": "(commate seiuncta)",
-      "planOnly": "Solum Consilium",
       "refreshOnly": "Solum Reficere",
       "skipRefresh": "Refectionem Praeterire",
       "allowEmptyApply": "Applicationem Vacuam Permittere",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "solum consilium",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "probatio moduli",
-      "sourceModulePublish": "editio moduli"
+      "sourceModulePublish": "editio moduli",
+      "queueApplyTitle": "Cursum consilii + exsecutionis in ordinem mittere",
+      "queueApplyRefBlocked": "Exsecutio non praesto est dum ramus, nota vel commissio electa est — ii cursus semper consilium solum sunt"
     },
     "state": {
       "deleteConfirm": "Versionem status #{serial} delere? Hoc revocari non potest.",

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -1863,7 +1863,8 @@
       "discarding": "Forkaster …",
       "cancelShort": "Avbryt",
       "cancelFull": "Avbryt kjøring",
-      "canceling": "Avbryter …"
+      "canceling": "Avbryter …",
+      "queuing": "Legger i kø…"
     },
     "confirm": {
       "apply": "Anvende denne kjøringen? Dette anvender planen og endrer infrastruktur.",
@@ -2160,6 +2161,13 @@
         "sendError": "Kunne ikke sende meldingen din."
       },
       "translatedNote": "Oversatt fra originalen ved visning."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Legg en plan + apply-kjøring i kø for å bringe infrastrukturen på linje med konfigurasjonen igjen",
+      "remediateConfirm": "Legge en plan + apply-kjøring i kø for dette arbeidsområdet?",
+      "remediateMessage": "Lagt i kø fra en avvikskontroll",
+      "remediateFailed": "Kunne ikke legge rettekjøringen i kø"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Alternativer",
       "hideOptions": "Skjul alternativer",
-      "queueDestroy": "Legg nedriving i kø",
+      "queueDestroy": "Ødelegg",
       "queueDestroyTitle": "Legg en nedrivingsplan i kø",
       "destroyAllConfirm": "Rive ned alle ressurser?",
       "confirmDestroy": "Bekreft nedriving",
-      "queuePlan": "Legg plan i kø",
-      "queueRun": "Legg kjøring i kø",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Legge en spekulativ plan i kø for dette arbeidsområdet?",
       "queueApplyConfirm": "Legge en plan + anvend-kjøring i kø? Dette kan endre infrastruktur.",
       "planOptions": "Planalternativer",
       "targetResources": "Målressurser",
       "replaceResources": "Erstatt ressurser",
       "commaSeparated": "(kommaseparert)",
-      "planOnly": "Kun plan",
       "refreshOnly": "Kun oppdater",
       "skipRefresh": "Hopp over oppdatering",
       "allowEmptyApply": "Tillat tom anvendelse",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "kun plan",
       "typePlanApply": "plan + anvend",
       "sourceModuleTest": "modultest",
-      "sourceModulePublish": "modulpublisering"
+      "sourceModulePublish": "modulpublisering",
+      "queueApplyTitle": "Legg en plan + apply-kjøring i kø",
+      "queueApplyRefBlocked": "Apply er utilgjengelig mens en branch, tag eller commit er valgt — slike kjøringer er alltid kun plan"
     },
     "state": {
       "deleteConfirm": "Slett tilstandsversjon #{serial}? Dette kan ikke angres.",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1863,7 +1863,8 @@
       "discarding": "Bezig met verwerpen…",
       "cancelShort": "Annuleren",
       "cancelFull": "Uitvoering annuleren",
-      "canceling": "Bezig met annuleren…"
+      "canceling": "Bezig met annuleren…",
+      "queuing": "In wachtrij zetten…"
     },
     "confirm": {
       "apply": "Deze uitvoering toepassen? Hiermee wordt het plan toegepast en infrastructuur gewijzigd.",
@@ -2160,6 +2161,13 @@
         "sendError": "Kan uw bericht niet verzenden."
       },
       "translatedNote": "Bij weergave vertaald vanuit het origineel."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Een plan + apply-run in de wachtrij zetten om de infrastructuur weer met de configuratie in lijn te brengen",
+      "remediateConfirm": "Een plan + apply-run voor deze workspace in de wachtrij zetten?",
+      "remediateMessage": "In wachtrij gezet vanuit een afwijkingscontrole",
+      "remediateFailed": "Kon de herstelrun niet in de wachtrij zetten"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opties",
       "hideOptions": "Opties verbergen",
-      "queueDestroy": "Destroy in wachtrij zetten",
+      "queueDestroy": "Vernietigen",
       "queueDestroyTitle": "Zet een destroy-plan in de wachtrij",
       "destroyAllConfirm": "Alle resources vernietigen?",
       "confirmDestroy": "Vernietigen bevestigen",
-      "queuePlan": "Plan in wachtrij zetten",
-      "queueRun": "Uitvoering in wachtrij zetten",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Een speculatief plan voor deze workspace in de wachtrij zetten?",
       "queueApplyConfirm": "Een plan + apply-uitvoering in de wachtrij zetten? Dit kan infrastructuur wijzigen.",
       "planOptions": "Planopties",
       "targetResources": "Doelresources",
       "replaceResources": "Resources vervangen",
       "commaSeparated": "(kommagescheiden)",
-      "planOnly": "Alleen plan",
       "refreshOnly": "Alleen refresh",
       "skipRefresh": "Refresh overslaan",
       "allowEmptyApply": "Lege apply toestaan",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "alleen plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "moduletest",
-      "sourceModulePublish": "modulepublicatie"
+      "sourceModulePublish": "modulepublicatie",
+      "queueApplyTitle": "Een plan + apply-run in de wachtrij zetten",
+      "queueApplyRefBlocked": "Apply is niet beschikbaar zolang een branch, tag of commit is geselecteerd — die runs zijn altijd alleen plan"
     },
     "state": {
       "deleteConfirm": "State-versie #{serial} verwijderen? Dit kan niet ongedaan worden gemaakt.",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1863,7 +1863,8 @@
       "discarding": "Odrzucanie…",
       "cancelShort": "Anuluj",
       "cancelFull": "Anuluj przebieg",
-      "canceling": "Anulowanie…"
+      "canceling": "Anulowanie…",
+      "queuing": "Dodawanie do kolejki…"
     },
     "confirm": {
       "apply": "Zastosować ten przebieg? Spowoduje to zastosowanie planu i zmianę infrastruktury.",
@@ -2160,6 +2161,13 @@
         "sendError": "Nie udało się wysłać wiadomości."
       },
       "translatedNote": "Przetłumaczono z oryginału podczas wyświetlania."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Dodaj do kolejki uruchomienie plan + apply, aby ponownie dopasować infrastrukturę do konfiguracji",
+      "remediateConfirm": "Dodać do kolejki uruchomienie plan + apply dla tej przestrzeni roboczej?",
+      "remediateMessage": "Dodane do kolejki z kontroli rozbieżności",
+      "remediateFailed": "Nie udało się dodać uruchomienia naprawczego do kolejki"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opcje",
       "hideOptions": "Ukryj opcje",
-      "queueDestroy": "Umieść niszczenie w kolejce",
+      "queueDestroy": "Zniszcz",
       "queueDestroyTitle": "Umieść w kolejce plan niszczenia",
       "destroyAllConfirm": "Zniszczyć wszystkie zasoby?",
       "confirmDestroy": "Potwierdź niszczenie",
-      "queuePlan": "Umieść plan w kolejce",
-      "queueRun": "Umieść przebieg w kolejce",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Umieścić w kolejce plan spekulatywny dla tego obszaru roboczego?",
       "queueApplyConfirm": "Umieścić w kolejce przebieg plan + apply? Może to zmienić infrastrukturę.",
       "planOptions": "Opcje planu",
       "targetResources": "Docelowe zasoby",
       "replaceResources": "Zastąp zasoby",
       "commaSeparated": "(oddzielone przecinkami)",
-      "planOnly": "Tylko plan",
       "refreshOnly": "Tylko odświeżenie",
       "skipRefresh": "Pomiń odświeżenie",
       "allowEmptyApply": "Zezwól na puste zastosowanie",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "tylko plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "test modułu",
-      "sourceModulePublish": "publikacja modułu"
+      "sourceModulePublish": "publikacja modułu",
+      "queueApplyTitle": "Dodaj do kolejki uruchomienie plan + apply",
+      "queueApplyRefBlocked": "Apply jest niedostępne, gdy wybrano gałąź, tag lub commit — takie uruchomienia są zawsze tylko plan"
     },
     "state": {
       "deleteConfirm": "Usunąć wersję stanu #{serial}? Tej operacji nie można cofnąć.",

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -1863,7 +1863,8 @@
       "discarding": "Descartando…",
       "cancelShort": "Cancelar",
       "cancelFull": "Cancelar Execução",
-      "canceling": "Cancelando…"
+      "canceling": "Cancelando…",
+      "queuing": "Enfileirando…"
     },
     "confirm": {
       "apply": "Aplicar esta execução? Isso aplica o plano e altera a infraestrutura.",
@@ -2160,6 +2161,13 @@
         "sendError": "Não foi possível enviar sua mensagem."
       },
       "translatedNote": "Traduzido do original na visualização."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Enfileirar uma execução plan + apply para realinhar a infraestrutura à configuração",
+      "remediateConfirm": "Enfileirar uma execução plan + apply para este workspace?",
+      "remediateMessage": "Enfileirado a partir de uma verificação de desvio",
+      "remediateFailed": "Não foi possível enfileirar a execução de correção"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opções",
       "hideOptions": "Ocultar Opções",
-      "queueDestroy": "Enfileirar Destroy",
+      "queueDestroy": "Destruir",
       "queueDestroyTitle": "Enfileirar um plano de destroy",
       "destroyAllConfirm": "Destruir todos os recursos?",
       "confirmDestroy": "Confirmar Destroy",
-      "queuePlan": "Enfileirar Plan",
-      "queueRun": "Enfileirar Execução",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Enfileirar um plano especulativo para este workspace?",
       "queueApplyConfirm": "Enfileirar uma execução de plan + apply? Isso pode alterar a infraestrutura.",
       "planOptions": "Opções de Plan",
       "targetResources": "Recursos alvo",
       "replaceResources": "Substituir recursos",
       "commaSeparated": "(separados por vírgula)",
-      "planOnly": "Somente Plano",
       "refreshOnly": "Somente Refresh",
       "skipRefresh": "Pular Refresh",
       "allowEmptyApply": "Permitir Apply Vazio",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "somente plano",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "teste de módulo",
-      "sourceModulePublish": "publicação de módulo"
+      "sourceModulePublish": "publicação de módulo",
+      "queueApplyTitle": "Enfileirar uma execução plan + apply",
+      "queueApplyRefBlocked": "Apply fica indisponível enquanto houver um branch, tag ou commit selecionado — essas execuções são sempre somente plan"
     },
     "state": {
       "deleteConfirm": "Excluir a versão de estado #{serial}? Isso não pode ser desfeito.",

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -1863,7 +1863,8 @@
       "discarding": "A descartar…",
       "cancelShort": "Cancelar",
       "cancelFull": "Cancelar Execução",
-      "canceling": "A cancelar…"
+      "canceling": "A cancelar…",
+      "queuing": "A colocar em fila…"
     },
     "confirm": {
       "apply": "Aplicar esta execução? Isto aplica o plano e altera a infraestrutura.",
@@ -2160,6 +2161,13 @@
         "sendError": "Não foi possível enviar a sua mensagem."
       },
       "translatedNote": "Traduzido do original na visualização."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Colocar em fila uma execução plan + apply para realinhar a infraestrutura com a configuração",
+      "remediateConfirm": "Colocar em fila uma execução plan + apply para esta área de trabalho?",
+      "remediateMessage": "Colocado em fila a partir de uma verificação de desvio",
+      "remediateFailed": "Não foi possível colocar em fila a execução de correção"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Opções",
       "hideOptions": "Ocultar Opções",
-      "queueDestroy": "Colocar Destroy na Fila",
+      "queueDestroy": "Destruir",
       "queueDestroyTitle": "Colocar na fila um plano de destroy",
       "destroyAllConfirm": "Destruir todos os recursos?",
       "confirmDestroy": "Confirmar Destroy",
-      "queuePlan": "Colocar Plano na Fila",
-      "queueRun": "Colocar Execução na Fila",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Colocar na fila um plano especulativo para este workspace?",
       "queueApplyConfirm": "Colocar na fila uma execução de plan + apply? Isto pode alterar a infraestrutura.",
       "planOptions": "Opções de Plano",
       "targetResources": "Recursos-alvo",
       "replaceResources": "Substituir recursos",
       "commaSeparated": "(separados por vírgula)",
-      "planOnly": "Apenas Plano",
       "refreshOnly": "Apenas Refresh",
       "skipRefresh": "Ignorar Refresh",
       "allowEmptyApply": "Permitir Apply Vazio",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "apenas plano",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "teste de módulo",
-      "sourceModulePublish": "publicação de módulo"
+      "sourceModulePublish": "publicação de módulo",
+      "queueApplyTitle": "Colocar em fila uma execução plan + apply",
+      "queueApplyRefBlocked": "Apply fica indisponível enquanto houver um ramo, etiqueta ou commit selecionado — essas execuções são sempre apenas plan"
     },
     "state": {
       "deleteConfirm": "Eliminar a versão de estado #{serial}? Isto não pode ser anulado.",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1863,7 +1863,8 @@
       "discarding": "Отклонение…",
       "cancelShort": "Отменить",
       "cancelFull": "Отменить запуск",
-      "canceling": "Отмена…"
+      "canceling": "Отмена…",
+      "queuing": "Постановка в очередь…"
     },
     "confirm": {
       "apply": "Применить этот запуск? Это применяет план и изменяет инфраструктуру.",
@@ -2160,6 +2161,13 @@
         "sendError": "Не удалось отправить сообщение."
       },
       "translatedNote": "Переведено с оригинала при просмотре."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Поставить в очередь запуск plan + apply, чтобы вернуть инфраструктуру в соответствие с конфигурацией",
+      "remediateConfirm": "Поставить в очередь запуск plan + apply для этой рабочей области?",
+      "remediateMessage": "Поставлено в очередь по проверке расхождений",
+      "remediateFailed": "Не удалось поставить в очередь запуск исправления"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Параметры",
       "hideOptions": "Скрыть параметры",
-      "queueDestroy": "Поставить уничтожение в очередь",
+      "queueDestroy": "Уничтожить",
       "queueDestroyTitle": "Поставить в очередь план уничтожения",
       "destroyAllConfirm": "Уничтожить все ресурсы?",
       "confirmDestroy": "Подтвердить уничтожение",
-      "queuePlan": "Поставить план в очередь",
-      "queueRun": "Поставить запуск в очередь",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Поставить в очередь спекулятивный план для этой рабочей области?",
       "queueApplyConfirm": "Поставить в очередь запуск plan + apply? Это может изменить инфраструктуру.",
       "planOptions": "Параметры плана",
       "targetResources": "Целевые ресурсы",
       "replaceResources": "Заменяемые ресурсы",
       "commaSeparated": "(через запятую)",
-      "planOnly": "Только план",
       "refreshOnly": "Только обновление",
       "skipRefresh": "Пропустить обновление",
       "allowEmptyApply": "Разрешить пустое применение",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "только план",
       "typePlanApply": "план + применение",
       "sourceModuleTest": "тест модуля",
-      "sourceModulePublish": "публикация модуля"
+      "sourceModulePublish": "публикация модуля",
+      "queueApplyTitle": "Поставить в очередь запуск plan + apply",
+      "queueApplyRefBlocked": "Apply недоступен, пока выбраны ветка, тег или коммит — такие запуски всегда только plan"
     },
     "state": {
       "deleteConfirm": "Удалить версию состояния #{serial}? Это действие нельзя отменить.",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1863,7 +1863,8 @@
       "discarding": "Kasserar…",
       "cancelShort": "Avbryt",
       "cancelFull": "Avbryt körning",
-      "canceling": "Avbryter…"
+      "canceling": "Avbryter…",
+      "queuing": "Köar…"
     },
     "confirm": {
       "apply": "Applicera denna körning? Detta tillämpar planen och ändrar infrastruktur.",
@@ -2160,6 +2161,13 @@
         "sendError": "Det gick inte att skicka ditt meddelande."
       },
       "translatedNote": "Översatt från originalet vid visning."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Köa en plan + apply-körning för att åter få infrastrukturen i linje med konfigurationen",
+      "remediateConfirm": "Köa en plan + apply-körning för denna arbetsyta?",
+      "remediateMessage": "Köad från en avvikelsekontroll",
+      "remediateFailed": "Kunde inte köa rättningskörningen"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Alternativ",
       "hideOptions": "Dölj alternativ",
-      "queueDestroy": "Köa förstörelse",
+      "queueDestroy": "Förstör",
       "queueDestroyTitle": "Köa en förstörelseplan",
       "destroyAllConfirm": "Förstör alla resurser?",
       "confirmDestroy": "Bekräfta förstörelse",
-      "queuePlan": "Köa plan",
-      "queueRun": "Köa körning",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Köa en spekulativ plan för denna arbetsyta?",
       "queueApplyConfirm": "Köa en plan- + apply-körning? Detta kan ändra infrastruktur.",
       "planOptions": "Planalternativ",
       "targetResources": "Målresurser",
       "replaceResources": "Ersätt resurser",
       "commaSeparated": "(kommaseparerat)",
-      "planOnly": "Endast plan",
       "refreshOnly": "Endast uppdatera",
       "skipRefresh": "Hoppa över uppdatering",
       "allowEmptyApply": "Tillåt tom applicering",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "endast plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "modultest",
-      "sourceModulePublish": "modulpublicering"
+      "sourceModulePublish": "modulpublicering",
+      "queueApplyTitle": "Köa en plan + apply-körning",
+      "queueApplyRefBlocked": "Apply är otillgängligt medan en gren, tagg eller commit är vald — de körningarna är alltid endast plan"
     },
     "state": {
       "deleteConfirm": "Ta bort tillståndsversion #{serial}? Detta kan inte ångras.",

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -1863,7 +1863,8 @@
       "discarding": "woDtaH…",
       "cancelShort": "qIl",
       "cancelFull": "Sar qIl",
-      "canceling": "qIltaH…"
+      "canceling": "qIltaH…",
+      "queuing": "lI'taH…"
     },
     "confirm": {
       "apply": "Sar vam lo''a'? nab lo'vam 'ej nISwI' choHvam.",
@@ -2160,6 +2161,13 @@
         "sendError": "QIn ngeHmeH lujpu'."
       },
       "translatedNote": "legh'eghmeH mughlu'pu'."
+    },
+    "drift": {
+      "remediate": "nab + ta",
+      "remediateTitle": "cham chenmoHwI' rap 'e' luqaSmoH nab + ta lI'",
+      "remediateConfirm": "DaqvamvaD nab + ta DalI''a'?",
+      "remediateMessage": "Deq wIv lo''egh lI'lu'",
+      "remediateFailed": "tI'wI' lI'laHbe'"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "wIvmey",
       "hideOptions": "wIvmey So'",
-      "queueDestroy": "Qaw' tlham",
+      "queueDestroy": "Qaw'",
       "queueDestroyTitle": "Qaw' nab tlham",
       "destroyAllConfirm": "Hoch Sepmey Qaw''a'?",
       "confirmDestroy": "Qaw' tob",
-      "queuePlan": "nab tlham",
-      "queueRun": "Sar tlham",
+      "queuePlan": "nab",
+      "queueRun": "nab + ta",
       "queuePlanConfirm": "Qumwo'vamvaD Hech nab tlham'a'?",
       "queueApplyConfirm": "nab + lo' Sar tlham'a'? nISwI' choHlaH vam.",
       "planOptions": "nab wIvmey",
       "targetResources": "DoS Sepmey",
       "replaceResources": "Sepmey chartlh",
       "commaSeparated": "(HIvje' chevlu')",
-      "planOnly": "nab neH",
       "refreshOnly": "tI'ang qa' neH",
       "skipRefresh": "tI'ang qa' jump",
       "allowEmptyApply": "chIm lo' chaw'",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "nab neH",
       "typePlanApply": "nab + lo'",
       "sourceModuleTest": "Segh toblu'",
-      "sourceModulePublish": "Segh chum"
+      "sourceModulePublish": "Segh chum",
+      "queueApplyTitle": "nab + ta qaStaHvIS lI",
+      "queueApplyRefBlocked": "wIv ramus, per ghap commit qaStaHvIS talaHbe — nab neH bIH"
     },
     "state": {
       "deleteConfirm": "Dotlh mI' #{serial} Qaw''a'? choHlaHbe'lu'.",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1863,7 +1863,8 @@
       "discarding": "İptal ediliyor…",
       "cancelShort": "İptal",
       "cancelFull": "Çalıştırmayı İptal Et",
-      "canceling": "İptal ediliyor…"
+      "canceling": "İptal ediliyor…",
+      "queuing": "Kuyruğa alınıyor…"
     },
     "confirm": {
       "apply": "Bu çalıştırma uygulansın mı? Bu, planı uygular ve altyapıyı değiştirir.",
@@ -2160,6 +2161,13 @@
         "sendError": "Mesajınız gönderilemedi."
       },
       "translatedNote": "Görüntülenirken orijinalinden çevrildi."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Altyapıyı yeniden yapılandırmayla uyumlu hale getirmek için bir plan + apply çalıştırması kuyruğa al",
+      "remediateConfirm": "Bu çalışma alanı için plan + apply çalıştırması kuyruğa alınsın mı?",
+      "remediateMessage": "Sapma kontrolünden kuyruğa alındı",
+      "remediateFailed": "Düzeltme çalıştırması kuyruğa alınamadı"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Seçenekler",
       "hideOptions": "Seçenekleri Gizle",
-      "queueDestroy": "Yok Etmeyi Sıraya Al",
+      "queueDestroy": "Yok et",
       "queueDestroyTitle": "Bir yok etme planını sıraya al",
       "destroyAllConfirm": "Tüm kaynaklar yok edilsin mi?",
       "confirmDestroy": "Yok Etmeyi Onayla",
-      "queuePlan": "Planı Sıraya Al",
-      "queueRun": "Çalıştırmayı Sıraya Al",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Bu çalışma alanı için spekülatif bir plan sıraya alınsın mı?",
       "queueApplyConfirm": "Bir plan + apply çalıştırması sıraya alınsın mı? Bu, altyapıyı değiştirebilir.",
       "planOptions": "Plan Seçenekleri",
       "targetResources": "Hedef kaynaklar",
       "replaceResources": "Kaynakları değiştir",
       "commaSeparated": "(virgülle ayrılmış)",
-      "planOnly": "Yalnızca Plan",
       "refreshOnly": "Yalnızca Yenile",
       "skipRefresh": "Yenilemeyi Atla",
       "allowEmptyApply": "Boş Uygulamaya İzin Ver",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "yalnızca plan",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "modül testi",
-      "sourceModulePublish": "modül yayımlama"
+      "sourceModulePublish": "modül yayımlama",
+      "queueApplyTitle": "Plan + apply çalıştırması kuyruğa al",
+      "queueApplyRefBlocked": "Bir dal, etiket veya commit seçiliyken apply kullanılamaz — bu çalıştırmalar her zaman yalnızca plan olur"
     },
     "state": {
       "deleteConfirm": "#{serial} durum sürümü silinsin mi? Bu geri alınamaz.",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -1863,7 +1863,8 @@
       "discarding": "Відхилення…",
       "cancelShort": "Скасувати",
       "cancelFull": "Скасувати запуск",
-      "canceling": "Скасування…"
+      "canceling": "Скасування…",
+      "queuing": "Постановка в чергу…"
     },
     "confirm": {
       "apply": "Застосувати цей запуск? Це застосує план і змінить інфраструктуру.",
@@ -2160,6 +2161,13 @@
         "sendError": "Не вдалося надіслати повідомлення."
       },
       "translatedNote": "Перекладено з оригіналу під час перегляду."
+    },
+    "drift": {
+      "remediate": "Plan + apply",
+      "remediateTitle": "Поставити в чергу запуск plan + apply, щоб повернути інфраструктуру у відповідність до конфігурації",
+      "remediateConfirm": "Поставити в чергу запуск plan + apply для цієї робочої області?",
+      "remediateMessage": "Поставлено в чергу за перевіркою розходжень",
+      "remediateFailed": "Не вдалося поставити в чергу запуск виправлення"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "Опції",
       "hideOptions": "Приховати опції",
-      "queueDestroy": "Поставити знищення в чергу",
+      "queueDestroy": "Знищити",
       "queueDestroyTitle": "Поставити в чергу план знищення",
       "destroyAllConfirm": "Знищити всі ресурси?",
       "confirmDestroy": "Підтвердити знищення",
-      "queuePlan": "Поставити план у чергу",
-      "queueRun": "Поставити запуск у чергу",
+      "queuePlan": "Plan",
+      "queueRun": "Plan + apply",
       "queuePlanConfirm": "Поставити в чергу спекулятивний план для цього робочого простору?",
       "queueApplyConfirm": "Поставити в чергу запуск plan + apply? Це може змінити інфраструктуру.",
       "planOptions": "Опції плану",
       "targetResources": "Цільові ресурси",
       "replaceResources": "Замінити ресурси",
       "commaSeparated": "(через кому)",
-      "planOnly": "Лише план",
       "refreshOnly": "Лише оновлення",
       "skipRefresh": "Пропустити оновлення",
       "allowEmptyApply": "Дозволити порожнє застосування",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "лише план",
       "typePlanApply": "план + застосування",
       "sourceModuleTest": "тест модуля",
-      "sourceModulePublish": "публікація модуля"
+      "sourceModulePublish": "публікація модуля",
+      "queueApplyTitle": "Поставити в чергу запуск plan + apply",
+      "queueApplyRefBlocked": "Apply недоступний, поки вибрано гілку, тег або коміт — такі запуски завжди лише plan"
     },
     "state": {
       "deleteConfirm": "Видалити версію стану #{serial}? Це неможливо скасувати.",

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -1863,7 +1863,8 @@
       "discarding": "正在丢弃…",
       "cancelShort": "取消",
       "cancelFull": "取消运行",
-      "canceling": "正在取消…"
+      "canceling": "正在取消…",
+      "queuing": "正在加入队列…"
     },
     "confirm": {
       "apply": "应用此运行？这将应用计划并更改基础设施。",
@@ -2160,6 +2161,13 @@
         "sendError": "无法发送您的消息。"
       },
       "translatedNote": "查看时从原文翻译。"
+    },
+    "drift": {
+      "remediate": "计划 + 应用",
+      "remediateTitle": "将计划 + 应用运行加入队列，使基础设施重新与配置一致",
+      "remediateConfirm": "要为此工作区加入计划 + 应用运行吗？",
+      "remediateMessage": "由漂移检查加入队列",
+      "remediateFailed": "无法将修复运行加入队列"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "选项",
       "hideOptions": "隐藏选项",
-      "queueDestroy": "排队销毁",
+      "queueDestroy": "销毁",
       "queueDestroyTitle": "排队一次销毁计划",
       "destroyAllConfirm": "销毁所有资源？",
       "confirmDestroy": "确认销毁",
-      "queuePlan": "排队计划",
-      "queueRun": "排队运行",
+      "queuePlan": "计划",
+      "queueRun": "计划 + 应用",
       "queuePlanConfirm": "为此工作区排队一次推测性计划？",
       "queueApplyConfirm": "排队一次 plan + apply 运行？这可能会更改基础设施。",
       "planOptions": "计划选项",
       "targetResources": "目标资源",
       "replaceResources": "替换资源",
       "commaSeparated": "（逗号分隔）",
-      "planOnly": "仅计划",
       "refreshOnly": "仅刷新",
       "skipRefresh": "跳过刷新",
       "allowEmptyApply": "允许空应用",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "仅计划",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "模块测试",
-      "sourceModulePublish": "模块发布"
+      "sourceModulePublish": "模块发布",
+      "queueApplyTitle": "将计划 + 应用运行加入队列",
+      "queueApplyRefBlocked": "选择分支、标签或提交时无法应用——这些运行始终仅为计划"
     },
     "state": {
       "deleteConfirm": "删除状态版本 #{serial}？此操作无法撤销。",

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -1863,7 +1863,8 @@
       "discarding": "正在丟棄…",
       "cancelShort": "取消",
       "cancelFull": "取消執行",
-      "canceling": "正在取消…"
+      "canceling": "正在取消…",
+      "queuing": "正在加入佇列…"
     },
     "confirm": {
       "apply": "應用此執行？這將應用計畫並更改基礎設施。",
@@ -2160,6 +2161,13 @@
         "sendError": "無法傳送您的訊息。"
       },
       "translatedNote": "檢視時從原文翻譯。"
+    },
+    "drift": {
+      "remediate": "計畫 + 套用",
+      "remediateTitle": "將計畫 + 套用執行加入佇列，使基礎架構重新與組態一致",
+      "remediateConfirm": "要為此工作區加入計畫 + 套用執行嗎？",
+      "remediateMessage": "由偏移檢查加入佇列",
+      "remediateFailed": "無法將修復執行加入佇列"
     }
   },
   "workspaceDetail": {
@@ -2397,19 +2405,18 @@
     "runs": {
       "options": "選項",
       "hideOptions": "隱藏選項",
-      "queueDestroy": "排隊銷毀",
+      "queueDestroy": "銷毀",
       "queueDestroyTitle": "排隊一次銷毀計畫",
       "destroyAllConfirm": "銷毀所有資源？",
       "confirmDestroy": "確認銷毀",
-      "queuePlan": "排隊計畫",
-      "queueRun": "排隊執行",
+      "queuePlan": "計畫",
+      "queueRun": "計畫 + 套用",
       "queuePlanConfirm": "為此工作區排隊一次推測性計畫？",
       "queueApplyConfirm": "排隊一次 plan + apply 執行？這可能會更改基礎設施。",
       "planOptions": "計畫選項",
       "targetResources": "目標資源",
       "replaceResources": "替換資源",
       "commaSeparated": "（逗號分隔）",
-      "planOnly": "僅計畫",
       "refreshOnly": "僅重新整理",
       "skipRefresh": "跳過重新整理",
       "allowEmptyApply": "允許空應用",
@@ -2431,7 +2438,9 @@
       "typePlanOnly": "僅計畫",
       "typePlanApply": "plan + apply",
       "sourceModuleTest": "模組測試",
-      "sourceModulePublish": "模組釋出"
+      "sourceModulePublish": "模組釋出",
+      "queueApplyTitle": "將計畫 + 套用執行加入佇列",
+      "queueApplyRefBlocked": "選取分支、標籤或提交時無法套用——這些執行一律僅為計畫"
     },
     "state": {
       "deleteConfirm": "刪除狀態版本 #{serial}？此操作無法撤銷。",

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -29,6 +29,9 @@ interface WorkspacePermissions {
   'can-update': boolean
   'can-destroy': boolean
   'can-queue-run': boolean
+  // Plan-only vs apply are separate grants, so the UI needs both to know
+  // whether to offer the apply button at all (#1340).
+  'can-queue-apply'?: boolean
   'can-read-state-versions': boolean
   'can-create-state-versions': boolean
   'can-read-variable': boolean
@@ -357,7 +360,6 @@ function WorkspaceDetailContent() {
   const [planRefreshOnly, setPlanRefreshOnly] = useState(false)
   const [planRefresh, setPlanRefresh] = useState(true)
   const [planAllowEmpty, setPlanAllowEmpty] = useState(false)
-  const [planOnly, setPlanOnly] = useState(true)
   const [queueingDestroy, setQueueingDestroy] = useState(false)
   const [showDestroyConfirm, setShowDestroyConfirm] = useState(false)
 
@@ -587,13 +589,6 @@ function WorkspaceDetailContent() {
       loadVcsRefs()
     }
   }, [showPlanOptions, workspace, loadVcsRefs])
-
-  // Force plan-only when a non-default VCS ref is selected
-  useEffect(() => {
-    if (vcsRef) {
-      setPlanOnly(true)
-    }
-  }, [vcsRef])
 
   // Real-time workspace events via SSE (run status, lock/unlock, state, settings)
   const { connected: sseConnected } = useRunEvents(workspaceId, useCallback((event) => {
@@ -1412,11 +1407,17 @@ function WorkspaceDetailContent() {
     }
   }
 
-  async function handleQueuePlan() {
-    // Touch fat-finger guard — queuing a run is a state change (and on a
-    // non-VCS agent workspace a `plan + apply` run can change infrastructure),
-    // so a stray tap on a touch device (any width) gets a native confirm; a
-    // precise pointer runs immediately.
+  // `planOnly` is the button pressed, not a stored toggle (#1340) — the choice
+  // is per-press, so nothing persists between runs to be misread later.
+  async function handleQueuePlan(planOnly: boolean) {
+    // A non-default VCS ref is forced plan-only server-side. The apply button
+    // is disabled in that state, so reaching here with both set would mean the
+    // guard failed — refuse rather than silently queue the wrong kind of run.
+    if (!planOnly && vcsRef) return
+    // Touch fat-finger guard — queuing a run is a state change (and a
+    // `plan + apply` run can change infrastructure), so a stray tap on a touch
+    // device (any width) gets a native confirm; a precise pointer runs
+    // immediately.
     if (isTouch) {
       const msg = planOnly
         ? t('runs.queuePlanConfirm')
@@ -1468,7 +1469,6 @@ function WorkspaceDetailContent() {
       setPlanRefreshOnly(false)
       setPlanRefresh(true)
       setPlanAllowEmpty(false)
-      setPlanOnly(true)
       setVcsRef('')
       await loadRuns()
     } catch (err) {
@@ -3114,14 +3114,38 @@ function WorkspaceDetailContent() {
                       </button>
                     </div>
                   )}
+                  {/* Two buttons, not a button plus a hidden checkbox (#1340).
+                      Plan-vs-apply is the decision that matters every time, so
+                      it is made by which button you press; the options panel
+                      keeps only the genuinely occasional flags. Pressing Plan
+                      does exactly what it did before. */}
                   <button
-                    onClick={handleQueuePlan}
+                    onClick={() => handleQueuePlan(true)}
                     disabled={queueingPlan || attrs.locked}
                     className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors"
                     title={attrs.locked ? t('common.workspaceLocked') : undefined}
                   >
-                    {queueingPlan ? t('actions.queuing') : planOnly ? t('runs.queuePlan') : t('runs.queueRun')}
+                    {queueingPlan ? t('actions.queuing') : t('runs.queuePlan')}
                   </button>
+                  {perms['can-queue-apply'] && (
+                    <button
+                      onClick={() => handleQueuePlan(false)}
+                      // Disabled on a non-default VCS ref because the server
+                      // forces those runs plan-only. Leaving it enabled would
+                      // promise an apply and quietly deliver a plan.
+                      disabled={queueingPlan || attrs.locked || !!vcsRef}
+                      className="px-4 py-2 rounded-lg text-sm font-medium bg-amber-600 hover:bg-amber-500 disabled:bg-amber-900/40 disabled:text-amber-600/70 text-white transition-colors"
+                      title={
+                        attrs.locked
+                          ? t('common.workspaceLocked')
+                          : vcsRef
+                            ? t('runs.queueApplyRefBlocked')
+                            : t('runs.queueApplyTitle')
+                      }
+                    >
+                      {queueingPlan ? t('actions.queuing') : t('runs.queueRun')}
+                    </button>
+                  )}
                 </div>
                 {showPlanOptions && (
                   <div className="mt-3 p-4 bg-slate-800/50 rounded-lg border border-slate-700/50">
@@ -3149,16 +3173,8 @@ function WorkspaceDetailContent() {
                       </div>
                     </div>
                     <div className="flex flex-wrap gap-4 mt-3">
-                      <label className={`flex items-center gap-2 text-sm cursor-pointer ${vcsRef ? 'text-slate-500' : 'text-slate-300'}`}>
-                        <input
-                          type="checkbox"
-                          checked={planOnly}
-                          onChange={e => setPlanOnly(e.target.checked)}
-                          disabled={!!vcsRef}
-                          className="rounded border-slate-600 bg-slate-900 text-brand-500 focus:ring-brand-500 disabled:opacity-50"
-                        />
-                        {t('runs.planOnly')}
-                      </label>
+                      {/* The plan-only checkbox that used to live here is now
+                          the Plan / Plan + apply button pair above (#1340). */}
                       <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
                         <input
                           type="checkbox"

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -68,6 +68,7 @@ interface RunAttrs {
   'vcs-branch': string | null
   'vcs-pull-request-number': number | null
   'has-changes': boolean
+  'is-drift-detection': boolean
   'has-json-output'?: boolean
   'has-cost-estimate'?: boolean
   'plan-summary': {
@@ -597,6 +598,11 @@ function RunDetailPageInner() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [actionLoading, setActionLoading] = useState('')
+  // The workspace's RBAC + lock state, for the drift-remediation button
+  // (#1340). The run's own `permissions` block is state-based (can this run be
+  // applied), not "may this user queue an apply" — so it cannot answer it.
+  const [wsCanApply, setWsCanApply] = useState(false)
+  const [wsLocked, setWsLocked] = useState(false)
 
   const [planLog, setPlanLog] = useState<string | null>(null)
   const [applyLog, setApplyLog] = useState<string | null>(null)
@@ -737,6 +743,24 @@ function RunDetailPageInner() {
     if (!getAuthState()) { router.push('/login'); return }
     loadRun()
   }, [router, loadRun])
+
+  // Workspace RBAC + lock, for the drift-remediation button (#1340). The run's
+  // own `permissions` block is state-based ("can this run be applied"), not
+  // "may this user queue an apply", so it cannot answer this. Best-effort: if
+  // the fetch fails the button simply does not appear, which is the safe
+  // direction — never offer an apply we cannot stand behind.
+  useEffect(() => {
+    let cancelled = false
+    apiFetch(`/api/v2/workspaces/${workspaceId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (cancelled || !d?.data?.attributes) return
+        setWsCanApply(!!d.data.attributes.permissions?.['can-queue-apply'])
+        setWsLocked(!!d.data.attributes.locked)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [workspaceId])
 
   // Keep the Overview rollups fresh: AI on mount + whenever a summary
   // lifecycle SSE event bumps aiSummaryRefresh; policy on mount + whenever the
@@ -1118,7 +1142,18 @@ function RunDetailPageInner() {
     return { value: '—', tone: 'neutral' }
   })()
 
+  // A drift run that found drift is the one case where the obvious next step
+  // is a fresh remediation run, so offer it right there (#1340). Not shown
+  // when drift found nothing — there is nothing to fix, and an apply button
+  // would only invite a pointless run.
+  const showRemediateDrift =
+    attrs['is-drift-detection'] &&
+    attrs['has-changes'] === true &&
+    wsCanApply &&
+    !wsLocked
+
   const hasActions =
+    showRemediateDrift ||
     actions['is-confirmable'] ||
     actions['is-discardable'] ||
     actions['is-cancelable'] ||
@@ -1148,8 +1183,49 @@ function RunDetailPageInner() {
   // Labels go terse below `md` (Apply / Retry / Cancel) and full at `md+`
   // (Confirm & Apply / Retry Run / Cancel Run). `requestAction` inserts the
   // mobile confirm step; desktop runs immediately.
+  async function remediateDrift() {
+    // Deliberately a NEW run rather than applying this one: a drift run is
+    // plan-only and its plan is a detection artifact, so the right output is an
+    // ordinary run against current config with default options.
+    if (isTouch && !window.confirm(t('drift.remediateConfirm'))) return
+    setActionLoading('remediate')
+    try {
+      const res = await apiFetch('/api/v2/runs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: JSON.stringify({
+          data: {
+            type: 'runs',
+            attributes: { 'plan-only': false, message: t('drift.remediateMessage') },
+            relationships: { workspace: { data: { type: 'workspaces', id: workspaceId } } },
+          },
+        }),
+      })
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}))
+        throw new Error(d.detail || t('drift.remediateFailed'))
+      }
+      const newId = (await res.json().catch(() => null))?.data?.id
+      if (newId) router.push(`/workspaces/${workspaceId}/runs/${newId}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('drift.remediateFailed'))
+    } finally {
+      setActionLoading('')
+    }
+  }
+
   const actionButtons = (
     <>
+      {showRemediateDrift && (
+        <button
+          onClick={remediateDrift}
+          disabled={!!actionLoading}
+          className="px-3 md:px-4 py-2 rounded-lg text-sm font-medium bg-amber-600 hover:bg-amber-500 disabled:bg-amber-900/40 disabled:text-amber-600/70 text-white transition-colors"
+          title={t('drift.remediateTitle')}
+        >
+          {actionLoading === 'remediate' ? t('actions.queuing') : t('drift.remediate')}
+        </button>
+      )}
       {actions['is-retryable'] && (
         <button
           onClick={() => requestAction('retry')}


### PR DESCRIPTION
Queueing an apply from the workspace UI took four steps: reveal "Plan options",
find the "Plan only" checkbox, uncheck it, press Queue run. The decision that
matters on every run was buried in a collapsed panel behind a checkbox whose
state you could not see without opening it — sitting alongside the genuinely
occasional flags with equal billing.

## Plan / Plan + apply

The checkbox is replaced by a second button, so which button you press *is* the
choice:

| Button | Run |
|---|---|
| **Plan** | plan-only — unchanged, byte for byte |
| **Plan + apply** | apply-capable |

Chosen per press, so nothing persists between runs to be misread later. The
remaining options (target, replace, refresh-only, refresh, allow-empty-apply)
stay in the panel and apply to whichever button is pressed.

`Plan + apply` is **disabled while a branch, tag or commit is selected** — the
server forces those runs plan-only, and a button that promises an apply and
delivers a plan is worse than no button. It respects the workspace auto-apply
setting: on a manual-apply workspace the run still stops at `planned` for
confirmation. It means "this run may apply", not "skip the gate".

## Remediating a drift run

Absorbed into this issue (see the [scope
comment](https://github.com/mattrobinsonsre/terrapod/issues/1340#issuecomment-5302324745)).

Drift runs are plan-only by design — a scheduled job must not change
infrastructure on its own. But that left the operator on a page reporting a
problem with nothing to do about it; reconciling meant navigating back to the
workspace and queuing a run by hand.

A drift run that found changes now offers the same **Plan + apply**: a fresh
ordinary run against current config, not an apply of the drift run's own plan,
which is a detection artifact. Hidden when drift found nothing, when the
workspace is locked, and without `run:apply`.

Applying is one of two answers to drift; updating the configuration to match
what is deployed is the other. The button offers the first and says nothing
about which is right.

## `can-queue-apply`

Both surfaces need to know whether this user may apply, and `can-queue-run` is
plan-only — so the UI previously had to either hide the apply from everyone who
held the grant or show a control that 403s on press. New `can-queue-apply`
permission on the workspace, gated on `RUN_APPLY`. Purely additive to the
permissions block.

## Verification

- `make test` — **4427 passed**
- `tsc --noEmit`, `i18n:lint`, `i18n:check` (2424 keys × 32 catalogs), production
  `next build`
- Live on the local stack: both buttons render and queue the right kind of run;
  the drift button appears on a seeded drifted run
- Tests: 3 server assertions incl. `caps_for_level("plan")` proving
  plan-without-apply is expressible; e2e for both buttons, for Plan still
  sending `plan-only: true`, and for the drift button (route-mocked — the API
  cannot seed a drift run); a responsive assertion that both are reachable at
  phone width with no horizontal page scroll
- Docs: `api-reference.md`, both `rbac.md` tables, and a *Remediating drift*
  section

Closes #1340
