### PR TITLE
chore(1367): mirror third-party images daily, not weekly

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -10,9 +10,24 @@ name: Mirror third-party images
 
 on:
   schedule:
-    # Weekly. The tags are pinned, so this is about the mirror still existing
+    # Daily. The tags are pinned, so this is about the mirror still existing
     # and picking up rebuilt-in-place tags, not about chasing new versions.
-    - cron: "17 4 * * 1"
+    #
+    # Daily rather than weekly because that second purpose is a security path
+    # (#1367). `python:3.13-slim` is rebuilt in place with refreshed contents,
+    # and our copy only moves when this runs — so anything embedded in the base
+    # that apt does not manage rides this schedule. pip is the case in point:
+    # `pip/_vendor` pins its own msgpack/setuptools, and `apt-get upgrade` will
+    # never move them, so on a weekly sync that class of finding could sit for
+    # a week after upstream had already fixed it. Debian packages are already
+    # covered daily by the CI-dated PKG_REFRESH (#1178); this closes the gap
+    # for everything else.
+    #
+    # It costs nothing to run more often: this is a copy by digest, so on a day
+    # when upstream has not republished, the mirror is unchanged and every
+    # build keeps its layer cache. The cache is invalidated by a real content
+    # change, never by the clock.
+    - cron: "17 4 * * *"
   workflow_dispatch:
   pull_request:
     # Validate the list itself when it changes — a typo here would otherwise


### PR DESCRIPTION
Closes #1367.

The mirror workflow has two purposes, per its own comment: that the images still exist, and **picking up rebuilt-in-place tags**. The second is a security path, and weekly was too slow for it.

`python:3.13-slim` is rebuilt in place with refreshed contents, and our copy of it only moves when this workflow runs. So anything embedded in the base image that apt does not manage rides this schedule. `pip` is the case in point: `pip/_vendor` pins its own `msgpack` and `setuptools`, and `apt-get upgrade` will never move them — so a finding in that class could sit for a week after upstream had already fixed it.

Debian packages were never the gap; they are refreshed daily by the CI-dated `PKG_REFRESH` (#1178). This closes it for everything else.

## No cache cost

Worth being explicit, since "refresh more often" usually trades against caching. It doesn't here: this is a **copy by digest** (`imagetools create` republishing the source manifest), so on any day upstream has not republished, the mirrored digest is unchanged and every build keeps its layer cache. The cache is invalidated by a real content change, never by the clock. Running it daily just shortens how long we sit on a stale digest when upstream *has* moved.

## Context

This came out of #1366 / v1.4.2. Two corrections worth recording, because my first read of it was wrong:

- I originally claimed `PKG_REFRESH` was bumped by hand and had gone stale, freezing Debian security updates. It hasn't been manual since #1178 — CI dates it daily, and that was already in place when v1.4.1 was built. The v1.4.1 Debian findings were simply fixed upstream *after* that release was cut, which is the normal shape of an ageing release.
- The actual gap is narrower and is what this PR addresses: base-embedded tooling, refreshed only by this weekly sync.

No change to what is mirrored, only how often.