### PR TITLE
fix(1401): one page width, 1152px, everywhere

### DIFF
--- a/web/src/app/admin/audit-log/page.tsx
+++ b/web/src/app/admin/audit-log/page.tsx
@@ -150,7 +150,7 @@ export default function AuditLogPage() {
   return (
     <>
       <NavBar />
-      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-7xl mx-auto">
+      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">
         <PageHeader
           title={t('title')}
           description={t('description')}

--- a/web/src/app/admin/deleted-workspaces/page.tsx
+++ b/web/src/app/admin/deleted-workspaces/page.tsx
@@ -145,7 +145,7 @@ export default function DeletedWorkspacesPage() {
   return (
     <>
       <NavBar />
-      <main className="mx-auto max-w-7xl px-4 py-6">
+      <main className="mx-auto max-w-6xl px-4 py-6">
         <PageHeader title={t('title')} description={t('description')} />
 
         {error && <ErrorBanner message={error} />}

--- a/web/src/app/admin/policy-sets/[id]/page.tsx
+++ b/web/src/app/admin/policy-sets/[id]/page.tsx
@@ -205,15 +205,15 @@ export default function PolicySetDetailPage({ params }: { params: Promise<{ id: 
     }
   }
 
-  if (loading) return (<><NavBar /><main className="px-6 py-8 max-w-5xl mx-auto"><LoadingSpinner /></main></>)
-  if (!ps) return (<><NavBar /><main className="px-6 py-8 max-w-5xl mx-auto"><ErrorBanner message={error || t('notFound')} /></main></>)
+  if (loading) return (<><NavBar /><main className="px-6 py-8 max-w-6xl mx-auto"><LoadingSpinner /></main></>)
+  if (!ps) return (<><NavBar /><main className="px-6 py-8 max-w-6xl mx-auto"><ErrorBanner message={error || t('notFound')} /></main></>)
 
   const policies = ps.relationships?.policies?.data || []
 
   return (
     <>
       <NavBar />
-      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-5xl mx-auto">
+      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">
         <Link href="/admin/policy-sets" className="text-sm text-brand-400 hover:text-brand-300">&larr; {t('backLink')}</Link>
         <PageHeader
           title={ps.attributes.name}

--- a/web/src/app/estate/page.tsx
+++ b/web/src/app/estate/page.tsx
@@ -37,7 +37,7 @@ function Shell({ children }: { children: React.ReactNode }) {
   return (
     <>
       <NavBar />
-      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-7xl mx-auto">{children}</main>
+      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">{children}</main>
     </>
   )
 }

--- a/web/src/app/workspaces/[id]/onboarding/page.tsx
+++ b/web/src/app/workspaces/[id]/onboarding/page.tsx
@@ -231,7 +231,7 @@ export default function OnboardingPage() {
     return (
       <>
         <NavBar />
-        <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-5xl mx-auto">
+        <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">
           <LoadingSpinner />
         </main>
       </>
@@ -242,7 +242,7 @@ export default function OnboardingPage() {
   return (
     <>
       <NavBar />
-      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-5xl mx-auto">
+      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">
         <div className="mb-4">
           <Link
             href={`/workspaces/${workspaceId}`}


### PR DESCRIPTION
44 of 52 page containers were `max-w-6xl` (1152px). The rest had drifted:

| Page | Was |
|---|---|
| estate | `max-w-7xl` (1280) |
| admin/audit-log | `max-w-7xl` |
| admin/deleted-workspaces | `max-w-7xl` |
| admin/policy-sets/[id] | `max-w-5xl` (1024) |
| workspaces/[id]/onboarding | `max-w-5xl` |

None carried a comment explaining why, and none of the differences read as deliberate — a table is not wider on one admin page than another for a reason anybody wrote down. The visible effect is that the content column changes width as you move between pages, which reads as carelessness rather than design.

It also left no single answer to **"how wide is a page?"**, which the toolbar needs in order to be sized against it (#1400).

Inner elements keep their own widths — `max-w-md` on forms, `max-w-prose` on running text. Those are about line length and are unrelated.

Wide tables do not need a wider page: the responsive contract already requires wide content to scroll inside its own `overflow-x` container rather than widening the page around it.

Verified: `tsc`, eslint, and a full production build.