### PR TITLE
fix(1346): persist the budget window, and measure it instead of guessing

### DIFF
--- a/services/terrapod/services/vcs_rate_limit.py
+++ b/services/terrapod/services/vcs_rate_limit.py
@@ -257,36 +257,55 @@ def parse_headers(headers: object) -> RateLimitSnapshot | None:
     if 0 < reset < 10_000_000:
         reset = now + reset
 
-    # The window, inferred from how far away the reset is. This reads the
-    # remaining window rather than the whole one, so mid-window it under-reads
-    # — rounding up to the nearest familiar bucket (minute/hour) recovers the
-    # intent without hardcoding a provider. Unknown reset ⇒ unknown window.
-    window = _infer_window(reset - now) if reset > 0 else 0
-
+    # The window is NOT knowable from a single response: a header says when the
+    # budget next refills, never how wide the window is. It is learned across
+    # observations instead (`_learn_window`), so a single snapshot carries 0 —
+    # "not known yet" — rather than a guess.
     return RateLimitSnapshot(
         limit=limit,
         remaining=remaining,
         reset_at=reset,
         observed_at=now,
         resource=resource,
-        window_seconds=window,
+        window_seconds=0,
     )
 
 
-def _infer_window(seconds_remaining: int) -> int:
-    """Round a time-to-reset up to the budget window it most likely belongs to.
+# A refill interval outside this range is not a budget window; it is a clock
+# jump, a provider changing its mind, or a parse that went wrong.
+_MIN_WINDOW_SECONDS = 30
+_MAX_WINDOW_SECONDS = 86_400
 
-    Providers do not send the window, only when it next resets, so this maps
-    an observation onto the smallest standard bucket that contains it: GitLab's
-    per-minute throttles land on 60, GitHub's hourly quota on 3600. Anything
-    longer is reported as-is rather than forced into a bucket we invented.
+
+def _learn_window(previous: RateLimitSnapshot | None, current: RateLimitSnapshot) -> int:
+    """Derive the refill window from the distance between consecutive refills.
+
+    `reset_at` advances by exactly one window each time the budget refills, so
+    the delta between two observations that straddle a refill IS the window —
+    3600 on GitHub, 60 on GitLab.com. That is measured, not inferred, which
+    matters because the obvious shortcut (round the *time remaining* up to a
+    familiar bucket) depends on when you happen to sample: 612 seconds from a
+    GitHub reset it yields 900, not 3600, and the share computed from it is
+    then wrong by a factor of four.
+
+    Nothing is reported until a refill has actually been observed. The warm-up
+    costs at most one window, and during it the reader falls back to treating
+    the rate as hourly — exactly the behaviour that shipped in v1.5.0.
+
+    The learned value only ever shrinks. A gap where nobody called spans
+    several refills and reads long; it can never read short. Taking the minimum
+    therefore converges on the true window from above without assuming
+    anything about which provider this is.
     """
-    if seconds_remaining <= 0:
-        return 0
-    for bucket in (60, 300, 900, 3600):
-        if seconds_remaining <= bucket:
-            return bucket
-    return seconds_remaining
+    known = previous.window_seconds if previous is not None else 0
+    if previous is None or previous.reset_at <= 0 or current.reset_at <= 0:
+        return known
+    delta = current.reset_at - previous.reset_at
+    if delta <= 0:
+        return known  # same window, or a clock that went backwards
+    if not (_MIN_WINDOW_SECONDS <= delta <= _MAX_WINDOW_SECONDS):
+        return known
+    return min(known, delta) if known else delta
 
 
 async def record(conn: object, headers: object, *, outcome: str) -> None:
@@ -329,6 +348,10 @@ async def record(conn: object, headers: object, *, outcome: str) -> None:
     try:
         from terrapod.redis.client import get_redis_client
 
+        # The previous reading is what makes the window knowable: it is the
+        # gap between two refills, so it cannot come from this response alone.
+        window = _learn_window(await get_snapshot(connection_id), snapshot)
+
         await get_redis_client().hset(  # type: ignore[misc]
             _quota_key(connection_id),
             mapping={
@@ -337,6 +360,11 @@ async def record(conn: object, headers: object, *, outcome: str) -> None:
                 "reset_at": snapshot.reset_at,
                 "observed_at": snapshot.observed_at,
                 "resource": snapshot.resource,
+                # Persisting this is what #1345 missed: the field existed on the
+                # dataclass, in the parser, the reader, the SDK and the UI, and
+                # was simply never written — so it read back as 0 forever and
+                # the UI silently fell back to assuming an hour.
+                "window_seconds": window,
             },
         )
         await get_redis_client().expire(_quota_key(connection_id), _QUOTA_TTL_SECONDS)

--- a/services/tests/services/test_vcs_rate_limit.py
+++ b/services/tests/services/test_vcs_rate_limit.py
@@ -363,38 +363,134 @@ class TestConsumptionTally:
 
 
 class TestBudgetWindow:
-    """The window is read, never assumed (#1345).
+    """The window is measured, never assumed (#1345, fixed in #1346).
 
-    GitHub refills 5,000 per HOUR; GitLab.com 2,000 per MINUTE. The UI renders
-    the rate as a share of the allowance, so assuming an hour made a GitLab
-    connection read ~60x busier than it was.
+    GitHub refills per HOUR; GitLab.com per MINUTE. The UI renders the rate as
+    a share of the allowance, so assuming an hour made a GitLab connection read
+    ~60x busier than it was.
+
+    A single response cannot answer this: headers say when the budget next
+    refills, never how wide the window is. It is the gap between consecutive
+    refills, so it is learned across observations.
     """
 
-    def test_a_github_shaped_reset_infers_the_hourly_window(self):
-        now = int(time.time())
-        snap = vcs_rate_limit.parse_headers(
-            {
-                "X-RateLimit-Limit": "5000",
-                "X-RateLimit-Remaining": "4000",
-                "X-RateLimit-Reset": str(now + 3000),
-            }
+    def _snap(self, reset_at: int, window: int = 0):
+        return vcs_rate_limit.RateLimitSnapshot(
+            limit=5000,
+            remaining=4000,
+            reset_at=reset_at,
+            observed_at=reset_at - 10,
+            resource="core",
+            window_seconds=window,
         )
-        assert snap is not None
-        assert snap.window_seconds == 3600
 
-    def test_a_gitlab_shaped_reset_infers_the_per_minute_window(self):
-        now = int(time.time())
+    def test_a_single_response_does_not_claim_to_know_the_window(self):
+        """The bug this replaces: rounding time-to-reset up to a bucket is
+        sampling-dependent. Observed 612s from a GitHub reset it yields 900,
+        not 3600, and every share computed from it is wrong by a factor of
+        four. Better to report nothing than a number that moves with when you
+        happened to look."""
         snap = vcs_rate_limit.parse_headers(
             {
-                "RateLimit-Limit": "2000",
-                "RateLimit-Remaining": "1900",
-                "RateLimit-Reset": str(now + 40),
+                "X-RateLimit-Limit": "15000",
+                "X-RateLimit-Remaining": "12234",
+                "X-RateLimit-Reset": str(int(time.time()) + 612),
             }
         )
         assert snap is not None
-        assert snap.window_seconds == 60, (
-            "a per-minute throttle must not be reported as an hourly budget"
+        assert snap.window_seconds == 0
+
+    def test_an_hourly_refill_is_learned_from_the_gap_between_resets(self):
+        base = int(time.time()) + 600
+        got = vcs_rate_limit._learn_window(self._snap(base), self._snap(base + 3600))
+        assert got == 3600
+
+    def test_a_per_minute_refill_is_learned_the_same_way(self):
+        base = int(time.time()) + 30
+        got = vcs_rate_limit._learn_window(self._snap(base), self._snap(base + 60))
+        assert got == 60, "a per-minute throttle must not be reported as hourly"
+
+    def test_nothing_is_claimed_until_a_refill_has_been_seen(self):
+        base = int(time.time()) + 600
+        assert vcs_rate_limit._learn_window(None, self._snap(base)) == 0
+        # Same window observed twice: still no refill, so still nothing known.
+        assert vcs_rate_limit._learn_window(self._snap(base), self._snap(base)) == 0
+
+    def test_a_quiet_gap_cannot_inflate_a_known_window(self):
+        """Nobody called for three hours, so the reset jumped three windows.
+        A gap can only ever read LONG, never short, so the learned value takes
+        the minimum and converges on the truth from above — without assuming
+        which provider this is."""
+        base = int(time.time()) + 600
+        got = vcs_rate_limit._learn_window(self._snap(base, window=3600), self._snap(base + 10800))
+        assert got == 3600
+
+    def test_a_shorter_observation_corrects_a_longer_one(self):
+        base = int(time.time()) + 600
+        got = vcs_rate_limit._learn_window(self._snap(base, window=3600), self._snap(base + 60))
+        assert got == 60
+
+    def test_an_implausible_gap_is_rejected_rather_than_stored(self):
+        """A clock jump or a provider changing its mind is not a window."""
+        base = int(time.time()) + 600
+        assert vcs_rate_limit._learn_window(self._snap(base, window=60), self._snap(base + 5)) == 60
+        assert (
+            vcs_rate_limit._learn_window(self._snap(base, window=60), self._snap(base + 999_999))
+            == 60
         )
+
+    async def test_the_window_survives_the_round_trip_through_redis(self):
+        """The actual #1345 defect: computed, returned, consumed — never
+        stored. Everything above passes on code that writes nothing."""
+        redis = _FakeRedis()
+        base = int(time.time())
+        with patch("terrapod.redis.client.get_redis_client", return_value=redis):
+            await vcs_rate_limit.record(
+                _conn(),
+                {
+                    "X-RateLimit-Limit": "5000",
+                    "X-RateLimit-Remaining": "4999",
+                    "X-RateLimit-Reset": str(base + 600),
+                },
+                outcome="200",
+            )
+            await vcs_rate_limit.record(
+                _conn(),
+                {
+                    "X-RateLimit-Limit": "5000",
+                    "X-RateLimit-Remaining": "4998",
+                    "X-RateLimit-Reset": str(base + 600 + 3600),
+                },
+                outcome="200",
+            )
+            got = await vcs_rate_limit.get_snapshot("conn-1")
+
+        assert got is not None
+        assert got.window_seconds == 3600
+
+    async def test_every_field_survives_the_round_trip(self):
+        """Guards the CLASS of bug, not just the one field: a value that
+        reaches the dataclass, the parser, the reader, the SDK and the UI but
+        is missing from the write mapping reads back as a default forever, and
+        every test above it still passes."""
+        redis = _FakeRedis()
+        headers = {
+            "X-RateLimit-Limit": "5000",
+            "X-RateLimit-Remaining": "4321",
+            "X-RateLimit-Reset": str(int(time.time()) + 900),
+            "X-RateLimit-Resource": "graphql",
+        }
+        parsed = vcs_rate_limit.parse_headers(headers)
+        assert parsed is not None
+        with patch("terrapod.redis.client.get_redis_client", return_value=redis):
+            await vcs_rate_limit.record(_conn(), headers, outcome="200")
+            got = await vcs_rate_limit.get_snapshot("conn-1")
+
+        assert got is not None
+        for field in ("limit", "remaining", "reset_at", "resource"):
+            assert getattr(got, field) == getattr(parsed, field), (
+                f"{field} did not survive being written to Redis and read back"
+            )
 
     def test_gitlab_names_the_throttle_rather_than_a_resource(self):
         """`RateLimit-Name` answers the same question as GitHub's


### PR DESCRIPTION
Closes #1346.

`budget-window-seconds` shipped in v1.5.0 reaching the dataclass, the parser, the reader, go-terrapod and the UI — and never being written to Redis. It read back as 0 and serialized as `null` on every connection, so the field was inert. Verified against the live v1.5.0 instance before fixing.

## Impact

Narrow, and not what it looks like. `_verdict` and `exhausts-in-seconds` were never affected: they project a per-second rate over the provider's own `seconds_to_reset`, with no hourly assumption, so the verdict is correct on every provider.

The only consumer is the UI share, which falls back to treating the rate as hourly when the field is null:

- **GitHub** — accidentally correct, because its window really is an hour.
- **GitLab** — an hourly count over a per-minute allowance, rendering **~60x high** beside a badge saying "comfortable".

## Why this is more than one line

The obvious fix — add `window_seconds` to the `hset` mapping — makes GitHub worse. The window was inferred by rounding *time-to-reset* up to a bucket, which is sampling-dependent: observed 612s from a GitHub reset it returns 900, not 3600, so a correct 12.8% share would have become 3.2%.

A single response genuinely cannot answer this. Headers say when the budget next refills, never how wide the window is.

## What it does instead

`reset_at` advances by exactly one window on each refill, so the gap between two observations straddling a refill **is** the window — 3600 on GitHub, 60 on GitLab.com. Measured, not inferred, and no provider is hardcoded.

- Nothing is reported until a refill has actually been observed. The warm-up costs at most one window, during which the reader falls back to hourly — exactly what v1.5.0 does today, so the upgrade has no regression window.
- The learned value only ever shrinks. A quiet gap spans several refills and reads long; it can never read short. Taking the minimum converges on the truth from above.
- Implausible deltas (clock jumps, parse noise) are rejected rather than stored.

## Tests

Seven replace the two that encoded the old inference — one of which passed only because it happened to pick a time-to-reset that rounded correctly.

The one that matters is `test_every_field_survives_the_round_trip`: this was not a logic error, it was an unguarded link, and every other test passed against code that stored nothing. That test asserts the parsed snapshot survives Redis field by field, so the next field added to this dataclass cannot repeat it.

## Contracts

No snapshot moves: no route, attribute, wire, config or Helm surface changes — the attribute already exists and already serializes. `make test` 4442 passed.