### PR TITLE
fix(1382): add .dockerignore so a stale local node_modules cannot overwrite npm ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Keep developer state out of the build context.
+#
+# Every Dockerfile installs its own dependencies — Dockerfile.web runs `npm ci`
+# from package-lock.json before it copies the source. Without this file the
+# subsequent `COPY web/ .` overwrites that clean install with whatever is on
+# the developer's disk, so a stale local node_modules silently wins. That
+# happened: a machine still holding next 16.2.12 produced an image whose
+# next and @next/swc disagreed, and the production build failed with an
+# unrelated-looking error. CI never saw it because CI checks out clean.
+#
+# It is also just large: node_modules, .next and .git together are ~800 MB of
+# context uploaded on every build for no reason.
+**/node_modules
+**/.next
+.git
+.github
+
+# Python build/test droppings
+**/__pycache__
+**/*.pyc
+.pytest_cache
+.ruff_cache
+**/.venv
+
+# Local-only output
+reports/
+dist/
+*.tfstate
+*.tfstate.backup


### PR DESCRIPTION
## What happens

Any local image build of the web tier can fail with an error that has nothing to
do with the change being built:

```
⚠ Mismatching @next/swc version, detected: 16.3.0 while Next.js is on 16.2.12
▲ Next.js 16.2.12 (Turbopack)
> Build error occurred
Error: Missing field `turbopackMemoryEviction`
```

The versions in the message do not exist together in `package-lock.json` — the
lockfile pins one version of both.

## Why

The repository has no `.dockerignore`, so the whole working tree is sent as
build context. `Dockerfile.web` then does:

```dockerfile
COPY web/package.json web/package-lock.json* ./
RUN npm ci          # installs the lockfile's versions — correct
COPY web/ .         # ...and overwrites node_modules with the host's copy
```

The third line replaces the clean install with whatever the developer happens to
have on disk. A machine holding an older `next` produces an image whose `next`
and `@next/swc` disagree, and the build fails on an unrelated-looking error.

CI never sees it, because CI checks out clean.

It also sends ~800 MB of pointless context (`node_modules`, `.next`, `.git`) on
every build.

## Fix

Add a `.dockerignore` excluding `node_modules`, `.next`, `.git` and the usual
local droppings. Every Dockerfile already installs its own dependencies, so
nothing needs them in the context.

---

Found while building the web image for another change: the build failed on an error naming a Next.js internal field, with versions in the message that do not co-exist in the lockfile.

Closes #1382