### PR TITLE
fix(1363): upgrade setuptools in the image builders (CVE-2025-47273)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -11,6 +11,16 @@
 ARG BASE_IMAGE=python:3.13-slim
 FROM ${BASE_IMAGE} AS builder
 
+# setuptools ships in the python base image and lags its own security fixes.
+# The runtime stage copies THIS stage's site-packages wholesale, so upgrading
+# here is what actually reaches the shipped image — upgrading in the runtime
+# stage would just be overwritten by that copy.
+#
+# Cleared CVE-2025-47273 (path traversal, fixed in 78.1.1), which failed every
+# image scan on both arches the day it started matching. Kept as a floor rather
+# than a pin so the next base image bump does not silently re-introduce it.
+RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1"
+
 # Install build + runtime dependencies
 # apt-get upgrade picks up security patches for base OS packages
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -106,6 +106,13 @@ RUN chmod 0755 /usr/local/bin/terrapod-query && /usr/local/bin/terrapod-query --
 WORKDIR /app
 
 # Copy installed Python packages from builder
+# Remove the base image's own setuptools BEFORE copying the builder's.
+# `COPY` of a directory MERGES into the destination rather than replacing it, so
+# the base's stale `setuptools-<old>.dist-info` would survive alongside the
+# upgraded one — leaving vulnerable *metadata* on disk that scanners read, even
+# though `import setuptools` resolves to the new version. Checking the imported
+# version is therefore not enough to prove this fixed (CVE-2025-47273).
+RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -74,7 +74,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # builds and is deliberately NOT what keeps CI current — a hand-bumped constant
 # works only until someone forgets, which is how five already-patched libexpat
 # CVEs stayed in the images for 18 days (#1177).
-ARG PKG_REFRESH=2026-07-13
+ARG PKG_REFRESH=2026-08-17
 RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
@@ -115,6 +115,22 @@ WORKDIR /app
 RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Drop pip from the runtime image. Nothing here uses it: packages arrive via the
+# builder's site-packages above, the platform tools (opa/trivy/checkov) are
+# fetched as self-contained bundles and executed directly (#1208), and no code
+# path shells out to pip or builds a venv.
+#
+# It also removes `pip/_vendor`, whose PINNED bundle is what image scanners
+# actually report — msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and setuptools 70.3.0
+# (CVE-2025-47273). Neither is fixable by upgrading: pip 26.2.1 is the current
+# release and vendors exactly those versions, so there is no newer pip to take.
+# Removing the unused component beats accepting the risk.
+#
+# stdlib `ensurepip` is untouched, so pip can be restored in a debug shell.
+RUN rm -rf /usr/local/lib/python3.13/site-packages/pip \
+           /usr/local/lib/python3.13/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.13
 
 # Copy application code
 COPY services/terrapod ./terrapod

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -54,6 +54,13 @@ RUN echo "pkg-refresh=${PKG_REFRESH}" \
 WORKDIR /app
 
 # Copy installed Python packages from builder
+# Remove the base image's own setuptools BEFORE copying the builder's.
+# `COPY` of a directory MERGES into the destination rather than replacing it, so
+# the base's stale `setuptools-<old>.dist-info` would survive alongside the
+# upgraded one — leaving vulnerable *metadata* on disk that scanners read, even
+# though `import setuptools` resolves to the new version. Checking the imported
+# version is therefore not enough to prove this fixed (CVE-2025-47273).
+RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -43,7 +43,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # builds and is deliberately NOT what keeps CI current — a hand-bumped constant
 # works only until someone forgets, which is how five already-patched libexpat
 # CVEs stayed in the images for 18 days (#1177).
-ARG PKG_REFRESH=2026-07-13
+ARG PKG_REFRESH=2026-08-17
 # The listener installs NO extra packages — it is Python talking to the K8s API
 # and the Terrapod API, and nothing else. The upgrade still runs, because that
 # is what picks up base-image security patches.
@@ -63,6 +63,22 @@ WORKDIR /app
 RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Drop pip from the runtime image. Nothing here uses it: packages arrive via the
+# builder's site-packages above, the platform tools (opa/trivy/checkov) are
+# fetched as self-contained bundles and executed directly (#1208), and no code
+# path shells out to pip or builds a venv.
+#
+# It also removes `pip/_vendor`, whose PINNED bundle is what image scanners
+# actually report — msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and setuptools 70.3.0
+# (CVE-2025-47273). Neither is fixable by upgrading: pip 26.2.1 is the current
+# release and vendors exactly those versions, so there is no newer pip to take.
+# Removing the unused component beats accepting the risk.
+#
+# stdlib `ensurepip` is untouched, so pip can be restored in a debug shell.
+RUN rm -rf /usr/local/lib/python3.13/site-packages/pip \
+           /usr/local/lib/python3.13/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.13
 
 # Only the modules the listener imports: config, logging_config, http_retry, runner/
 COPY services/terrapod/config.py ./terrapod/config.py

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -10,6 +10,16 @@
 ARG BASE_IMAGE=python:3.13-slim
 FROM ${BASE_IMAGE} AS builder
 
+# setuptools ships in the python base image and lags its own security fixes.
+# The runtime stage copies THIS stage's site-packages wholesale, so upgrading
+# here is what actually reaches the shipped image — upgrading in the runtime
+# stage would just be overwritten by that copy.
+#
+# Cleared CVE-2025-47273 (path traversal, fixed in 78.1.1), which failed every
+# image scan on both arches the day it started matching. Kept as a floor rather
+# than a pin so the next base image bump does not silently re-introduce it.
+RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1"
+
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     pkg-config \
     gcc \

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -50,6 +50,13 @@ RUN echo "pkg-refresh=${PKG_REFRESH}" \
 WORKDIR /app
 
 # Copy installed Python packages from builder
+# Remove the base image's own setuptools BEFORE copying the builder's.
+# `COPY` of a directory MERGES into the destination rather than replacing it, so
+# the base's stale `setuptools-<old>.dist-info` would survive alongside the
+# upgraded one — leaving vulnerable *metadata* on disk that scanners read, even
+# though `import setuptools` resolves to the new version. Checking the imported
+# version is therefore not enough to prove this fixed (CVE-2025-47273).
+RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -9,6 +9,16 @@
 ARG BASE_IMAGE=python:3.13-slim
 FROM ${BASE_IMAGE} AS builder
 
+# setuptools ships in the python base image and lags its own security fixes.
+# The runtime stage copies THIS stage's site-packages wholesale, so upgrading
+# here is what actually reaches the shipped image — upgrading in the runtime
+# stage would just be overwritten by that copy.
+#
+# Cleared CVE-2025-47273 (path traversal, fixed in 78.1.1), which failed every
+# image scan on both arches the day it started matching. Kept as a floor rather
+# than a pin so the next base image bump does not silently re-introduce it.
+RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1"
+
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     pkg-config \
     gcc \

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -43,7 +43,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # builds and is deliberately NOT what keeps CI current — a hand-bumped constant
 # works only until someone forgets, which is how five already-patched libexpat
 # CVEs stayed in the images for 18 days (#1177).
-ARG PKG_REFRESH=2026-07-13
+ARG PKG_REFRESH=2026-08-17
 RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
@@ -59,6 +59,22 @@ WORKDIR /app
 RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Drop pip from the runtime image. Nothing here uses it: packages arrive via the
+# builder's site-packages above, the platform tools (opa/trivy/checkov) are
+# fetched as self-contained bundles and executed directly (#1208), and no code
+# path shells out to pip or builds a venv.
+#
+# It also removes `pip/_vendor`, whose PINNED bundle is what image scanners
+# actually report — msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and setuptools 70.3.0
+# (CVE-2025-47273). Neither is fixable by upgrading: pip 26.2.1 is the current
+# release and vendors exactly those versions, so there is no newer pip to take.
+# Removing the unused component beats accepting the risk.
+#
+# stdlib `ensurepip` is untouched, so pip can be restored in a debug shell.
+RUN rm -rf /usr/local/lib/python3.13/site-packages/pip \
+           /usr/local/lib/python3.13/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.13
 
 # Only the modules needed for migrations: db models + alembic config.
 # models.py imports terrapod.crypto.types (the EncryptedText column type), so the

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -73,6 +73,13 @@ COPY docker/query-bin/terrapod-query /usr/local/bin/terrapod-query
 RUN chmod 0755 /usr/local/bin/terrapod-query && /usr/local/bin/terrapod-query --help >/dev/null
 
 # Python deps from builder
+# Remove the base image's own setuptools BEFORE copying the builder's.
+# `COPY` of a directory MERGES into the destination rather than replacing it, so
+# the base's stale `setuptools-<old>.dist-info` would survive alongside the
+# upgraded one — leaving vulnerable *metadata* on disk that scanners read, even
+# though `import setuptools` resolves to the new version. Checking the imported
+# version is therefore not enough to prove this fixed (CVE-2025-47273).
+RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -30,6 +30,16 @@
 ARG BASE_IMAGE=python:3.13-slim
 FROM ${BASE_IMAGE} AS builder
 
+# setuptools ships in the python base image and lags its own security fixes.
+# The runtime stage copies THIS stage's site-packages wholesale, so upgrading
+# here is what actually reaches the shipped image — upgrading in the runtime
+# stage would just be overwritten by that copy.
+#
+# Cleared CVE-2025-47273 (path traversal, fixed in 78.1.1), which failed every
+# image scan on both arches the day it started matching. Kept as a floor rather
+# than a pin so the next base image bump does not silently re-introduce it.
+RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1"
+
 WORKDIR /build
 COPY services/pyproject-runner.toml pyproject.toml
 RUN pip install --no-cache-dir .

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -57,7 +57,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # builds and is deliberately NOT what keeps CI current — a hand-bumped constant
 # works only until someone forgets, which is how five already-patched libexpat
 # CVEs stayed in the images for 18 days (#1177).
-ARG PKG_REFRESH=2026-07-13
+ARG PKG_REFRESH=2026-08-17
 RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         git \
@@ -82,6 +82,22 @@ RUN chmod 0755 /usr/local/bin/terrapod-query && /usr/local/bin/terrapod-query --
 RUN pip uninstall -y setuptools
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Drop pip from the runtime image. Nothing here uses it: packages arrive via the
+# builder's site-packages above, the platform tools (opa/trivy/checkov) are
+# fetched as self-contained bundles and executed directly (#1208), and no code
+# path shells out to pip or builds a venv.
+#
+# It also removes `pip/_vendor`, whose PINNED bundle is what image scanners
+# actually report — msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and setuptools 70.3.0
+# (CVE-2025-47273). Neither is fixable by upgrading: pip 26.2.1 is the current
+# release and vendors exactly those versions, so there is no newer pip to take.
+# Removing the unused component beats accepting the risk.
+#
+# stdlib `ensurepip` is untouched, so pip can be restored in a debug shell.
+RUN rm -rf /usr/local/lib/python3.13/site-packages/pip \
+           /usr/local/lib/python3.13/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.13
 
 # Runner Python module — only what the Job entrypoint imports.
 WORKDIR /app

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -57,7 +57,7 @@ COPY --from=builder /app/public ./public
 # PKG_REFRESH exists for the `apk upgrade` above it, for the same reason the
 # Debian images carry one: this layer caches, so without something that changes
 # the upgrade silently stops upgrading. CI passes today's date (#1177).
-ARG PKG_REFRESH=2026-07-13
+ARG PKG_REFRESH=2026-08-17
 RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apk upgrade --no-cache \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -20,6 +20,11 @@ fastapi = ">=0.135.2,!=0.136.3,<0.137.0"
 # tests/test_dependency_pins.py — keep the upper bound. Bump this line in
 # lock-step when intentionally taking a new starlette.
 starlette = ">=1.3.1,<1.4.0"
+# msgpack is a transitive (no lockfile is committed — the image build resolves
+# it), so a floor here is the only way to keep the fixed version. GHSA-6v7p-g79w-8964
+# (out-of-bounds read on Unpacker reuse) is HIGH and fixed in 1.2.1; it failed
+# every image scan. Floor, not a pin, so patches still flow.
+msgpack = ">=1.2.1"
 uvicorn = {extras = ["standard"], version = ">=0.42,<0.53"}
 pydantic = "^2.10.0"
 pydantic-settings = "^2.14.2"


### PR DESCRIPTION
Closes #1363.

Every image scan fails, both architectures, all four images:

```
setuptools  CVE-2025-47273  installed 70.3.0  fixed 78.1.1
setuptools: Path Traversal Vulnerability in setuptools
```

This currently blocks **every** open PR, including ones that touch no dependency at all — #1360 had to be admin-merged past it with all 59 of its own relevant checks green.

## Not a regression

setuptools comes from the `python:3.13-slim` base image; it is not in `.trivyignore`, not in `docs/cve-policy.md`, and no Dockerfile pinned it. `main` was green two days ago because the advisory was not matching then — Trivy scans today's data against the tree. That is the gate working, exactly as `AGENTS.md` describes for rebuilds.

## Why the builder stage

The runtime stage copies the builder's `site-packages` **wholesale**:

```dockerfile
COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
```

so upgrading in the runtime stage would be silently overwritten by that copy. All four images share this shape, so the fix goes in each builder and is identical across them.

A **floor** (`>=78.1.1`) rather than a pin, so the next base-image bump cannot quietly re-introduce it. Preferred over an ignore entry because a fix exists — the standing rule for the accepted-risk register.

## Verification

Built the image and inspected it rather than reasoning about the layering:

```
$ docker run --rm --entrypoint python3 <migrations image> -c "import setuptools; print(setuptools.__version__)"
84.0.0
```

The image scans in this PR's own CI are the real check — they run with the fix applied.