### PR TITLE
chore: hold starlette at <1.4 in dependabot, with the fastapi hold

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,23 @@ updates:
       # PR with a full smoke pass; revisit then.
       - dependency-name: fastapi
         versions: [">=0.137"]
+      # starlette is the other half of that same hold. pyproject caps it
+      # `<1.4.0` deliberately: fastapi declares only a FLOOR for it, so our cap
+      # is the only thing stopping starlette floating to latest on every build.
+      # Dependabot's proposal was to WIDEN the cap to `<1.7.0` — which is not
+      # "take starlette 1.4", it is "allow anything below 1.7", i.e. precisely
+      # the drift the pin exists to prevent (#1355, closed unmerged).
+      #
+      # Version-scoped rather than a blanket ignore so 1.3.x patches — security
+      # fixes inside our supported range — still come through.
+      #
+      # Worth knowing: tests/test_dependency_pins.py only asserts that SOME
+      # upper bound exists, so a widened cap passes CI. Review was the only
+      # gate that caught this, hence holding it here instead.
+      #
+      # Lift together with the fastapi hold above, as one migration.
+      - dependency-name: starlette
+        versions: [">=1.4"]
 
   - package-ecosystem: npm
     directory: /web


### PR DESCRIPTION
`fastapi` is already held at `<0.137` in `.github/dependabot.yml`, with the comment *"fastapi 0.137 pulls starlette 1.x (major)… Hold until a dedicated migration PR with a full smoke pass"*. **starlette itself was never held**, so Dependabot kept proposing to widen our own cap — #1355, `>=1.3.1,<1.4.0` -> `<1.7.0`.

That proposal is not "take starlette 1.4". It is "allow anything below 1.7", letting starlette float across three minors on any future build — exactly the drift the pin exists to prevent. `pyproject.toml` says so directly:

> Capping it here forces every starlette move to be an explicit, reviewed edit… Bump this line in lock-step when intentionally taking a new starlette.

And it wasn't paired with a fastapi move, which the same comment requires.

**Version-scoped (`>=1.4`), not a blanket ignore** — mirroring the fastapi entry — so 1.3.x patches, including security fixes inside our supported range, still come through. A bare `dependency-name: starlette` would silence those too.

Worth recording: `tests/test_dependency_pins.py` only asserts that *some* upper bound exists, so `<1.7.0` passes CI. Review was the only gate that caught it — which is the argument for holding it in config rather than relying on catching it again next time.

Lift this together with the fastapi hold; they are one migration.

#1355 is closed unmerged.