### PR TITLE
fix(1374): only take the "Latest release" badge when the tag is newest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2559,10 +2559,32 @@ jobs:
           version="${{ needs.prepare.outputs.version }}"
           chart_version="${version#v}"
 
+          # Is this the newest version we have released? GitHub picks "latest"
+          # by PUBLISH TIME, not by version — so a security patch cut for an
+          # older line silently takes the badge from a newer minor, pointing
+          # the repo front page and everything reading /releases/latest at an
+          # older release. That happened with v1.4.2 over v1.5.0 (#1374).
+          #
+          # Compare versions, not branch names: a patch on the NEWEST line
+          # (v1.5.1 over v1.5.0) should take the badge.
+          highest=$(
+            {
+              gh release list --limit 100 --json tagName --jq '.[].tagName'
+              echo "$version"
+            } | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+          )
+          if [ "$highest" = "$version" ]; then
+            latest=true
+          else
+            latest=false
+            echo "::notice::$version is not the newest release ($highest is) — not taking the 'Latest' badge"
+          fi
+
           # GoReleaser already created the release with provider binaries.
           # Update title/notes and upload remaining assets.
           gh release edit "$version" \
             --title "$version" \
+            --latest="$latest" \
             --notes-file /tmp/release-notes.md
 
           gh release upload "$version" \


### PR DESCRIPTION
Closes #1374.

GitHub picks "latest" by **publish time, not version**. So cutting **v1.4.2** — a security patch for the previous minor — took the badge from **v1.5.0**:

```
GET /releases/latest  ->  v1.4.2
```

The repo front page, the releases page badge, and everything consuming `/releases/latest` (install snippets, dashboards, an AI assistant asked "what's the current version") pointed at an older minor. It is silent — the patch pipeline was green and nothing looked wrong.

Corrected by hand at the time; this stops it recurring. Patching an older line is documented in `AGENTS.md` and actively prompted by the scheduled re-scan, so it was certain to happen again.

## Change

The finalize step computes the flag instead of inheriting GitHub's default, and passes `--latest=true|false` explicitly.

It compares **versions, not branch names**, which is the part that matters: a patch on the *newest* line should still take the badge. Verified against the live release list:

| Tag | Verdict |
|---|---|
| `v1.5.1` | latest = **true** |
| `v1.6.0` | latest = **true** |
| `v1.4.3` | latest = false (newest is v1.5.0) |
| `v1.3.4` | latest = false (newest is v1.5.0) |

When it declines the badge it emits a `::notice::` naming the newer release, so the decision shows up in the run rather than being invisible.