### PR TITLE
fix(1396): a triggered run fetches its code, and speculative config versions can never be applied

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -355,106 +355,23 @@ async def _require_run_ws_capability(
 async def _fetch_vcs_config(
     db: AsyncSession, ws: Workspace, *, ref_override: str = ""
 ) -> tuple[uuid.UUID, str, str]:
-    """Download code from VCS and create a ConfigurationVersion.
+    """HTTP wrapper over `vcs_config_service.fetch_config_version`.
 
-    Used when the UI queues a run on a VCS-connected workspace without
-    uploading code (no CLI config version). Replicates the same flow
-    the VCS poller uses: resolve branch → get HEAD SHA → download
-    tarball → create CV → upload → mark uploaded.
-
-    When ref_override is set, fetches code from that branch/tag/SHA instead
-    of the workspace's tracked branch.
-
-    Returns (cv_id, commit_sha, ref_name).
+    The fetch itself moved to a service (#1396) so the run-trigger path could
+    share it; this keeps the HTTP mapping where it belongs. A workspace we
+    cannot fetch for is a 422; a provider outage is somebody else's 5xx, not
+    ours, and gets 502/504 with the marker header (#1358).
     """
-    from terrapod.services.vcs_archive_cache import VCSArchiveCache
-    from terrapod.services.vcs_poller import (
-        _get_branch_sha,
-        _list_tags,
-        _parse_repo_url,
-        _resolve_branch,
-        _stream_cv_upload_from_cache,
-    )
+    from terrapod.services import vcs_config_service
 
     conn = await db.get(VCSConnection, ws.vcs_connection_id)
-    if not conn or conn.status != "active":
-        raise HTTPException(status_code=422, detail="VCS connection is not active")
-
-    parsed = _parse_repo_url(conn, ws.vcs_repo_url)
-    if not parsed:
-        raise HTTPException(status_code=422, detail="Cannot parse VCS repo URL")
-    owner, repo = parsed
-
-    if ref_override:
-        # Try as branch first, then tag, then treat as raw SHA
-        sha = await _get_branch_sha(conn, owner, repo, ref_override, meta=None)
-        ref_name = ref_override
-        if not sha:
-            tags = await _list_tags(conn, owner, repo)
-            tag_match = next((t for t in tags if t["name"] == ref_override), None)
-            if tag_match:
-                sha = tag_match["sha"]
-            else:
-                # Treat as raw SHA — providers accept any git ref
-                sha = ref_override
-    else:
-        # The provider is reached here, so a provider outage lands here too.
-        # These calls RAISE on an error status rather than returning None, so
-        # the `if not sha` guard below never sees one — before this was caught,
-        # a GitHub incident returning 403 propagated to the catch-all handler
-        # and the operator got a bare 500 for someone else's outage.
-        try:
-            ref_name = await _resolve_branch(conn, ws, owner, repo) or ""
-            if not ref_name:
-                raise HTTPException(status_code=422, detail="Cannot determine VCS branch")
-            sha = await _get_branch_sha(conn, owner, repo, ref_name, meta=None)
-        except httpx.HTTPError as e:
-            raise vcs_unavailable(conn, f"{owner}/{repo}", ref_name or ws.vcs_branch, e) from e
-        if not sha:
-            raise HTTPException(status_code=422, detail="Cannot get branch HEAD SHA")
-
-    # Streaming + storage cache: tarball never lands in process memory, and
-    # subsequent UI fetches at the same SHA hit the cache (storage `head()`)
-    # instead of re-downloading from the provider. Single-shot cache instance
-    # is fine here — the in-process single-flight only matters when multiple
-    # workspaces poll the same SHA concurrently.
-    #
-    # Path narrowing: pass this workspace's own `working_directory ∪
-    # trigger_prefixes`. Cross-workspace coalescing isn't useful here
-    # (one request, one workspace), so we don't bother computing a wider
-    # union. If another caller fetched the same SHA with a different path
-    # set, that's a different cache entry — content-addressed by paths_hash.
-    #
-    # If the workspace's terraform crosses directory boundaries via relative
-    # module sources (`module "auth0" { source = "../auth0" }`), the operator
-    # MUST declare the referenced paths in `trigger_prefixes` — sparse-checkout
-    # cone mode includes parent directories but not siblings, so without an
-    # explicit prefix the runner would `lstat ../foo: no such file`. This
-    # contract is consistent with the VCS-poll path's `_compute_paths_unions`,
-    # so a workspace that works under VCS poll also works here. See #478 /
-    # #480 for the history (v0.35.3 briefly forced whole-repo here as a
-    # blanket fix; v0.35.4 reverted that and put the responsibility back on
-    # the workspace declaration).
-    fetch_paths: list[str] = []
-    if ws.working_directory:
-        fetch_paths.append(ws.working_directory.strip("/ "))
-    if ws.trigger_prefixes:
-        fetch_paths.extend(p.strip("/ ") for p in ws.trigger_prefixes if p)
-    fetch_paths = [p for p in fetch_paths if p]
-
-    cache = VCSArchiveCache()
-    cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha, paths=fetch_paths or None)
-
-    cv = await run_service.create_configuration_version(
-        db, workspace_id=ws.id, source="vcs", auto_queue_runs=False
-    )
-    await db.flush()
-
-    await _stream_cv_upload_from_cache(cache_storage_key, ws.id, cv.id)
-
-    cv = await run_service.mark_configuration_uploaded(db, cv)
-
-    return cv.id, sha, ref_name
+    try:
+        return await vcs_config_service.fetch_config_version(db, ws, ref_override=ref_override)
+    except vcs_config_service.VCSConfigError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    except httpx.HTTPError as e:
+        repo = ws.vcs_repo_url or ""
+        raise vcs_unavailable(conn, repo, ref_override or ws.vcs_branch, e) from e
 
 
 @router.post("/runs", status_code=201)

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -651,6 +651,32 @@ async def create_run(
     when a configuration version is uploaded (or immediately if none needed).
     """
     await ha_role.ensure_leader("create runs")
+
+    # A run against a SPECULATIVE configuration version is always plan-only.
+    #
+    # A speculative CV is the artifact of a plan-only run — an unmerged pull
+    # request, or a `tofu plan` upload from the CLI. Its code has not been
+    # merged and may never be. Applying one would put unreviewed code into a
+    # real workspace, so this is not a preference: there is no combination of
+    # arguments that produces an apply-capable run against one.
+    #
+    # This lives HERE, in the service, because that is the one place every
+    # caller passes through. It was previously enforced only in the HTTP
+    # endpoint (#661), which left every internal caller — run triggers, the VCS
+    # poller, drift detection, module impact, autodiscovery — able to create an
+    # apply-capable run against a speculative CV by passing plan_only=False.
+    # `fire_run_triggers` did exactly that (#1396).
+    if configuration_version_id is not None and not plan_only:
+        spec_cv = await db.get(ConfigurationVersion, configuration_version_id)
+        if spec_cv is not None and spec_cv.speculative:
+            logger.warning(
+                "Forcing plan-only: run points at a speculative configuration version",
+                workspace=workspace.name,
+                configuration_version_id=str(configuration_version_id),
+                source=source,
+            )
+            plan_only = True
+
     # An explicit `auto_apply` argument (the CLI/API asking for a specific
     # behaviour on this one run) still means exactly what it says, so it maps
     # onto the flat modes. Only an unset argument inherits the workspace's
@@ -1284,8 +1310,6 @@ async def fire_run_triggers(
     """
     from sqlalchemy.orm import selectinload
 
-    from terrapod.db.models import ConfigurationVersion
-
     result = await db.execute(
         select(RunTrigger)
         .options(selectinload(RunTrigger.workspace))
@@ -1305,18 +1329,50 @@ async def fire_run_triggers(
         if dest_ws is None:
             continue
 
-        # Latest uploaded CV for the destination — required so the
-        # runner has code to plan against.
-        cv_result = await db.execute(
-            select(ConfigurationVersion.id)
-            .where(
-                ConfigurationVersion.workspace_id == dest_ws.id,
-                ConfigurationVersion.status == "uploaded",
-            )
-            .order_by(ConfigurationVersion.created_at.desc())
-            .limit(1)
-        )
-        latest_cv_id = cv_result.scalar_one_or_none()
+        # Where the destination's code comes from.
+        #
+        # VCS-connected: FETCH IT. A trigger means "the thing upstream of you
+        # changed, reconcile" — reconcile against the tracked branch, which is
+        # the workspace's declared desired state. This used to reuse whichever
+        # configuration version happened to be newest, which is not the same
+        # thing and was wrong in three separate ways: it could be days stale
+        # (a drift check uploads a CV daily, so on a quiet repo every one of
+        # the newest CVs is a drift artifact); it could be a drift CV, which
+        # the apply guard then refuses, leaving the trigger permanently unable
+        # to apply; and it could be a SPECULATIVE CV from an open pull request,
+        # whose source is "vcs" so the guard waved it straight through — an
+        # apply of unmerged code (#1396).
+        #
+        # If the fetch fails, the trigger fails. There is no fallback, because
+        # every available fallback is "apply some other code instead", and
+        # applying code nobody asked for is worse than not running.
+        #
+        # Non-VCS: the CLI is the only producer of code, so the last upload is
+        # the desired state. Via get_latest_uploaded_cv, which excludes
+        # speculative CVs — the open-coded query it replaces did not.
+        latest_cv_id = None
+        vcs_sha = ""
+        vcs_ref = ""
+        if dest_ws.vcs_connection_id is not None and dest_ws.vcs_repo_url:
+            try:
+                from terrapod.services import vcs_config_service
+
+                latest_cv_id, vcs_sha, vcs_ref = await vcs_config_service.fetch_config_version(
+                    db, dest_ws
+                )
+            except Exception as e:
+                logger.error(
+                    "Run trigger failed: could not fetch code from VCS",
+                    source_workspace=source_name,
+                    destination_workspace=dest_ws.name,
+                    repo=dest_ws.vcs_repo_url,
+                    error=str(e),
+                    exc_info=True,
+                )
+                continue
+        else:
+            cv = await get_latest_uploaded_cv(db, dest_ws.id)
+            latest_cv_id = cv.id if cv else None
 
         if latest_cv_id is None:
             logger.warning(
@@ -1340,6 +1396,13 @@ async def fire_run_triggers(
             source="run-trigger",
             configuration_version_id=latest_cv_id,
         )
+
+        # Record where the code came from. Beyond provenance in the UI, this is
+        # what marks the run as carrying VCS-fetched code, which the apply guard
+        # reads to exempt it — the same signal a poller-created run carries.
+        if vcs_sha:
+            run.vcs_commit_sha = vcs_sha
+            run.vcs_branch = vcs_ref
         await queue_run(db, run)
 
         logger.info(
@@ -1450,6 +1513,20 @@ async def confirm_run(db: AsyncSession, run: Run) -> Run:
     # reflects the current state, or has aged past the workspace TTL, must not be
     # applied. Auto-discard it (unlocking the workspace) and surface a 409 so the
     # caller re-plans. State drift is the always-on correctness guard.
+    # Second line of defence for the speculative invariant. `create_run` forces
+    # plan-only for a speculative CV, so a run reaching here with one should not
+    # exist — but "should not exist" is not a guarantee for rows already in the
+    # database, written before that guard, or by any future path that builds a
+    # Run without going through it. Applying unmerged pull-request code is bad
+    # enough to be worth checking twice (#1396).
+    if run.configuration_version_id is not None:
+        cv = await db.get(ConfigurationVersion, run.configuration_version_id)
+        if cv is not None and cv.speculative:
+            raise ValueError(
+                "this run's configuration version is speculative (a plan-only "
+                "artifact of an unmerged change) and cannot be applied"
+            )
+
     stale = await _staleness_reason(db, run, workspace)
     if stale is not None:
         await discard_run(db, run, reason=stale)

--- a/services/terrapod/services/vcs_config_service.py
+++ b/services/terrapod/services/vcs_config_service.py
@@ -1,0 +1,139 @@
+"""Fetching a workspace's code from its VCS connection.
+
+Extracted from the runs router (#1396) so the run-trigger path can use it too.
+It was a private helper there, which is why the trigger path grew its own,
+worse answer — reuse whichever configuration version happened to be newest —
+rather than sharing this one.
+"""
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.db.models import VCSConnection, Workspace
+from terrapod.logging_config import get_logger
+from terrapod.services import run_service
+
+logger = get_logger(__name__)
+
+
+class VCSConfigError(Exception):
+    """The workspace's code cannot be fetched — a property of the workspace or
+    its connection, not a transient provider failure."""
+
+
+async def fetch_config_version(
+    db: AsyncSession, ws: Workspace, *, ref_override: str = ""
+) -> tuple[uuid.UUID, str, str]:
+    """Download code from VCS and create a ConfigurationVersion.
+
+    The one place code is fetched for a run that did not bring its own.
+    Resolve branch -> get HEAD SHA -> download tarball -> create CV ->
+    upload -> mark uploaded, which is the flow the VCS poller uses.
+
+    Two callers, for the same reason — the workspace is VCS-connected, so
+    its code comes from VCS:
+
+      - a UI-queued run with no uploaded configuration version;
+      - a run trigger firing on a VCS-connected destination (#1396). That
+        one used to reuse whichever CV was newest, which could be a stale
+        drift artifact or an unmerged pull request.
+
+    Raises VCSConfigError for a workspace we cannot fetch for (inactive
+    connection, unparseable URL, no resolvable branch). Provider transport
+    failures propagate as httpx errors so callers can tell "your workspace is
+    misconfigured" from "GitHub is having a bad afternoon" — the API maps the
+    latter to 502/504 (#1358); the run-trigger path fails the trigger.
+
+    When ref_override is set, fetches code from that branch/tag/SHA instead
+    of the workspace's tracked branch.
+
+    Returns (cv_id, commit_sha, ref_name).
+    """
+    from terrapod.services.vcs_archive_cache import VCSArchiveCache
+    from terrapod.services.vcs_poller import (
+        _get_branch_sha,
+        _list_tags,
+        _parse_repo_url,
+        _resolve_branch,
+        _stream_cv_upload_from_cache,
+    )
+
+    conn = await db.get(VCSConnection, ws.vcs_connection_id)
+    if not conn or conn.status != "active":
+        raise VCSConfigError("VCS connection is not active")
+
+    parsed = _parse_repo_url(conn, ws.vcs_repo_url)
+    if not parsed:
+        raise VCSConfigError("Cannot parse VCS repo URL")
+    owner, repo = parsed
+
+    if ref_override:
+        # Try as branch first, then tag, then treat as raw SHA
+        sha = await _get_branch_sha(conn, owner, repo, ref_override, meta=None)
+        ref_name = ref_override
+        if not sha:
+            tags = await _list_tags(conn, owner, repo)
+            tag_match = next((t for t in tags if t["name"] == ref_override), None)
+            if tag_match:
+                sha = tag_match["sha"]
+            else:
+                # Treat as raw SHA — providers accept any git ref
+                sha = ref_override
+    else:
+        # The provider is reached here, so a provider outage lands here too.
+        # These calls RAISE on an error status rather than returning None, so
+        # the `if not sha` guard below never sees one. The httpx error is
+        # deliberately NOT caught here: the caller decides what a provider
+        # outage means. The API turns it into 502/504 rather than a bare 500
+        # (#1358); the run-trigger path fails the trigger rather than reaching
+        # for some other configuration version (#1396).
+        ref_name = await _resolve_branch(conn, ws, owner, repo) or ""
+        if not ref_name:
+            raise VCSConfigError("Cannot determine VCS branch")
+        sha = await _get_branch_sha(conn, owner, repo, ref_name, meta=None)
+        if not sha:
+            raise VCSConfigError("Cannot get branch HEAD SHA")
+
+    # Streaming + storage cache: tarball never lands in process memory, and
+    # subsequent UI fetches at the same SHA hit the cache (storage `head()`)
+    # instead of re-downloading from the provider. Single-shot cache instance
+    # is fine here — the in-process single-flight only matters when multiple
+    # workspaces poll the same SHA concurrently.
+    #
+    # Path narrowing: pass this workspace's own `working_directory ∪
+    # trigger_prefixes`. Cross-workspace coalescing isn't useful here
+    # (one request, one workspace), so we don't bother computing a wider
+    # union. If another caller fetched the same SHA with a different path
+    # set, that's a different cache entry — content-addressed by paths_hash.
+    #
+    # If the workspace's terraform crosses directory boundaries via relative
+    # module sources (`module "auth0" { source = "../auth0" }`), the operator
+    # MUST declare the referenced paths in `trigger_prefixes` — sparse-checkout
+    # cone mode includes parent directories but not siblings, so without an
+    # explicit prefix the runner would `lstat ../foo: no such file`. This
+    # contract is consistent with the VCS-poll path's `_compute_paths_unions`,
+    # so a workspace that works under VCS poll also works here. See #478 /
+    # #480 for the history (v0.35.3 briefly forced whole-repo here as a
+    # blanket fix; v0.35.4 reverted that and put the responsibility back on
+    # the workspace declaration).
+    fetch_paths: list[str] = []
+    if ws.working_directory:
+        fetch_paths.append(ws.working_directory.strip("/ "))
+    if ws.trigger_prefixes:
+        fetch_paths.extend(p.strip("/ ") for p in ws.trigger_prefixes if p)
+    fetch_paths = [p for p in fetch_paths if p]
+
+    cache = VCSArchiveCache()
+    cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha, paths=fetch_paths or None)
+
+    cv = await run_service.create_configuration_version(
+        db, workspace_id=ws.id, source="vcs", auto_queue_runs=False
+    )
+    await db.flush()
+
+    await _stream_cv_upload_from_cache(cache_storage_key, ws.id, cv.id)
+
+    cv = await run_service.mark_configuration_uploaded(db, cv)
+
+    return cv.id, sha, ref_name

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -25,7 +25,7 @@ def _user(email="test@example.com", roles=None):
     )
 
 
-def _mock_workspace(ws_id=None, name="test-ws"):
+def _mock_workspace(ws_id=None, name="test-ws", *, vcs=False):
     ws = MagicMock()
     ws.id = ws_id or uuid.uuid4()
     ws.name = name
@@ -35,6 +35,14 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
+    # Set explicitly, and default to NOT VCS-connected. An unset MagicMock
+    # attribute is a MagicMock, which is truthy — so every workspace built here
+    # silently looked VCS-connected to any code that tested the field. That went
+    # unnoticed while nothing branched on it; the moment run triggers did
+    # (#1396), these tests took the VCS path by accident.
+    ws.vcs_connection_id = uuid.uuid4() if vcs else None
+    ws.vcs_repo_url = "https://github.com/example/repo" if vcs else ""
+    ws.vcs_branch = "main" if vcs else ""
     return ws
 
 
@@ -480,7 +488,12 @@ class TestFireRunTriggers:
     @patch("terrapod.services.run_service.queue_run")
     @patch("terrapod.services.run_service.create_run")
     async def test_fire_triggers_attaches_latest_cv(self, mock_create, mock_queue):
-        """#439: triggered runs must carry the destination's latest uploaded CV."""
+        """#439: triggered runs must carry the destination's latest uploaded CV.
+
+        Non-VCS destination — the CLI is the only producer of code there, so the
+        last upload is the desired state. A VCS-connected destination fetches
+        instead; see the tests below.
+        """
         from terrapod.services.run_service import fire_run_triggers
 
         source_ws_id = uuid.uuid4()
@@ -493,8 +506,12 @@ class TestFireRunTriggers:
 
         triggers_result = MagicMock()
         triggers_result.scalars.return_value.all.return_value = [trigger]
+        # get_latest_uploaded_cv returns the CV row, not its id — and it filters
+        # out speculative CVs, which the open-coded query it replaced did not.
+        latest_cv = MagicMock()
+        latest_cv.id = latest_cv_id
         cv_result = MagicMock()
-        cv_result.scalar_one_or_none.return_value = latest_cv_id
+        cv_result.scalar_one_or_none.return_value = latest_cv
 
         mock_db = AsyncMock()
         mock_db.execute.side_effect = [triggers_result, cv_result]
@@ -508,6 +525,79 @@ class TestFireRunTriggers:
         mock_create.assert_called_once()
         assert mock_create.call_args.kwargs["configuration_version_id"] == latest_cv_id
         mock_queue.assert_called_once_with(mock_db, downstream_run)
+
+    @patch("terrapod.services.run_service.queue_run")
+    @patch("terrapod.services.run_service.create_run")
+    async def test_a_vcs_destination_fetches_code_rather_than_reusing_a_cv(
+        self, mock_create, mock_queue
+    ):
+        """#1396. A trigger means "reconcile against your desired state", and for
+        a VCS-connected workspace that is the tracked branch — not whichever
+        configuration version happens to be newest.
+
+        Reusing the newest CV was wrong three ways: it could be days stale (a
+        drift check uploads one daily); it could be a drift CV, which the apply
+        guard then refuses outright; and it could be a SPECULATIVE CV from an
+        open pull request, whose source is "vcs" so the guard allowed it — an
+        apply of unmerged code.
+        """
+        from terrapod.services.run_service import fire_run_triggers
+
+        source_ws_id = uuid.uuid4()
+        dest_ws = _mock_workspace(name="downstream", vcs=True)
+        trigger = MagicMock()
+        trigger.workspace = dest_ws
+
+        triggers_result = MagicMock()
+        triggers_result.scalars.return_value.all.return_value = [trigger]
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = triggers_result
+        mock_db.get.return_value = _mock_workspace(ws_id=source_ws_id, name="upstream")
+
+        downstream_run = MagicMock()
+        mock_create.return_value = downstream_run
+
+        fetched_cv_id = uuid.uuid4()
+        with patch(
+            "terrapod.services.vcs_config_service.fetch_config_version",
+            new=AsyncMock(return_value=(fetched_cv_id, "abc1234", "main")),
+        ) as mock_fetch:
+            await fire_run_triggers(mock_db, source_ws_id)
+
+        mock_fetch.assert_awaited_once()
+        assert mock_create.call_args.kwargs["configuration_version_id"] == fetched_cv_id
+        # The sha is what marks the run as carrying VCS code — the same signal a
+        # poller-created run has, and what the apply guard reads.
+        assert downstream_run.vcs_commit_sha == "abc1234"
+        assert downstream_run.vcs_branch == "main"
+
+    @patch("terrapod.services.run_service.queue_run")
+    @patch("terrapod.services.run_service.create_run")
+    async def test_a_failed_fetch_fires_no_run_at_all(self, mock_create, mock_queue):
+        """#1396. No fallback. Every available fallback is "apply some other
+        code instead", and applying code nobody asked for is worse than not
+        running — so a provider outage means the trigger does not fire."""
+        from terrapod.services.run_service import fire_run_triggers
+
+        source_ws_id = uuid.uuid4()
+        dest_ws = _mock_workspace(name="downstream", vcs=True)
+        trigger = MagicMock()
+        trigger.workspace = dest_ws
+
+        triggers_result = MagicMock()
+        triggers_result.scalars.return_value.all.return_value = [trigger]
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = triggers_result
+        mock_db.get.return_value = _mock_workspace(ws_id=source_ws_id, name="upstream")
+
+        with patch(
+            "terrapod.services.vcs_config_service.fetch_config_version",
+            new=AsyncMock(side_effect=RuntimeError("github is having a bad afternoon")),
+        ):
+            await fire_run_triggers(mock_db, source_ws_id)
+
+        mock_create.assert_not_called()
+        mock_queue.assert_not_called()
 
     @patch("terrapod.services.run_service.queue_run")
     @patch("terrapod.services.run_service.create_run")

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -1517,3 +1517,95 @@ class TestRunTriggerRunsAreApplicable:
 
         resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
         assert resp.status_code == 200, resp.text
+
+
+class TestSpeculativeConfigVersionsAreNeverApplied:
+    """A speculative configuration version can never be applied. Not by any
+    caller, not by any combination of arguments (#1396).
+
+    A speculative CV is the artifact of a plan-only run — an unmerged pull
+    request, or a `tofu plan` upload. Applying one puts unreviewed code into a
+    real workspace.
+
+    The rule was enforced only in the HTTP endpoint (#661), so every internal
+    caller could opt out of it simply by passing `plan_only=False`.
+    `fire_run_triggers` did, because it selected the newest uploaded CV without
+    excluding speculative ones — and a speculative CV created by the VCS poller
+    for an open PR carries `source="vcs"`, which the apply guard waves through.
+    """
+
+    @staticmethod
+    async def _mark_cv_speculative(ws_id: str):
+        import uuid as _uuid
+
+        from sqlalchemy import select
+
+        from terrapod.db.models import ConfigurationVersion
+        from terrapod.db.session import get_db_session
+
+        async with get_db_session() as db:
+            result = await db.execute(
+                select(ConfigurationVersion)
+                .where(ConfigurationVersion.workspace_id == _uuid.UUID(ws_id.removeprefix("ws-")))
+                .order_by(ConfigurationVersion.created_at.desc())
+                .limit(1)
+            )
+            cv = result.scalar_one_or_none()
+            assert cv is not None
+            cv.speculative = True
+            await db.commit()
+            return cv.id
+
+    async def test_the_service_forces_plan_only_whatever_the_caller_asked_for(
+        self, app, client, setup
+    ):
+        """The chokepoint. Every internal caller goes through `create_run`, so
+        the invariant belongs there rather than in one HTTP handler."""
+        import uuid as _uuid
+
+        from terrapod.db.models import Workspace
+        from terrapod.db.session import get_db_session
+        from terrapod.services import run_service
+
+        pool_id, _ = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "spec-service")
+        cv_id = await self._mark_cv_speculative(ws_id)
+
+        async with get_db_session() as db:
+            ws = await db.get(Workspace, _uuid.UUID(ws_id.removeprefix("ws-")))
+            run = await run_service.create_run(
+                db,
+                workspace=ws,
+                message="asking for an apply against speculative code",
+                plan_only=False,  # explicitly asking for the thing that must not happen
+                configuration_version_id=cv_id,
+            )
+            await db.commit()
+            assert run.plan_only is True, (
+                "an apply-capable run was created against a speculative CV"
+            )
+
+    async def test_confirm_refuses_even_if_such_a_run_exists(self, app, client, setup):
+        """Second line of defence, for rows written before the guard above —
+        which is not hypothetical, since this shipped broken."""
+        import uuid as _uuid
+
+        from terrapod.db.models import Run
+        from terrapod.db.session import get_db_session
+
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "spec-confirm")
+
+        run = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+        # Make the CV speculative AFTER the run was created and planned, which
+        # reproduces the pre-fix row shape: plan_only False, speculative CV.
+        await self._mark_cv_speculative(ws_id)
+        async with get_db_session() as db:
+            r = await db.get(Run, _uuid.UUID(run["id"].removeprefix("run-")))
+            r.plan_only = False
+            await db.commit()
+
+        resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 409, resp.text
+        assert "speculative" in resp.text.lower()

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -126,6 +126,11 @@ def _mock_run(**kwargs):
     # MagicMock here silently defeats the pool-set resolution.
     run.pool_id = kwargs.get("pool_id", None)
     run.pool_extra_ids = kwargs.get("pool_extra_ids", [])
+    # Explicit, and None by default, for the same reason as pool_id above: an
+    # unset MagicMock attribute is truthy, so confirm_run's speculative-CV check
+    # (#1396) would look one up and find whatever `db.get` was stubbed with —
+    # usually the workspace, whose `.speculative` is itself a truthy MagicMock.
+    run.configuration_version_id = kwargs.get("configuration_version_id", None)
     return run
 
 
@@ -557,6 +562,21 @@ class TestConfirmRun:
         run = _mock_run(status="planned")
         result = await confirm_run(db, run)
         assert result.status == "confirmed"
+
+    async def test_rejects_a_speculative_configuration_version(self):
+        """#1396. A speculative CV is the artifact of a plan-only run — an
+        unmerged PR, or a `tofu plan` upload. Applying one puts unreviewed code
+        into a real workspace, so confirm refuses even if such a run exists."""
+        db = AsyncMock(spec=AsyncSession)
+        ws = MagicMock()
+        ws.locked = False
+        cv = MagicMock()
+        cv.speculative = True
+        # First lookup is the workspace, second is the configuration version.
+        db.get.side_effect = [ws, cv]
+        run = _mock_run(status="planned", configuration_version_id=uuid.uuid4())
+        with pytest.raises(ValueError, match="speculative"):
+            await confirm_run(db, run)
 
     async def test_rejects_non_planned(self):
         db = AsyncMock(spec=AsyncSession)


### PR DESCRIPTION
Reported as *"this run can't be applied; on some level the platform thinks it's a drift detection run"*. Two apply attempts on a live instance, both `422`, naming the configuration version's source: `drift-detection`. The run was nothing of the sort — `source: run-trigger`, `plan_only: false`, `is_drift_detection: false`.

## Why it had that code

`fire_run_triggers` selected the destination's newest uploaded CV, filtered on nothing but `status`. **It never consulted VCS**, even for a VCS-connected workspace.

On the affected workspace the eight newest CVs were all drift artifacts — one a day, because a drift check uploads one every time it runs. The newest genuinely VCS-fetched CV was older than all of them. The guard refused it, **correctly**: had it not, the trigger would have applied up to a day of stale code silently, which is worse than the 422.

The UI path on the same workspace already fetches the tracked branch. Triggered runs now do too, sharing one implementation — the helper moves out of the runs router into a service, since being private to the router is how the trigger path came to have its own, worse answer. **If the fetch fails, the trigger fails**; every available fallback is "apply some other code instead".

## And a worse one, found while confirming the first

That same unfiltered query also returns **speculative** CVs. On a `merge_then_apply` workspace — the default — an open PR creates one via the poller with `source="vcs"`, and the apply guard tests exactly that field.

**A run trigger could therefore produce an apply-capable run against unmerged pull-request code.**

The rule *"a run against a speculative CV is plan-only"* existed — but only in the HTTP endpoint (#661). Every internal caller (run triggers, poller, drift, module impact, autodiscovery) could opt out by passing `plan_only=False`, and `fire_run_triggers` did. It now lives in `create_run`, the one place they all pass through, with `confirm_run` refusing outright as a second line of defence — rows written before this exist.

## What the two share

A drift CV and a speculative CV are both **artifacts of a plan-only run**. Neither run can be applied; that always worked. What neither was stopped from doing is leaving behind a configuration version that a later run treats as deployable code. One was caught by a guard by accident of its label; the other was waved through by the same guard for the same reason.

## Verification

- **4,474 tests pass**, including all contract snapshots.
- Both new guards were confirmed to **fail their tests when removed** — independently, one test each.
- Integration coverage for the service-level chokepoint and the confirm-time defence; unit coverage for the VCS fetch path, the no-fallback-on-failure path, and the non-VCS path.

## Fixture note

`_mock_workspace` never set `vcs_connection_id` and `_mock_run` never set `configuration_version_id`, so both were **truthy MagicMocks**. Invisible while nothing branched on them — the moment this change did, three tests took the wrong path. Both are now explicit with the honest default.

Closes #1396