### PR TITLE
fix(1372): stop a stale status rewinding a failed plan's PR comment

### DIFF
--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -1529,13 +1529,34 @@ async def _summarise_one(payload: dict, _slack: dict) -> None:
         try:
             from terrapod.services.scheduler import enqueue_trigger
 
+            # Re-read the status rather than trusting `run`. That row was
+            # loaded BEFORE the model call, which takes tens of seconds — long
+            # enough for the run to have reached a terminal state since, and
+            # the session is already closed so the object cannot have been
+            # refreshed. Sending the snapshot rewrote the comment with the
+            # status the run had when the summary STARTED: a failed plan ended
+            # up reading "Plan in progress" directly above the failure analysis
+            # explaining why it failed (#1372).
+            status, changed = run.status, run.has_changes
+            try:
+                async with get_db_session() as fresh:
+                    row = (
+                        await fresh.execute(
+                            select(Run.status, Run.has_changes).where(Run.id == run_id)
+                        )
+                    ).first()
+                    if row is not None:
+                        status, changed = row
+            except Exception as e:  # pragma: no cover - best effort refresh
+                logger.debug("Could not refresh run status for comment", error=str(e))
+
             await enqueue_trigger(
                 "vcs_commit_status",
                 {
                     "run_id": str(run_id),
                     "workspace_id": str(ws.id),
-                    "target_status": run.status,
-                    "has_changes": run.has_changes,
+                    "target_status": status,
+                    "has_changes": changed,
                 },
                 dedup_key=f"vcs_status:aisum:{run_id}",
                 dedup_ttl=60,

--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -70,6 +70,11 @@ _STATUS_MAP: dict[str, tuple[str, str, str]] = {
     "canceled": ("error", "canceled", "Run canceled"),
 }
 
+# Terminal run states. A run cannot leave one, so a live status in this set is
+# strictly newer than any non-terminal status a trigger payload carries — which
+# is what lets a late writer be corrected rather than trusted (#1372).
+_TERMINAL_STATUSES = frozenset({"applied", "errored", "discarded", "canceled"})
+
 # Status → emoji for PR comments
 _STATUS_EMOJI: dict[str, str] = {
     "pending": ":hourglass:",
@@ -381,6 +386,27 @@ async def handle_vcs_commit_status(payload: dict) -> None:
             if payload_has_changes is not _UNSET
             else run.has_changes
         )
+        # The payload's status is normally authoritative: it is snapshotted at
+        # the transition so the dispatcher does not depend on the DB commit
+        # having landed yet. The exception is a payload that has gone STALE —
+        # a writer that enqueued before a long side task (the AI summary) and
+        # fired after the run finished. Since a terminal state cannot be left,
+        # a terminal live status is strictly newer, so prefer it. Without this
+        # a failed plan's comment read "Plan in progress" above its own failure
+        # analysis (#1372). The comment is a shared, last-write-wins surface,
+        # which is why it needs the same kind of guard as the superseded-run
+        # check further down.
+        if run.status in _TERMINAL_STATUSES and target_status not in _TERMINAL_STATUSES:
+            logger.info(
+                "Preferring terminal run status over stale trigger payload",
+                run_id=run_id_str,
+                payload_status=target_status,
+                live_status=run.status,
+            )
+            target_status = run.status
+            if payload_has_changes is _UNSET:
+                has_changes = run.has_changes
+
         github_state, gitlab_state, description = _resolve_status(
             target_status, run.plan_only, has_changes
         )

--- a/services/tests/services/test_vcs_status_dispatcher.py
+++ b/services/tests/services/test_vcs_status_dispatcher.py
@@ -484,3 +484,128 @@ class TestFindOrCreateCommentRaceFix:
         )
         # And the update targeted the freshly-created comment, not a phantom one.
         assert update_calls[0] == create_calls[0]
+
+
+class TestStaleStatusDoesNotClobberTheComment:
+    """A late writer must not rewind the comment to a status the run has left.
+
+    The PR comment is shared per (workspace, PR) and written last-wins. The AI
+    summariser re-enqueues this trigger once its summary is ready — but it
+    snapshots the run BEFORE a model call that takes tens of seconds, so on a
+    failed plan it arrived carrying `planning` after the run had already
+    errored. The comment then read "Plan in progress" directly above the
+    failure analysis explaining why the plan failed (#1372).
+    """
+
+    def _session(self, run, ws, conn, latest_run_id):
+        session = MagicMock()
+        session.get = AsyncMock()
+        # Two different queries run here: the latest-run-for-this-PR lookup and
+        # the ready-PlanSummary lookup. Returning one value for both handed the
+        # comment builder a UUID where it expected a summary.
+        latest = MagicMock()
+        latest.scalar_one_or_none = MagicMock(return_value=latest_run_id)
+        no_summary = MagicMock()
+        no_summary.scalar_one_or_none = MagicMock(return_value=None)
+        session.execute = AsyncMock(side_effect=[latest, no_summary])
+
+        async def _get(model, _id):
+            from terrapod.db.models import Run, VCSConnection, Workspace
+
+            return {Run: run, Workspace: ws, VCSConnection: conn}.get(model)
+
+        session.get.side_effect = _get
+        return session
+
+    async def _dispatch(self, *, live_status: str, payload_status: str) -> str:
+        """Run the handler and return the comment body it wrote."""
+        from terrapod.services.vcs_status_dispatcher import handle_vcs_commit_status
+
+        run_id, ws_id, conn_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+        run = MagicMock()
+        run.id = run_id
+        run.workspace_id = ws_id
+        run.vcs_commit_sha = "cafebabecafebabecafebabecafebabecafebabe"
+        run.vcs_pull_request_number = 97
+        run.plan_only = True
+        run.has_changes = None
+        run.status = live_status
+
+        ws = MagicMock()
+        ws.id = ws_id
+        ws.name = "core-prod"
+        ws.vcs_connection_id = conn_id
+        ws.vcs_repo_url = "https://github.com/example-org/infra"
+
+        conn = MagicMock()
+        conn.provider = "github"
+        conn.status = "active"
+
+        session = self._session(run, ws, conn, latest_run_id=run_id)
+
+        class _Ctx:
+            async def __aenter__(self):
+                return session
+
+            async def __aexit__(self, *a):
+                return False
+
+        with (
+            patch("terrapod.services.vcs_status_dispatcher.get_db_session", lambda: _Ctx()),
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.parse_repo_url",
+                return_value=("example-org", "infra"),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.create_commit_status",
+                new=AsyncMock(),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.create_pr_comment",
+                new=AsyncMock(),
+            ) as mock_create,
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.update_pr_comment",
+                new=AsyncMock(),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher._find_or_create_comment",
+                new=AsyncMock(),
+            ) as mock_comment,
+        ):
+            await handle_vcs_commit_status(
+                {
+                    "run_id": str(run_id),
+                    "workspace_id": str(ws_id),
+                    "target_status": payload_status,
+                    "has_changes": None,
+                }
+            )
+
+        assert mock_comment.await_count == 1, "expected exactly one comment write"
+        _ = mock_create
+        return mock_comment.await_args.args[5]
+
+    @pytest.mark.asyncio
+    async def test_terminal_live_status_wins_over_a_stale_payload(self):
+        """The reported bug: errored run, payload still says planning."""
+        body = await self._dispatch(live_status="errored", payload_status="planning")
+        assert "Run failed" in body
+        assert "Plan in progress" not in body
+
+    @pytest.mark.asyncio
+    async def test_a_non_terminal_payload_is_still_used_when_the_run_agrees(self):
+        """The payload stays authoritative in the normal case — it exists so the
+        dispatcher does not depend on the transition's DB commit having landed."""
+        body = await self._dispatch(live_status="planning", payload_status="planning")
+        assert "Plan in progress" in body
+
+    @pytest.mark.asyncio
+    async def test_a_terminal_payload_is_never_overridden(self):
+        """A run that has genuinely reached `planned` after the payload was
+        written must not be rewritten by this guard — only NON-terminal payloads
+        are suspect."""
+        body = await self._dispatch(live_status="applied", payload_status="errored")
+        assert "Run failed" in body
+        assert "Apply complete" not in body


### PR DESCRIPTION
Closes #1372.

A failed speculative plan's PR comment kept reading:

```
**Status:** :gear: Plan in progress
```

…directly above the rendered **Failure analysis** explaining why the plan had failed. The run was `errored` and the commit status was correct — only the comment was wrong, and wrong in the most confusing way available: reporting the run as still going while displaying the analysis of its failure.

## Cause

A race, resolved the wrong way round.

1. The plan fails; `ai_plan_summary` is enqueued while the run is still `planning`.
2. `_summarise_one` loads the `Run`, then calls the model — tens of seconds.
3. Meanwhile `transition_run(errored)` fires and the dispatcher correctly writes **Run failed**.
4. The summariser finishes and re-enqueues the status trigger so the comment picks up the summary — passing `run.status` from the row loaded in step 2, which still says `planning`. The DB session closed long before (the re-enqueue sits under `# Out-of-transaction side effects`), so the object cannot have seen the transition.
5. The dispatcher renders from that stale payload and clobbers the correct comment.

Observed on a real PR: plan finished `07:58:08`, comment rewritten `07:58:30`, run `errored`.

## Fix

**At source** — re-read `status` and `has_changes` immediately before the re-enqueue, instead of trusting a snapshot taken before a long model call.

**And guarded in the dispatcher**, because the comment is a shared, last-write-wins surface and this is the *second* way it has been clobbered — the first being a superseded run, handled a few lines further down. The payload stays authoritative in general (it exists precisely so the dispatcher does not depend on the transition's DB commit having landed), with one narrow exception: **a terminal live status beats a non-terminal payload**, since a run cannot leave a terminal state, so the live value is strictly newer. A terminal payload is never overridden.

## Tests

Three, covering the rule rather than just the bug:

- the reported case — live `errored`, payload `planning` → **Run failed**, and *not* "Plan in progress";
- the normal case — payload `planning`, run agrees → payload still used, so the commit-timing independence the payload exists for is preserved;
- a terminal payload is never overridden by a different terminal live status.

The first **fails without the guard** (verified by reverting it: the handler posts `status=planning` for an errored run) and passes with it.

`make test`: 4466 passed.

## Worth noting

`module_impact_service._post_module_vcs_status` builds its comment without passing `ai_summary` at all, so comments written by that path never carry the analysis. Not a bug being fixed here — it is what identified `vcs_status_dispatcher` as the writer responsible — but the two paths do render different bodies.