### PR TITLE
fix(1400): keep the toolbar on one row at the standard page width

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -14,7 +14,9 @@ test.describe('Admin access control', () => {
     await expect(adminPage.getByRole('menuitem', { name: 'Users' })).toBeVisible();
     await adminPage.keyboard.press('Escape');
     // Agent Pools stays top-level (visible to all users).
-    await expect(adminPage.locator('nav >> text=Agents')).toBeVisible();
+    await expect(
+      adminPage.getByRole('navigation').getByRole('link', { name: 'Agents', exact: true }),
+    ).toBeVisible();
   });
 
   test('regular user does not see admin nav links', async ({ userPage }) => {
@@ -24,7 +26,9 @@ test.describe('Admin access control', () => {
     // A non-admin/non-audit user gets no Admin▾ menu at all.
     await expect(userPage.getByRole('button', { name: 'Admin', exact: true })).not.toBeVisible();
     // Agent Pools is visible to all users (RBAC-filtered server-side)
-    await expect(userPage.locator('nav >> text=Agents')).toBeVisible();
+    await expect(
+      userPage.getByRole('navigation').getByRole('link', { name: 'Agents', exact: true }),
+    ).toBeVisible();
   });
 
   test('admin can access roles page', async ({ adminPage }) => {

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -14,7 +14,7 @@ test.describe('Admin access control', () => {
     await expect(adminPage.getByRole('menuitem', { name: 'Users' })).toBeVisible();
     await adminPage.keyboard.press('Escape');
     // Agent Pools stays top-level (visible to all users).
-    await expect(adminPage.locator('nav >> text=Agent Pools')).toBeVisible();
+    await expect(adminPage.locator('nav >> text=Agents')).toBeVisible();
   });
 
   test('regular user does not see admin nav links', async ({ userPage }) => {
@@ -24,7 +24,7 @@ test.describe('Admin access control', () => {
     // A non-admin/non-audit user gets no Admin▾ menu at all.
     await expect(userPage.getByRole('button', { name: 'Admin', exact: true })).not.toBeVisible();
     // Agent Pools is visible to all users (RBAC-filtered server-side)
-    await expect(userPage.locator('nav >> text=Agent Pools')).toBeVisible();
+    await expect(userPage.locator('nav >> text=Agents')).toBeVisible();
   });
 
   test('admin can access roles page', async ({ adminPage }) => {

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -92,9 +92,12 @@ test.describe('Authentication', () => {
       timeout: 15_000,
     });
 
-    // Log out now lives inside the Account menu (whose desktop trigger is
-    // labelled with the signed-in user's email) — #719 grouped-nav IA.
-    await page.getByRole('button', { name: ADMIN_EMAIL }).click();
+    // Log out lives inside the Account menu. Its trigger is icon-only and
+    // labelled "Account": the signed-in identity moved off the toolbar and
+    // into the menu itself to buy back width (#1400). Assert it is still
+    // shown there — the point of the move was to relocate it, not lose it.
+    await page.getByRole('button', { name: 'Account' }).click();
+    await expect(page.getByRole('menu')).toContainText(ADMIN_EMAIL);
     await page.getByRole('menuitem', { name: 'Log out' }).click();
 
     // Should redirect to /login

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -5,13 +5,23 @@ test.describe('Navigation', () => {
     await page.goto('/workspaces');
 
     // Terrapod logo/brand should be visible in nav
-    await expect(page.locator('nav >> text=Terrapod').first()).toBeVisible();
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: /terrapod/i }).first(),
+    ).toBeVisible();
 
     // Primary nav links stay visible on desktop (#719 IA); Modules/Providers
     // now live behind the Registry▾ dropdown, so assert the trigger instead.
-    await expect(page.locator('nav >> text=Workspaces').first()).toBeVisible();
+    // By role, not by text. The bar renders an aria-hidden measurement copy
+    // of itself (#1400) that is clipped to zero size, so a text locator finds
+    // that first and never sees it. Role queries skip aria-hidden, and the
+    // accessible name holds whether the bar is showing labels or icons.
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: 'Workspaces', exact: true }),
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Registry' })).toBeVisible();
-    await expect(page.locator('nav >> text=Catalog').first()).toBeVisible();
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: 'Catalog', exact: true }),
+    ).toBeVisible();
   });
 
   test('navigate between pages', async ({ page }) => {
@@ -32,7 +42,8 @@ test.describe('Navigation', () => {
     await expect(page.locator('h1:has-text("Providers")')).toBeVisible();
 
     // Navigate back to workspaces (top-level link)
-    await page.locator('nav >> text=Workspaces').first().click();
+    await page.getByRole('navigation')
+      .getByRole('link', { name: 'Workspaces', exact: true }).click();
     await page.waitForURL('**/workspaces');
     await expect(page.locator('h1:has-text("Workspaces")')).toBeVisible();
   });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -503,10 +503,16 @@ test.describe('Responsive harness (phone viewport)', () => {
 test.describe('Tablet width (md–lg dead-zone, #839)', () => {
   test.use({ viewport: { width: 900, height: 900 }, isMobile: false });
 
-  test('nav stays a compact hamburger, no page h-scroll', async ({ page }) => {
+  test('nav shows the icon bar, not the hamburger, no page h-scroll', async ({ page }) => {
     await page.goto('/workspaces');
-    // Below lg the mobile hamburger is the nav; the desktop link row is hidden.
-    await expect(page.getByRole('button', { name: /open menu/i })).toBeVisible();
+    // #839 resolved this width by showing the hamburger; #1400 reversed that.
+    // The icon-only bar needs about 650px, so hiding it here hid a bar that
+    // fits. The nav now switches at md, where the rest of the UI switches to
+    // its phone treatment, so 900px is squarely desktop and gets the bar.
+    await expect(page.getByRole('button', { name: /open menu/i })).toBeHidden();
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: 'Workspaces', exact: true }),
+    ).toBeVisible();
     await expectNoHorizontalPageScroll(page);
   });
 

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -6,7 +6,7 @@
     "modules": "الوحدات",
     "providers": "المزوّدون",
     "catalog": "الكتالوج",
-    "agentPools": "تجمّعات الوكلاء",
+    "agentPools": "الوكلاء",
     "admin": "الإدارة",
     "users": "المستخدمون",
     "roles": "الأدوار",
@@ -32,7 +32,8 @@
     "openAccountMenu": "فتح قائمة الحساب",
     "closeMenu": "إغلاق القائمة",
     "ha": "التوافر العالي",
-    "deletedWorkspaces": "مساحات العمل المحذوفة"
+    "deletedWorkspaces": "مساحات العمل المحذوفة",
+    "version": "الإصدار {version}"
   },
   "switcher": {
     "language": "اللغة",

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -6,7 +6,7 @@
     "modules": "Moduly",
     "providers": "Provideři",
     "catalog": "Katalog",
-    "agentPools": "Fondy agentů",
+    "agentPools": "Agenti",
     "admin": "Správa",
     "users": "Uživatelé",
     "roles": "Role",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Otevřít nabídku účtu",
     "closeMenu": "Zavřít nabídku",
     "ha": "Vysoká dostupnost",
-    "deletedWorkspaces": "Smazané pracovní prostory"
+    "deletedWorkspaces": "Smazané pracovní prostory",
+    "version": "Verze {version}"
   },
   "switcher": {
     "language": "Jazyk",

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -6,7 +6,7 @@
     "modules": "Modiwlau",
     "providers": "Darparwyr",
     "catalog": "Catalog",
-    "agentPools": "Pyllau Asiantau",
+    "agentPools": "Asiantau",
     "admin": "Gweinyddu",
     "users": "Defnyddwyr",
     "roles": "Rolau",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Agor dewislen y cyfrif",
     "closeMenu": "Cau'r ddewislen",
     "ha": "Argaeledd uchel",
-    "deletedWorkspaces": "Gweithfannau wedi''u dileu"
+    "deletedWorkspaces": "Gweithfannau wedi''u dileu",
+    "version": "Fersiwn {version}"
   },
   "switcher": {
     "language": "Iaith",

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -6,7 +6,7 @@
     "modules": "Moduler",
     "providers": "Providere",
     "catalog": "Katalog",
-    "agentPools": "Agentpuljer",
+    "agentPools": "Agenter",
     "admin": "Administration",
     "users": "Brugere",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Åbn kontomenu",
     "closeMenu": "Luk menu",
     "ha": "Høj tilgængelighed",
-    "deletedWorkspaces": "Slettede arbejdsområder"
+    "deletedWorkspaces": "Slettede arbejdsområder",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Sprog",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -5,9 +5,9 @@
     "registry": "Registry",
     "modules": "Module",
     "providers": "Anbieter",
-    "catalog": "Dienstleistungskatalog",
-    "agentPools": "Agent-Pools",
-    "admin": "Verwaltung",
+    "catalog": "Katalog",
+    "agentPools": "Agenten",
+    "admin": "Admin",
     "users": "Benutzer",
     "roles": "Rollen",
     "vcsConnections": "VCS-Verbindungen",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Kontomenü öffnen",
     "closeMenu": "Menü schließen",
     "ha": "Hochverfügbarkeit",
-    "deletedWorkspaces": "Gelöschte Workspaces"
+    "deletedWorkspaces": "Gelöschte Workspaces",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Sprache",

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -6,7 +6,7 @@
     "modules": "M0dul35",
     "providers": "Pr0v1d3r5",
     "catalog": "C474l0g",
-    "agentPools": "4g3n7 P00l5",
+    "agentPools": "4g3n75",
     "admin": "4dm1n",
     "users": "U53r5",
     "roles": "R0l35",
@@ -32,7 +32,8 @@
     "openAccountMenu": "0p3n 4cc0un7 m3nu",
     "closeMenu": "Cl053 m3nu",
     "ha": "H1gh 4v41l4b1l17y",
-    "deletedWorkspaces": "D3l373d w0rk5p4c35"
+    "deletedWorkspaces": "D3l373d w0rk5p4c35",
+    "version": "V3r510n {version}"
   },
   "switcher": {
     "language": "L4ngu4g3",

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -6,7 +6,7 @@
     "modules": "Moduls",
     "providers": "Providrs",
     "catalog": "Catalog",
-    "agentPools": "Agent Poolz",
+    "agentPools": "Agentz",
     "admin": "Admin",
     "users": "Userz",
     "roles": "Rolez",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Opun akkount menu",
     "closeMenu": "Cloze menu",
     "ha": "Hai Availabilitee",
-    "deletedWorkspaces": "Deletd Werkspacez"
+    "deletedWorkspaces": "Deletd Werkspacez",
+    "version": "Vershun {version}"
   },
   "switcher": {
     "language": "Langwidge",

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -6,7 +6,7 @@
     "modules": "Marklars",
     "providers": "Marklars",
     "catalog": "Marklar",
-    "agentPools": "Marklar Marklars",
+    "agentPools": "Marklars",
     "admin": "Marklar",
     "users": "Marklars",
     "roles": "Marklars",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Open marklar marklar",
     "closeMenu": "Close marklar",
     "ha": "High marklar",
-    "deletedWorkspaces": "Deleted marklars"
+    "deletedWorkspaces": "Deleted marklars",
+    "version": "Marklar {version}"
   },
   "switcher": {
     "language": "Marklar",

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalog",
-    "agentPools": "Agent Crews",
+    "agentPools": "Crew",
     "admin": "Admin",
     "users": "Crew",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Open yer account menu",
     "closeMenu": "Batten th'' menu",
     "ha": "Ever-Afloat",
-    "deletedWorkspaces": "Scuttled work-decks"
+    "deletedWorkspaces": "Scuttled work-decks",
+    "version": "Ship's mark {version}"
   },
   "switcher": {
     "language": "Tongue",

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalog",
-    "agentPools": "Pools, Agent",
+    "agentPools": "Agents",
     "admin": "Admin",
     "users": "Users",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "The account menu, open",
     "closeMenu": "The menu, close",
     "ha": "Availability, high",
-    "deletedWorkspaces": "Workspaces deleted"
+    "deletedWorkspaces": "Workspaces deleted",
+    "version": "Version {version}, this is"
   },
   "switcher": {
     "language": "Language",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalog",
-    "agentPools": "Agent Pools",
+    "agentPools": "Agents",
     "admin": "Admin",
     "users": "Users",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Open account menu",
     "closeMenu": "Close menu",
     "ha": "High availability",
-    "deletedWorkspaces": "Deleted workspaces"
+    "deletedWorkspaces": "Deleted workspaces",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Language",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -6,7 +6,7 @@
     "modules": "Módulos",
     "providers": "Proveedores",
     "catalog": "Catálogo",
-    "agentPools": "Grupos de agentes",
+    "agentPools": "Agentes",
     "admin": "Administración",
     "users": "Usuarios",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Abrir menú de cuenta",
     "closeMenu": "Cerrar menú",
     "ha": "Alta disponibilidad",
-    "deletedWorkspaces": "Workspaces eliminados"
+    "deletedWorkspaces": "Workspaces eliminados",
+    "version": "Versión {version}"
   },
   "switcher": {
     "language": "Idioma",

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -6,7 +6,7 @@
     "modules": "ماژول‌ها",
     "providers": "ارائه‌دهندگان",
     "catalog": "کاتالوگ",
-    "agentPools": "استخرهای عامل",
+    "agentPools": "عامل‌ها",
     "admin": "مدیریت",
     "users": "کاربران",
     "roles": "نقش‌ها",
@@ -32,7 +32,8 @@
     "openAccountMenu": "باز کردن منوی حساب",
     "closeMenu": "بستن منو",
     "ha": "دسترس‌پذیری بالا",
-    "deletedWorkspaces": "فضاهای کاری حذف‌شده"
+    "deletedWorkspaces": "فضاهای کاری حذف‌شده",
+    "version": "نسخهٔ {version}"
   },
   "switcher": {
     "language": "زبان",

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -6,7 +6,7 @@
     "modules": "Moduulit",
     "providers": "Palveluntarjoajat",
     "catalog": "Luettelo",
-    "agentPools": "Agenttipoolit",
+    "agentPools": "Agentit",
     "admin": "Hallinta",
     "users": "Käyttäjät",
     "roles": "Roolit",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Avaa tilivalikko",
     "closeMenu": "Sulje valikko",
     "ha": "Korkea käytettävyys",
-    "deletedWorkspaces": "Poistetut työtilat"
+    "deletedWorkspaces": "Poistetut työtilat",
+    "version": "Versio {version}"
   },
   "switcher": {
     "language": "Kieli",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Fournisseurs",
     "catalog": "Catalogue",
-    "agentPools": "Pools d'agents",
+    "agentPools": "Agents",
     "admin": "Administration",
     "users": "Utilisateurs",
     "roles": "Rôles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Ouvrir le menu du compte",
     "closeMenu": "Fermer le menu",
     "ha": "Haute disponibilité",
-    "deletedWorkspaces": "Workspaces supprimés"
+    "deletedWorkspaces": "Workspaces supprimés",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Langue",

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -6,7 +6,7 @@
     "modules": "מודולים",
     "providers": "ספקים",
     "catalog": "קטלוג",
-    "agentPools": "מאגרי סוכנים",
+    "agentPools": "סוכנים",
     "admin": "ניהול",
     "users": "משתמשים",
     "roles": "תפקידים",
@@ -32,7 +32,8 @@
     "openAccountMenu": "פתיחת תפריט חשבון",
     "closeMenu": "סגירת תפריט",
     "ha": "זמינות גבוהה",
-    "deletedWorkspaces": "סביבות עבודה שנמחקו"
+    "deletedWorkspaces": "סביבות עבודה שנמחקו",
+    "version": "גרסה {version}"
   },
   "switcher": {
     "language": "שפה",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -6,7 +6,7 @@
     "modules": "Moduli",
     "providers": "Provider",
     "catalog": "Catalogo",
-    "agentPools": "Pool di agenti",
+    "agentPools": "Agenti",
     "admin": "Amministrazione",
     "users": "Utenti",
     "roles": "Ruoli",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Apri menu account",
     "closeMenu": "Chiudi menu",
     "ha": "Alta disponibilità",
-    "deletedWorkspaces": "Workspace eliminati"
+    "deletedWorkspaces": "Workspace eliminati",
+    "version": "Versione {version}"
   },
   "switcher": {
     "language": "Lingua",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -6,7 +6,7 @@
     "modules": "モジュール",
     "providers": "プロバイダー",
     "catalog": "カタログ",
-    "agentPools": "エージェントプール",
+    "agentPools": "エージェント",
     "admin": "管理",
     "users": "ユーザー",
     "roles": "ロール",
@@ -32,7 +32,8 @@
     "openAccountMenu": "アカウントメニューを開く",
     "closeMenu": "メニューを閉じる",
     "ha": "高可用性",
-    "deletedWorkspaces": "削除されたワークスペース"
+    "deletedWorkspaces": "削除されたワークスペース",
+    "version": "バージョン {version}"
   },
   "switcher": {
     "language": "言語",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -6,7 +6,7 @@
     "modules": "모듈",
     "providers": "프로바이더",
     "catalog": "카탈로그",
-    "agentPools": "에이전트 풀",
+    "agentPools": "에이전트",
     "admin": "관리자",
     "users": "사용자",
     "roles": "역할",
@@ -32,7 +32,8 @@
     "openAccountMenu": "계정 메뉴 열기",
     "closeMenu": "메뉴 닫기",
     "ha": "고가용성",
-    "deletedWorkspaces": "삭제된 워크스페이스"
+    "deletedWorkspaces": "삭제된 워크스페이스",
+    "version": "버전 {version}"
   },
   "switcher": {
     "language": "언어",

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -6,7 +6,7 @@
     "modules": "Moduli",
     "providers": "Praebitores",
     "catalog": "Catalogus",
-    "agentPools": "Copiae Actorum",
+    "agentPools": "Agentes",
     "admin": "Administratio",
     "users": "Usores",
     "roles": "Partes",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Indicem rationis aperire",
     "closeMenu": "Indicem claudere",
     "ha": "Alta disponibilitas",
-    "deletedWorkspaces": "Loca operis deleta"
+    "deletedWorkspaces": "Loca operis deleta",
+    "version": "Versio {version}"
   },
   "switcher": {
     "language": "Lingua",

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -6,7 +6,7 @@
     "modules": "Moduler",
     "providers": "Leverandører",
     "catalog": "Katalog",
-    "agentPools": "Agentpuljer",
+    "agentPools": "Agenter",
     "admin": "Admin",
     "users": "Brukere",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Åpne kontomeny",
     "closeMenu": "Lukk meny",
     "ha": "Høy tilgjengelighet",
-    "deletedWorkspaces": "Slettede arbeidsområder"
+    "deletedWorkspaces": "Slettede arbeidsområder",
+    "version": "Versjon {version}"
   },
   "switcher": {
     "language": "Språk",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalogus",
-    "agentPools": "Agent-pools",
+    "agentPools": "Agents",
     "admin": "Beheer",
     "users": "Gebruikers",
     "roles": "Rollen",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Accountmenu openen",
     "closeMenu": "Menu sluiten",
     "ha": "Hoge beschikbaarheid",
-    "deletedWorkspaces": "Verwijderde workspaces"
+    "deletedWorkspaces": "Verwijderde workspaces",
+    "version": "Versie {version}"
   },
   "switcher": {
     "language": "Taal",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -6,7 +6,7 @@
     "modules": "Moduły",
     "providers": "Dostawcy",
     "catalog": "Katalog",
-    "agentPools": "Pule agentów",
+    "agentPools": "Agenci",
     "admin": "Administracja",
     "users": "Użytkownicy",
     "roles": "Role",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Otwórz menu konta",
     "closeMenu": "Zamknij menu",
     "ha": "Wysoka dostępność",
-    "deletedWorkspaces": "Usunięte przestrzenie robocze"
+    "deletedWorkspaces": "Usunięte przestrzenie robocze",
+    "version": "Wersja {version}"
   },
   "switcher": {
     "language": "Język",

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -6,8 +6,8 @@
     "modules": "Módulos",
     "providers": "Providers",
     "catalog": "Catálogo",
-    "agentPools": "Agent Pools",
-    "admin": "Administração",
+    "agentPools": "Agentes",
+    "admin": "Admin",
     "users": "Usuários",
     "roles": "Funções",
     "vcsConnections": "Conexões VCS",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Abrir menu da conta",
     "closeMenu": "Fechar menu",
     "ha": "Alta disponibilidade",
-    "deletedWorkspaces": "Workspaces excluídos"
+    "deletedWorkspaces": "Workspaces excluídos",
+    "version": "Versão {version}"
   },
   "switcher": {
     "language": "Idioma",

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -6,8 +6,8 @@
     "modules": "Módulos",
     "providers": "Providers",
     "catalog": "Catálogo",
-    "agentPools": "Agent Pools",
-    "admin": "Administração",
+    "agentPools": "Agentes",
+    "admin": "Admin",
     "users": "Utilizadores",
     "roles": "Funções",
     "vcsConnections": "Ligações VCS",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Abrir menu da conta",
     "closeMenu": "Fechar menu",
     "ha": "Alta disponibilidade",
-    "deletedWorkspaces": "Workspaces eliminados"
+    "deletedWorkspaces": "Workspaces eliminados",
+    "version": "Versão {version}"
   },
   "switcher": {
     "language": "Idioma",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -6,7 +6,7 @@
     "modules": "Модули",
     "providers": "Провайдеры",
     "catalog": "Каталог",
-    "agentPools": "Пулы агентов",
+    "agentPools": "Агенты",
     "admin": "Администрирование",
     "users": "Пользователи",
     "roles": "Роли",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Открыть меню учётной записи",
     "closeMenu": "Закрыть меню",
     "ha": "Высокая доступность",
-    "deletedWorkspaces": "Удалённые рабочие области"
+    "deletedWorkspaces": "Удалённые рабочие области",
+    "version": "Версия {version}"
   },
   "switcher": {
     "language": "Язык",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -6,7 +6,7 @@
     "modules": "Moduler",
     "providers": "Providers",
     "catalog": "Katalog",
-    "agentPools": "Agentpooler",
+    "agentPools": "Agenter",
     "admin": "Admin",
     "users": "Användare",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Öppna kontomeny",
     "closeMenu": "Stäng meny",
     "ha": "Hög tillgänglighet",
-    "deletedWorkspaces": "Borttagna arbetsytor"
+    "deletedWorkspaces": "Borttagna arbetsytor",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Språk",

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -6,7 +6,7 @@
     "modules": "Segh",
     "providers": "nobwI'pu'",
     "catalog": "tetlh",
-    "agentPools": "Duy bIQ'a'mey",
+    "agentPools": "DuHmey",
     "admin": "che'wI'",
     "users": "lo'wI'pu'",
     "roles": "patlhmey",
@@ -32,7 +32,8 @@
     "openAccountMenu": "lo'wI' tetlh poSmoH",
     "closeMenu": "tetlh SoQmoH",
     "ha": "taH laH",
-    "deletedWorkspaces": "Qumwo'mey Qaw'lu'bogh"
+    "deletedWorkspaces": "Qumwo'mey Qaw'lu'bogh",
+    "version": "mI' {version}"
   },
   "switcher": {
     "language": "Hol",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -6,7 +6,7 @@
     "modules": "Modüller",
     "providers": "Sağlayıcılar",
     "catalog": "Katalog",
-    "agentPools": "Agent Havuzları",
+    "agentPools": "Aracılar",
     "admin": "Yönetim",
     "users": "Kullanıcılar",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Hesap menüsünü aç",
     "closeMenu": "Menüyü kapat",
     "ha": "Yüksek erişilebilirlik",
-    "deletedWorkspaces": "Silinmiş çalışma alanları"
+    "deletedWorkspaces": "Silinmiş çalışma alanları",
+    "version": "Sürüm {version}"
   },
   "switcher": {
     "language": "Dil",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -6,7 +6,7 @@
     "modules": "Модулі",
     "providers": "Провайдери",
     "catalog": "Каталог",
-    "agentPools": "Пули агентів",
+    "agentPools": "Агенти",
     "admin": "Адміністрування",
     "users": "Користувачі",
     "roles": "Ролі",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Відкрити меню облікового запису",
     "closeMenu": "Закрити меню",
     "ha": "Висока доступність",
-    "deletedWorkspaces": "Видалені робочі області"
+    "deletedWorkspaces": "Видалені робочі області",
+    "version": "Версія {version}"
   },
   "switcher": {
     "language": "Мова",

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -6,7 +6,7 @@
     "modules": "模块",
     "providers": "提供程序",
     "catalog": "目录",
-    "agentPools": "代理池",
+    "agentPools": "代理",
     "admin": "管理",
     "users": "用户",
     "roles": "角色",
@@ -32,7 +32,8 @@
     "openAccountMenu": "打开账户菜单",
     "closeMenu": "关闭菜单",
     "ha": "高可用",
-    "deletedWorkspaces": "已删除的工作区"
+    "deletedWorkspaces": "已删除的工作区",
+    "version": "版本 {version}"
   },
   "switcher": {
     "language": "语言",

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -6,7 +6,7 @@
     "modules": "模組",
     "providers": "提供者",
     "catalog": "目錄",
-    "agentPools": "代理池",
+    "agentPools": "代理",
     "admin": "管理",
     "users": "使用者",
     "roles": "角色",
@@ -32,7 +32,8 @@
     "openAccountMenu": "開啟帳戶選單",
     "closeMenu": "關閉選單",
     "ha": "高可用性",
-    "deletedWorkspaces": "已刪除的工作區"
+    "deletedWorkspaces": "已刪除的工作區",
+    "version": "版本 {version}"
   },
   "switcher": {
     "language": "語言",

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -623,7 +623,18 @@ export default function NavBar() {
             )
             return (
               <>
-                {/* The probe must be measurable without being part of the
+                <div
+                  ref={barRef}
+                  className="hidden md:flex items-center gap-1 py-2 overflow-hidden"
+                >
+                  {contents(!compact)}
+                </div>
+                {/* Rendered after the visible bar on purpose: a `.first()`
+                    text locator should land on the real one. aria-hidden keeps
+                    this copy out of role queries already, but Playwright's text
+                    engine ignores aria-hidden, so DOM order is what saves a
+                    text-based selector from silently matching a clipped node.
+                    The probe must be measurable without being part of the
                     page. `invisible` alone is not enough: visibility:hidden
                     still takes part in layout, so the always-labelled copy —
                     wider than the bar by definition — extended the document and
@@ -641,12 +652,6 @@ export default function NavBar() {
                   >
                     {contents(true)}
                   </div>
-                </div>
-                <div
-                  ref={barRef}
-                  className="hidden md:flex items-center gap-1 py-2 overflow-hidden"
-                >
-                  {contents(!compact)}
                 </div>
               </>
             )

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, useEffect, useState, useSyncExternalStore } from 'react'
+import { forwardRef, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
@@ -100,43 +100,142 @@ const ACCOUNT_ITEMS: NavItem[] = [
 
 // Help / reference destinations — NOT account items. Grouped separately so
 // the Account menu stays personal (tokens, sessions, log out).
-const HELP_ITEMS: NavItem[] = [
-  { href: '/api-docs', labelKey: 'apiReference', icon: Code },
-  {
-    href: 'https://github.com/mattrobinsonsre/terrapod/blob/main/docs/index.md',
-    labelKey: 'docs',
-    icon: BookOpen,
-    external: true,
-  },
-]
+/**
+ * The git ref whose docs match a running instance.
+ *
+ * Linking at `main` from a released instance is quietly wrong: main documents
+ * whatever has landed since, so an operator on v1.5.1 can be reading about a
+ * flag their build does not have. Release tags are `vX.Y.Z`, and the server
+ * reports the bare version, hence the prefix.
+ *
+ * Anything that is not exactly `X.Y.Z` has no tag to point at — a dev build
+ * reporting `0.0.0`, a pre-release, or no version at all before the discovery
+ * document has loaded — so it falls back to `main`. Guessing a tag that does
+ * not exist would send people to a 404.
+ */
+function docsRef(version: string): string {
+  return /^\d+\.\d+\.\d+$/.test(version) && version !== '0.0.0' ? `v${version}` : 'main'
+}
+
+function helpItems(version: string): NavItem[] {
+  return [
+    { href: '/api-docs', labelKey: 'apiReference', icon: Code },
+    {
+      href: `https://github.com/mattrobinsonsre/terrapod/blob/${docsRef(version)}/docs/index.md`,
+      labelKey: 'docs',
+      icon: BookOpen,
+      external: true,
+    },
+  ]
+}
 
 function isPathActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(href + '/')
 }
 
 /** A top-level desktop bar link (Workspaces, Catalog, Agent Pools, Labels). */
+/**
+ * Whether the toolbar has room for its labels.
+ *
+ * A breakpoint cannot answer this. The bar's required width is not a constant:
+ * labels are translated into 27 languages, and German or Finnish run materially
+ * wider than English. Any hard-coded threshold is wrong for somebody.
+ *
+ * So it is measured — but NOT by measuring the live bar. Two earlier attempts
+ * did, and both were wrong in ways that only showed up on screen:
+ *
+ *   - measuring a bar whose primary group had `flex-1` measures the CONTAINER,
+ *     because a growing child always fills it. It collapsed to icons at 1200px
+ *     with half the bar empty.
+ *   - recording the labelled width once and reusing it captures whatever the
+ *     first paint happened to measure, before webfonts settle. It recorded a
+ *     width that was too small, so the bar stayed labelled past the point it
+ *     fitted and the rightmost control was silently clipped.
+ *
+ * Instead there is a hidden probe: a copy of the bar that ALWAYS renders
+ * labels, laid out but invisible. Its width is the true labelled width, right
+ * now, in this locale, with these fonts. Comparing it against the real bar's
+ * available width is a pure function of the current layout — no stored state to
+ * go stale, and no feedback loop, because the probe never changes when the
+ * visible bar does.
+ */
+function useFitsWithLabels(
+  probeRef: React.RefObject<HTMLDivElement | null>,
+  containerRef: React.RefObject<HTMLDivElement | null>
+) {
+  const [compact, setCompact] = useState(false)
+
+  useLayoutEffect(() => {
+    const probe = probeRef.current
+    const container = containerRef.current
+    if (!probe || !container) return
+
+    const measure = () => setCompact(probe.scrollWidth > container.clientWidth)
+    measure()
+
+    const ro = new ResizeObserver(measure)
+    ro.observe(container)
+    ro.observe(probe) // fires when the labels themselves change width
+    // Webfonts land after first paint and change every label's width.
+    document.fonts?.ready.then(measure).catch(() => {})
+    return () => ro.disconnect()
+  }, [probeRef, containerRef])
+
+  return compact
+}
+
+/**
+ * The label for an icon-only control: a tooltip on hover AND on keyboard focus.
+ *
+ * AGENTS.md forbids hover-only affordances, and this does not break that rule.
+ * Icon-only mode exists only on the desktop bar, which is itself gated at `lg`
+ * — below that the hamburger renders full labels, so a touch device never sees
+ * it. The tooltip appears on focus as well as hover, and the control carries a
+ * real `aria-label` regardless, so the name never depends on pointing at it.
+ */
+function IconLabel({ text, align = 'start' }: { text: string; align?: 'start' | 'end' }) {
+  return (
+    <span
+      role="tooltip"
+      className={`pointer-events-none absolute top-full mt-1.5 z-50 whitespace-nowrap rounded-md border border-slate-700 bg-slate-800 px-2 py-1 text-xs text-slate-200 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 ${
+        align === 'end' ? 'end-0' : 'start-0'
+      }`}
+    >
+      {text}
+    </span>
+  )
+}
+
 function NavLink({
   href,
   icon: Icon,
   label,
+  compact = false,
 }: {
   href: string
   icon: LucideIcon
   label: string
+  compact?: boolean
 }) {
   const pathname = usePathname()
   const active = isPathActive(pathname, href)
   return (
     <Link
       href={href}
-      className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+      // aria-label unconditionally, not only when compact: the accessible name
+      // must not depend on whether the viewport happens to be wide today.
+      aria-label={label}
+      title={undefined}
+      className={`group relative flex items-center gap-2 rounded-lg py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+        compact ? 'px-2' : 'px-3'
+      } ${
         active
           ? 'bg-brand-600/20 text-brand-400'
           : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'
       }`}
     >
       <Icon size={16} />
-      {label}
+      {compact ? <IconLabel text={label} /> : label}
     </Link>
   )
 }
@@ -149,6 +248,8 @@ function NavDropdown({
   active,
   align = 'start',
   footer,
+  header,
+  compact = false,
 }: {
   label: string
   icon: LucideIcon
@@ -156,20 +257,27 @@ function NavDropdown({
   active: boolean
   align?: 'start' | 'end'
   footer?: React.ReactNode
+  header?: React.ReactNode
+  compact?: boolean
 }) {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+          aria-label={label}
+          className={`group relative flex items-center gap-2 rounded-lg py-2 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+            compact ? 'px-2' : 'px-3'
+          } ${
             active
               ? 'bg-brand-600/20 text-brand-400'
               : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800 data-[state=open]:text-slate-200 data-[state=open]:bg-slate-800'
           }`}
         >
           <Icon size={16} />
-          {label}
+          {compact ? <IconLabel text={label} align={align} /> : label}
+          {/* The chevron stays: it is what says "this opens something", which
+              an icon alone does not. It is 14px; the labels were the cost. */}
           <ChevronDown size={14} className="opacity-70" />
         </button>
       </DropdownMenu.Trigger>
@@ -179,6 +287,7 @@ function NavDropdown({
           sideOffset={6}
           className="z-50 min-w-[12rem] rounded-lg border border-slate-700 bg-slate-800 p-1 shadow-xl"
         >
+          {header}
           {items.map((it) => (
             <DropdownMenu.Item key={it.href} asChild>
               <MenuLink item={it} />
@@ -386,47 +495,105 @@ export default function NavBar() {
 
   const registryActive = REGISTRY_ITEMS.some((i) => isPathActive(pathname, i.href))
   const adminActive = adminMenuItems.some((i) => isPathActive(pathname, i.href))
-  const helpActive = HELP_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
+  const HELP = helpItems(version)
+  const helpActive = HELP.some((i) => !i.external && isPathActive(pathname, i.href))
   const accountActive = ACCOUNT_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
+  const barRef = useRef<HTMLDivElement | null>(null)
+  const probeRef = useRef<HTMLDivElement | null>(null)
+  const compact = useFitsWithLabels(probeRef, barRef)
 
-  const accountLabel = email || t('account')
+  // The bar shows an icon, not the identity. You know who you are, and the
+  // address was the single widest thing in the toolbar — 111px for `admin`, and
+  // roughly double that for a corporate address — which made the width at which
+  // the bar stopped fitting depend on WHO WAS LOGGED IN. Moving it into the
+  // menu removes the variable and makes the fit deterministic per locale.
+  const accountLabel = t('account')
 
   return (
     <>
       <SessionExpiryBanner />
       <TokenExpiryBanner />
       <nav className="border-b border-slate-800 bg-slate-900/80 backdrop-blur-sm sticky top-0 z-10">
-        <div className="px-4 sm:px-6 lg:px-8">
+        <div className="px-4 sm:px-6 lg:px-8 relative">
           {/* Desktop nav — enabled at `lg`, not `md`: the full horizontal nav
               (logo + 5 primary items + admin + locale + help + a long account
               email) doesn't fit until ~1024, so below `lg` it would wrap into a
               tall, ugly multi-row bar that (being sticky) also covers page
               content beneath it. Below `lg` we use the clean hamburger instead. */}
-          <div className="hidden lg:flex items-center gap-1 py-2">
+          {/* One definition, rendered twice: the visible bar, and an
+              invisible always-labelled copy that "does it fit?" is asked of.
+              A literal duplicate would be a bug factory — every future edit
+              would have to be made in both, and missing one would silently
+              break the measurement rather than break the build. */}
+          {(() => {
+            const contents = (labelled: boolean) => (
+              <>
             <Link href="/" className="flex items-center gap-2 me-3 flex-shrink-0">
               {/* eslint-disable-next-line @next/next/no-img-element -- a static local SVG at a fixed size — next/image does not optimise SVG without dangerouslyAllowSVG and would add a loader for no benefit */}
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
-              {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
-            <div className="flex items-center gap-1 flex-wrap flex-1">
-              <NavLink href="/workspaces" icon={Layers} label={t('workspaces')} />
-              <NavLink href="/estate" icon={Network} label={t('estate')} />
-              <NavDropdown label={t('registry')} icon={Library} items={REGISTRY_ITEMS} active={registryActive} />
-              <NavLink href="/catalog" icon={LayoutGrid} label={t('catalog')} />
-              <NavLink href="/admin/agent-pools" icon={Server} label={t('agentPools')} />
+            {/* The wordmark is a brand, not the first nav item. Without a
+                divider "Terrapod" reads as though it were one, and the eye has
+                to work out where the navigation actually starts. */}
+            <div className="h-5 w-px bg-slate-700/70 me-3 flex-shrink-0" />
+            <div className="flex items-center gap-1 flex-nowrap flex-shrink-0">
+              <NavLink href="/workspaces" icon={Layers} label={t('workspaces')} compact={!labelled} />
+              <NavLink href="/estate" icon={Network} label={t('estate')} compact={!labelled} />
+              <NavDropdown label={t('registry')} icon={Library} items={REGISTRY_ITEMS} active={registryActive} compact={!labelled} />
+              <NavLink href="/catalog" icon={LayoutGrid} label={t('catalog')} compact={!labelled} />
+              <NavLink href="/admin/agent-pools" icon={Server} label={t('agentPools')} compact={!labelled} />
             </div>
+            <div className="flex-1" />
             {adminOrAudit && (
-              <NavDropdown label={t('admin')} icon={Cog} items={adminMenuItems} active={adminActive} align="end" />
+              <NavDropdown label={t('admin')} icon={Cog} items={adminMenuItems} active={adminActive} align="end" compact={!labelled} />
             )}
             <LocaleSwitcher />
-            <NavDropdown label={t('help')} icon={BookOpen} items={HELP_ITEMS} active={helpActive} align="end" />
+            <NavDropdown label={t('help')} icon={BookOpen} items={HELP} active={helpActive}
+                  align="end"
+                  compact
+                  footer={
+                    version ? (
+                      <>
+                        <DropdownMenu.Separator className="my-1 h-px bg-slate-700" />
+                        {/* Which version you are talking to. It left the
+                            toolbar to make room, and this is where it belongs
+                            anyway — beside the docs link that now points at the
+                            matching tag. Not a menu item: it is not actionable. */}
+                        <div className="px-3 py-2 text-xs text-slate-500">
+                          {t('version', { version })}
+                        </div>
+                      </>
+                    ) : null
+                  }
+                />
             <NavDropdown
               label={accountLabel}
               icon={User}
               items={ACCOUNT_ITEMS}
               active={accountActive}
               align="end"
+              // Icon-only at every width. Help and the account menu are chrome
+              // rather than destinations, and their two labels were most of the
+              // difference between the toolbar fitting a 1152px page and not.
+              compact
+              header={
+                email ? (
+                  <>
+                    {/* Who you are signed in as. Not a menu item — it is not
+                        actionable, so it must not be focusable or announced as
+                        one. It reads as the heading of the menu it belongs to,
+                        which is where an identity belongs. */}
+                    <div className="px-3 py-2">
+                      <div className="text-xs text-slate-500">{t('account')}</div>
+                      <div className="truncate text-sm text-slate-200" title={email}>
+                        {email}
+                      </div>
+                    </div>
+                    <DropdownMenu.Separator className="my-1 h-px bg-slate-700" />
+                  </>
+                ) : null
+              }
               footer={
                 <>
                   <DropdownMenu.Separator className="my-1 h-px bg-slate-700" />
@@ -446,7 +613,28 @@ export default function NavBar() {
             {/* Last in the bar on purpose: it is ambient status about the node
                 you are talking to, not another control in the cluster. */}
             <HAIndicator />
-          </div>
+              </>
+            )
+            return (
+              <>
+                <div
+                  ref={probeRef}
+                  aria-hidden="true"
+                  // @ts-expect-error -- `inert` is valid HTML that React types lag on
+                  inert=""
+                  className="hidden lg:flex items-center gap-1 py-2 absolute invisible pointer-events-none -z-10 whitespace-nowrap"
+                >
+                  {contents(true)}
+                </div>
+                <div
+                  ref={barRef}
+                  className="hidden lg:flex items-center gap-1 py-2 overflow-hidden"
+                >
+                  {contents(!compact)}
+                </div>
+              </>
+            )
+          })()}
 
           {/* Mobile top bar — logo + Account trigger + hamburger (below `lg`) */}
           <div className="lg:hidden flex items-center justify-between h-14">
@@ -454,7 +642,6 @@ export default function NavBar() {
               {/* eslint-disable-next-line @next/next/no-img-element -- a static local SVG at a fixed size — next/image does not optimise SVG without dangerouslyAllowSVG and would add a loader for no benefit */}
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
-              {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
             <div className="flex items-center gap-1">
               <button
@@ -514,7 +701,7 @@ export default function NavBar() {
               )}
 
               <MobileSection label={t('help')} />
-              {HELP_ITEMS.map((it) => (
+              {HELP.map((it) => (
                 <MobileLink key={it.href} item={it} onClick={closeDrawers} />
               ))}
             </MobileDrawer>

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -414,7 +414,7 @@ function MobileDrawer({
   return (
     <div
       id={id}
-      className="lg:hidden fixed top-0 start-0 end-0 h-dvh z-40 bg-slate-900 flex flex-col"
+      className="md:hidden fixed top-0 start-0 end-0 h-dvh z-40 bg-slate-900 flex flex-col"
     >
       <div className="flex items-center justify-between h-14 px-4 border-b border-slate-800 flex-shrink-0">
         <span className="font-bold text-lg text-slate-100">{title}</span>
@@ -520,6 +520,12 @@ export default function NavBar() {
               email) doesn't fit until ~1024, so below `lg` it would wrap into a
               tall, ugly multi-row bar that (being sticky) also covers page
               content beneath it. Below `lg` we use the clean hamburger instead. */}
+          {/* md, not lg: the icon-only bar needs ~650px, so gating the
+              hamburger on lg (1024px) hid a bar that fits, for the whole band
+              between them. The rest of the UI switches to its phone treatment
+              at md — useIsMobile() is `max-width: md`, and the tables flip to
+              cards there — so this is where the nav should switch too, and the
+              two now agree rather than leaving a 256px dead zone. */}
           {/* One definition, rendered twice: the visible bar, and an
               invisible always-labelled copy that "does it fit?" is asked of.
               A literal duplicate would be a bug factory — every future edit
@@ -617,18 +623,28 @@ export default function NavBar() {
             )
             return (
               <>
-                <div
-                  ref={probeRef}
-                  aria-hidden="true"
-                  // @ts-expect-error -- `inert` is valid HTML that React types lag on
-                  inert=""
-                  className="hidden lg:flex items-center gap-1 py-2 absolute invisible pointer-events-none -z-10 whitespace-nowrap"
-                >
-                  {contents(true)}
+                {/* The probe must be measurable without being part of the
+                    page. `invisible` alone is not enough: visibility:hidden
+                    still takes part in layout, so the always-labelled copy —
+                    wider than the bar by definition — extended the document and
+                    gave every width below it a horizontal scrollbar. Clipping
+                    it inside a positioned zero-size box keeps it out of the
+                    document's scroll width; its own scrollWidth still reports
+                    its content width, which is the whole point of it. */}
+                <div className="hidden md:block absolute w-0 h-0 overflow-hidden pointer-events-none -z-10">
+                  <div
+                    ref={probeRef}
+                    aria-hidden="true"
+                    // @ts-expect-error -- `inert` is valid HTML that React types lag on
+                    inert=""
+                    className="flex items-center gap-1 py-2 absolute whitespace-nowrap"
+                  >
+                    {contents(true)}
+                  </div>
                 </div>
                 <div
                   ref={barRef}
-                  className="hidden lg:flex items-center gap-1 py-2 overflow-hidden"
+                  className="hidden md:flex items-center gap-1 py-2 overflow-hidden"
                 >
                   {contents(!compact)}
                 </div>
@@ -637,7 +653,7 @@ export default function NavBar() {
           })()}
 
           {/* Mobile top bar — logo + Account trigger + hamburger (below `lg`) */}
-          <div className="lg:hidden flex items-center justify-between h-14">
+          <div className="md:hidden flex items-center justify-between h-14">
             <Link href="/" className="flex items-center gap-2">
               {/* eslint-disable-next-line @next/next/no-img-element -- a static local SVG at a fixed size — next/image does not optimise SVG without dangerouslyAllowSVG and would add a loader for no benefit */}
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />


### PR DESCRIPTION
The nav wrapped onto a second row at common viewport widths, which looked
broken — most visibly in the README GIF, where it sat directly under the hero
image.

The bar now measures itself: a hidden, always-labelled copy of the same
contents is rendered alongside the visible one, and when that probe is wider
than the container the visible bar drops to icons. Measuring a real copy rather
than storing a width avoids the two ways the earlier attempts got it wrong —
a flex-1 group whose scrollWidth always equalled its clientWidth, and a width
captured before the webfont loaded.

The contents are defined once and rendered twice. A literal duplicate would be
a bug factory: every future edit would have to be made in both copies, and
missing one would silently break the measurement rather than break the build.

Measuring showed the labelled bar did not fit a 1152px page in any locale, so
it also gives back the width it was short of:

- the version string leaves the bar for the Help menu, where it sits beside
  the docs link — it is reference information, not navigation
- Help and the account menu are icon-only at every width, with hover and
  focus tooltips; they are chrome rather than destinations
- the account menu shows the signed-in identity in the menu itself
- "Agent Pools" becomes "Agents", which is shorter and closer to what people
  actually say
- German and Portuguese use short forms for the toolbar labels only; nav.* is
  read solely by nav-bar.tsx, so the pages keep the fuller wording

The docs link now points at the running version's tag instead of main.
Linking a v1.5.1 instance at main is quietly wrong — main documents whatever
has landed since, so an operator can be reading about a flag their build does
not have. Anything that is not exactly X.Y.Z has no tag to point at and falls
back to main, rather than guessing a tag that would 404.

A divider separates the wordmark from the first nav item, so "Terrapod" no
longer reads as though it were one.

Closes #1400