### PR TITLE
fix(1378): snapshot the plan result for module-PR comments

### DIFF
--- a/services/terrapod/services/module_impact_service.py
+++ b/services/terrapod/services/module_impact_service.py
@@ -36,6 +36,10 @@ from terrapod.storage.keys import config_version_key, module_override_key
 
 logger = get_logger(__name__)
 
+# Distinguishes "the payload did not carry this field" (an older replica's
+# trigger, mid-upgrade) from a genuine None. See _post_module_vcs_status.
+_UNSET = object()
+
 
 # ---------------------------------------------------------------------------
 # VCS dispatch helpers (shared with registry_vcs_poller / vcs_poller)
@@ -479,6 +483,11 @@ async def handle_module_test_completed(payload: dict) -> None:
     """Post VCS commit status to the module's repo when a module-test run finishes."""
     run_id_str = payload.get("run_id", "")
     target_status = payload.get("target_status", "")
+    # `_UNSET` rather than None: None is a meaningful value here ("the plan did
+    # not record it"), so it has to be distinguishable from "the payload predates
+    # this field", which is the case for a trigger enqueued by an older replica
+    # mid-upgrade.
+    payload_has_changes = payload.get("has_changes", _UNSET)
 
     if not run_id_str or not target_status:
         return
@@ -496,7 +505,9 @@ async def handle_module_test_completed(payload: dict) -> None:
         if module is None:
             return
 
-        await _post_module_vcs_status(db, run, module, target_status)
+        await _post_module_vcs_status(
+            db, run, module, target_status, payload_has_changes=payload_has_changes
+        )
 
 
 async def _resolve_module_from_overrides(
@@ -548,8 +559,16 @@ async def _post_module_vcs_status(
     run: Run,
     module: RegistryModule,
     target_status: str,
+    payload_has_changes: object = _UNSET,
 ) -> None:
-    """Post commit status and PR comment to the module's VCS repo."""
+    """Post commit status and PR comment to the module's VCS repo.
+
+    `payload_has_changes` is the value snapshotted at the transition. Prefer it
+    over the row: this handler can run before the transaction that set the
+    status has committed, and reading the row then yields the PREVIOUS value —
+    which rendered a completed plan as "Plan finished" rather than "No changes"
+    (#1378). Falls back to the row when the payload predates the field.
+    """
     from terrapod.config import settings
     from terrapod.services.vcs_status_dispatcher import (
         _build_comment_body,
@@ -583,7 +602,14 @@ async def _post_module_vcs_status(
         )
 
     # Post commit status
-    github_state, gitlab_state, description = _resolve_status(target_status, run.plan_only)
+    has_changes = (
+        payload_has_changes  # type: ignore[assignment]
+        if payload_has_changes is not _UNSET
+        else run.has_changes
+    )
+    github_state, gitlab_state, description = _resolve_status(
+        target_status, run.plan_only, has_changes
+    )
     context = f"terrapod/{ws_name}"
 
     try:
@@ -620,7 +646,7 @@ async def _post_module_vcs_status(
             run_id=f"run-{run.id}",
             run_status=target_status,
             plan_only=run.plan_only,
-            has_changes=run.has_changes,
+            has_changes=has_changes,
             run_url=run_url,
         )
         await _find_or_create_comment(

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -261,6 +261,13 @@ async def _enqueue_module_test_status(run: Run, target_status: str) -> None:
             {
                 "run_id": str(run.id),
                 "target_status": target_status,
+                # Snapshotted for the same reason as _enqueue_vcs_status: this
+                # enqueue is inside the transaction that sets the status, so a
+                # consumer on another replica can re-read the row BEFORE the
+                # commit lands and see has_changes still unset. That rendered
+                # "Plan finished" instead of "No changes" on module PRs, with
+                # sibling workspaces disagreeing about identical runs (#1378).
+                "has_changes": run.has_changes,
             },
             dedup_key=f"modtest:{run.id}:{target_status}",
             dedup_ttl=60,

--- a/services/tests/services/test_module_impact_service.py
+++ b/services/tests/services/test_module_impact_service.py
@@ -61,3 +61,71 @@ async def test_fetch_config_non_vcs_with_no_cv_returns_none() -> None:
         result = await module_impact_service._fetch_workspace_config(db, ws, MagicMock())
 
     assert result is None
+
+
+class TestModuleCommentUsesTheSnapshottedResult:
+    """A module PR's comment must not render a plan result that has not landed.
+
+    Two speculative runs on the same module PR, both `planned` with
+    has_changes=False, rendered differently: one "No changes", the other
+    "Plan finished" — which is what `_resolve_status` produces when has_changes
+    is None. The enqueue happens inside the transaction that sets the status,
+    so a consumer on another replica can re-read the row before the commit
+    lands and see the PREVIOUS value. Which run loses the race is timing, which
+    is why it looked arbitrary (#1378).
+
+    The ordinary VCS path already snapshots the value into the payload for
+    exactly this reason; this path did not.
+    """
+
+    def _payload_from_enqueue(self, run, target_status):
+        """Capture what _enqueue_module_test_status puts on the queue."""
+        import asyncio
+
+        from terrapod.services import run_service
+
+        captured = {}
+
+        async def _fake_enqueue(name, payload, **kw):
+            captured.update(payload)
+            return True
+
+        with patch("terrapod.services.scheduler.enqueue_trigger", new=_fake_enqueue):
+            asyncio.run(run_service._enqueue_module_test_status(run, target_status))
+        return captured
+
+    def test_has_changes_is_snapshotted_onto_the_trigger(self):
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.has_changes = False
+
+        payload = self._payload_from_enqueue(run, "planned")
+
+        assert "has_changes" in payload, (
+            "without the snapshot the handler re-reads the row and can race the commit"
+        )
+        assert payload["has_changes"] is False
+
+    def test_a_snapshotted_false_renders_no_changes_even_if_the_row_lags(self):
+        """The bug, at the point where it showed: the row still says None
+        (uncommitted) but the payload carries the real answer."""
+        from terrapod.services.vcs_status_dispatcher import _resolve_status
+
+        stale_row_value = None
+        snapshotted = False
+
+        _, _, stale = _resolve_status("planned", True, stale_row_value)
+        _, _, fixed = _resolve_status("planned", True, snapshotted)
+
+        assert stale == "Plan finished"
+        assert fixed == "No changes"
+
+    def test_the_sentinel_keeps_a_genuine_none_distinguishable(self):
+        """None means 'the plan did not record it' and must survive; only an
+        ABSENT field falls back to the row. An older replica's trigger, raised
+        mid-upgrade, carries no field at all."""
+        from terrapod.services.module_impact_service import _UNSET
+
+        assert _UNSET is not None
+        assert {"has_changes": None}.get("has_changes", _UNSET) is None
+        assert {}.get("has_changes", _UNSET) is _UNSET


### PR DESCRIPTION
Closes #1378.

Two speculative runs on the same module PR, **both `planned` with `has_changes=false`**, rendered differently:

```
core-dev-eu1       comment: "No changes"      <- correct
core-mai-dev-us1   comment: "Plan finished"   <- stale
```

"Plan finished" is what `_resolve_status` produces when `has_changes` is **None**, so that comment was written from a row whose value had not landed. Which of the two lost the race is timing — which is why it looked arbitrary.

## Cause

The ordinary VCS path snapshots `has_changes` into the trigger payload, with a comment saying exactly why: the enqueue sits **inside the transaction that sets the status**, so a consumer on another replica can re-read the row before the commit lands and see the previous value.

`_enqueue_module_test_status` sent only `run_id` and `target_status`, and the handler then re-read the run — straight into that race.

## Change

Snapshot it and prefer it, mirroring `_enqueue_vcs_status`. The commit status is resolved from the same value, so the two surfaces can no longer disagree.

The sentinel is deliberate: `None` is a **real** value here ("the plan did not record it") and has to stay distinguishable from a payload that predates the field — which is what an older replica raises during a rolling upgrade. `_UNSET` falls back to the row; an explicit `None` does not.

## Severity

Cosmetic, unlike #1373 — "Plan finished" still reports success, and the commit status was already correct. But it is the same defect, and identical runs disagreeing on one PR undermines trust in the comment.

## Tests

Three, and the first **fails without the fix** (verified by reverting `run_service`):

- `has_changes` is snapshotted onto the trigger — without it the handler re-reads and can race the commit;
- a snapshotted `False` renders "No changes" where a lagging row renders "Plan finished" — the bug at the point it showed;
- the sentinel keeps a genuine `None` distinguishable from an absent field, so a mid-upgrade payload still falls back to the row.

`make test`: 4469 passed.