### PR TITLE
fix(1402): report listener pods on /ha, not listener identities

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -14,7 +14,9 @@ test.describe('Admin access control', () => {
     await expect(adminPage.getByRole('menuitem', { name: 'Users' })).toBeVisible();
     await adminPage.keyboard.press('Escape');
     // Agent Pools stays top-level (visible to all users).
-    await expect(adminPage.locator('nav >> text=Agents')).toBeVisible();
+    await expect(
+      adminPage.getByRole('navigation').getByRole('link', { name: 'Agents', exact: true }),
+    ).toBeVisible();
   });
 
   test('regular user does not see admin nav links', async ({ userPage }) => {
@@ -24,7 +26,9 @@ test.describe('Admin access control', () => {
     // A non-admin/non-audit user gets no Admin▾ menu at all.
     await expect(userPage.getByRole('button', { name: 'Admin', exact: true })).not.toBeVisible();
     // Agent Pools is visible to all users (RBAC-filtered server-side)
-    await expect(userPage.locator('nav >> text=Agents')).toBeVisible();
+    await expect(
+      userPage.getByRole('navigation').getByRole('link', { name: 'Agents', exact: true }),
+    ).toBeVisible();
   });
 
   test('admin can access roles page', async ({ adminPage }) => {

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -14,7 +14,7 @@ test.describe('Admin access control', () => {
     await expect(adminPage.getByRole('menuitem', { name: 'Users' })).toBeVisible();
     await adminPage.keyboard.press('Escape');
     // Agent Pools stays top-level (visible to all users).
-    await expect(adminPage.locator('nav >> text=Agent Pools')).toBeVisible();
+    await expect(adminPage.locator('nav >> text=Agents')).toBeVisible();
   });
 
   test('regular user does not see admin nav links', async ({ userPage }) => {
@@ -24,7 +24,7 @@ test.describe('Admin access control', () => {
     // A non-admin/non-audit user gets no Admin▾ menu at all.
     await expect(userPage.getByRole('button', { name: 'Admin', exact: true })).not.toBeVisible();
     // Agent Pools is visible to all users (RBAC-filtered server-side)
-    await expect(userPage.locator('nav >> text=Agent Pools')).toBeVisible();
+    await expect(userPage.locator('nav >> text=Agents')).toBeVisible();
   });
 
   test('admin can access roles page', async ({ adminPage }) => {

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -92,9 +92,12 @@ test.describe('Authentication', () => {
       timeout: 15_000,
     });
 
-    // Log out now lives inside the Account menu (whose desktop trigger is
-    // labelled with the signed-in user's email) — #719 grouped-nav IA.
-    await page.getByRole('button', { name: ADMIN_EMAIL }).click();
+    // Log out lives inside the Account menu. Its trigger is icon-only and
+    // labelled "Account": the signed-in identity moved off the toolbar and
+    // into the menu itself to buy back width (#1400). Assert it is still
+    // shown there — the point of the move was to relocate it, not lose it.
+    await page.getByRole('button', { name: 'Account' }).click();
+    await expect(page.getByRole('menu')).toContainText(ADMIN_EMAIL);
     await page.getByRole('menuitem', { name: 'Log out' }).click();
 
     // Should redirect to /login

--- a/e2e/tests/ha.spec.ts
+++ b/e2e/tests/ha.spec.ts
@@ -163,7 +163,7 @@ test.describe('HA page — replication', () => {
 test.describe('HA page — runner readiness', () => {
   const pools = (
     page: Page,
-    list: Array<{ name: string; status: string; listeners?: number }>,
+    list: Array<{ name: string; status: string; listeners?: number; pods?: number }>,
   ) =>
     page.route('**/api/terrapod/v1/agent-pools*', (route: Route) =>
       route.fulfill({
@@ -176,6 +176,9 @@ test.describe('HA page — runner readiness', () => {
               name: p.name,
               status: p.status,
               'listener-count': p.listeners ?? (p.status === 'online' ? 1 : 0),
+              // Omitted when undefined, which is the real server's way of
+              // saying "unknown" for a listener too old to report its pod.
+              ...(p.pods === undefined ? {} : { 'listener-pod-count': p.pods }),
             },
           })),
           meta: {},
@@ -199,6 +202,41 @@ test.describe('HA page — runner readiness', () => {
     // materially different answers to "can I fail over onto this".
     await expect(page.getByText('3 listeners', { exact: true })).toBeVisible();
     await expect(page.getByText('No live listener', { exact: true })).toBeVisible();
+  });
+
+  test('pods are shown, so a redundant pair does not read as a single listener', async ({
+    page,
+  }) => {
+    // The defect this replaced (#1402): replicas of one Deployment share a
+    // listener identity, so a two-pod pool reports one listener. On the page
+    // whose job is finding single points of failure, that is the wrong answer
+    // to the only question being asked.
+    await mockHA(page, BASE_STATUS);
+    await pools(page, [
+      { name: 'redundant', status: 'online', listeners: 1, pods: 2 },
+      { name: 'lonely', status: 'online', listeners: 1, pods: 1 },
+    ]);
+    await page.goto('/ha');
+
+    await expect(page.getByText('1 listener · 2 pods', { exact: true })).toBeVisible();
+    await expect(page.getByText('1 listener · 1 pod', { exact: true })).toBeVisible();
+    // Exactly one warning: the one-pod pool earns it, the pair does not.
+    await expect(page.getByText('Single pod', { exact: true })).toHaveCount(1);
+  });
+
+  test('a listener that cannot report pods shows the listener count, not a false zero', async ({
+    page,
+  }) => {
+    // A pre-0.19.0 listener never sends its pod name. Rendering that as
+    // "0 pods" would invent an outage on a pool that is running fine — the
+    // same lie as the one above, pointing the other way.
+    await mockHA(page, BASE_STATUS);
+    await pools(page, [{ name: 'legacy', status: 'online', listeners: 2 }]);
+    await page.goto('/ha');
+
+    await expect(page.getByText('2 listeners', { exact: true })).toBeVisible();
+    await expect(page.getByText(/0 pods/)).toHaveCount(0);
+    await expect(page.getByText('Single pod', { exact: true })).toHaveCount(0);
   });
 
   test('all pools online raises nothing', async ({ page }) => {

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -5,13 +5,23 @@ test.describe('Navigation', () => {
     await page.goto('/workspaces');
 
     // Terrapod logo/brand should be visible in nav
-    await expect(page.locator('nav >> text=Terrapod').first()).toBeVisible();
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: /terrapod/i }).first(),
+    ).toBeVisible();
 
     // Primary nav links stay visible on desktop (#719 IA); Modules/Providers
     // now live behind the Registry▾ dropdown, so assert the trigger instead.
-    await expect(page.locator('nav >> text=Workspaces').first()).toBeVisible();
+    // By role, not by text. The bar renders an aria-hidden measurement copy
+    // of itself (#1400) that is clipped to zero size, so a text locator finds
+    // that first and never sees it. Role queries skip aria-hidden, and the
+    // accessible name holds whether the bar is showing labels or icons.
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: 'Workspaces', exact: true }),
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Registry' })).toBeVisible();
-    await expect(page.locator('nav >> text=Catalog').first()).toBeVisible();
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: 'Catalog', exact: true }),
+    ).toBeVisible();
   });
 
   test('navigate between pages', async ({ page }) => {
@@ -32,7 +42,8 @@ test.describe('Navigation', () => {
     await expect(page.locator('h1:has-text("Providers")')).toBeVisible();
 
     // Navigate back to workspaces (top-level link)
-    await page.locator('nav >> text=Workspaces').first().click();
+    await page.getByRole('navigation')
+      .getByRole('link', { name: 'Workspaces', exact: true }).click();
     await page.waitForURL('**/workspaces');
     await expect(page.locator('h1:has-text("Workspaces")')).toBeVisible();
   });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -503,10 +503,16 @@ test.describe('Responsive harness (phone viewport)', () => {
 test.describe('Tablet width (md–lg dead-zone, #839)', () => {
   test.use({ viewport: { width: 900, height: 900 }, isMobile: false });
 
-  test('nav stays a compact hamburger, no page h-scroll', async ({ page }) => {
+  test('nav shows the icon bar, not the hamburger, no page h-scroll', async ({ page }) => {
     await page.goto('/workspaces');
-    // Below lg the mobile hamburger is the nav; the desktop link row is hidden.
-    await expect(page.getByRole('button', { name: /open menu/i })).toBeVisible();
+    // #839 resolved this width by showing the hamburger; #1400 reversed that.
+    // The icon-only bar needs about 650px, so hiding it here hid a bar that
+    // fits. The nav now switches at md, where the rest of the UI switches to
+    // its phone treatment, so 900px is squarely desktop and gets the bar.
+    await expect(page.getByRole('button', { name: /open menu/i })).toBeHidden();
+    await expect(
+      page.getByRole('navigation').getByRole('link', { name: 'Workspaces', exact: true }),
+    ).toBeVisible();
     await expectNoHorizontalPageScroll(page);
   });
 

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -93,6 +93,7 @@ def _pool_json(
     status: str | None = None,
     permission: str | None = None,
     listener_count: int | None = None,
+    listener_pod_count: int | None = None,
 ) -> dict:
     """Format an AgentPool as JSON:API.
 
@@ -106,6 +107,14 @@ def _pool_json(
     so counting it would inflate the number an operator is using to decide
     whether a pool has capacity. It rides along with `status` for free: both
     come from one already-fetched list, so no endpoint gains a round trip.
+
+    `listener-pod-count` (#1402) is how many PODS back those listeners. The two
+    differ, and the difference is the whole point: replicas of one Deployment
+    share a listener identity, so a redundant pair reports `listener-count: 1`.
+    Reading that as "one listener, therefore a single point of failure" is
+    exactly wrong, and it is the reading /ha invited. None means unknown rather
+    than zero — a listener on a pre-0.19.0 image does not report its pod name,
+    and guessing zero for it would invent an outage.
     """
     attrs: dict = {
         "name": pool.name,
@@ -119,6 +128,8 @@ def _pool_json(
         attrs["status"] = status
     if listener_count is not None:
         attrs["listener-count"] = listener_count
+    if listener_pod_count is not None:
+        attrs["listener-pod-count"] = listener_pod_count
     if permission is not None:
         attrs["permission"] = permission
     return {
@@ -208,6 +219,26 @@ def _live_listener_count(listeners: list[dict]) -> int:
     counting it would tell an operator they have capacity they do not have.
     """
     return sum(1 for item in listeners if _derive_listener_status(item) == "online")
+
+
+async def _live_listener_pod_count(listeners: list[dict]) -> int | None:
+    """Total pods backing the usable listeners of a pool.
+
+    Same predicate as `_live_listener_count`, so the pod figure and the listener
+    figure always describe the same set. Returns None when no usable listener
+    reports pod tracking — unknown, not zero: pre-0.19.0 images never send a pod
+    name, and showing them as zero pods would read as an outage that is not
+    happening.
+    """
+    tracking = {
+        item["id"]
+        for item in listeners
+        if _derive_listener_status(item) == "online" and item.get("tracks_pods") == "1"
+    }
+    if not tracking:
+        return None
+    counts = await agent_pool_service.count_listener_replicas_bulk(tracking)
+    return sum(counts.get(lid, 0) for lid in tracking)
 
 
 def _listener_json(listener: dict, replica_count: int | None = None) -> dict:
@@ -306,7 +337,7 @@ async def list_pools(
     pools = await agent_pool_service.list_pools(db)
     # Pre-fetch custom roles once to avoid N+1 queries
     custom_roles = await fetch_custom_roles(db, user.roles)
-    result = []
+    visible: list[tuple] = []
     for p in pools:
         caps = await resolve_pool_capabilities_for(
             db,
@@ -325,12 +356,35 @@ async def list_pools(
         # not enough — a listener with an expired cert keeps heartbeating but
         # 401s every authenticated call, so we cross-check cert expiry too.
         status = _derive_pool_status(listeners)
+        visible.append((p, perm, status, listeners))
+
+    # Pod counts for every visible pool in ONE scan. Calling the per-pool helper
+    # inside the loop above would issue a keyspace scan per pool, which is the
+    # O(N)-per-request shape this endpoint exists on the right side of.
+    tracking = {
+        item["id"]
+        for _, _, _, listeners in visible
+        for item in listeners
+        if _derive_listener_status(item) == "online" and item.get("tracks_pods") == "1"
+    }
+    pod_counts = await agent_pool_service.count_listener_replicas_bulk(tracking) if tracking else {}
+
+    result = []
+    for p, perm, status, listeners in visible:
+        ids = [
+            item["id"]
+            for item in listeners
+            if _derive_listener_status(item) == "online" and item.get("tracks_pods") == "1"
+        ]
         result.append(
             _pool_json(
                 p,
                 status=status,
                 permission=perm,
                 listener_count=_live_listener_count(listeners),
+                # None, not 0, when nothing in this pool tracks pods — unknown
+                # is not an outage.
+                listener_pod_count=(sum(pod_counts.get(i, 0) for i in ids) if ids else None),
             )
         )
     page_items, meta = paginate(result, request)
@@ -381,6 +435,7 @@ async def show_pool(
                 status=status,
                 permission=perm,
                 listener_count=_live_listener_count(listeners),
+                listener_pod_count=await _live_listener_pod_count(listeners),
             )
         }
     )

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -636,6 +636,32 @@ async def heartbeat_listener(
     await pipe.execute()
 
 
+async def count_listener_replicas_bulk(listener_ids: set[str]) -> dict[str, int]:
+    """Pod counts for many listeners in ONE scan.
+
+    `count_listener_replicas` scans the keyspace per listener, which is fine for
+    a single listener detail view and wrong for a list: a pools list would then
+    issue one SCAN per listener per request, and SCAN walks the whole keyspace
+    whatever the match pattern. That is the same O(N)-per-request shape that
+    made the workspace list the scalability bottleneck (#1056), so the list path
+    gets a single pass that buckets by listener id instead.
+
+    Ids absent from the result have no live pod keys; the caller decides whether
+    that means zero or unknown, since only it knows if the listener tracks pods.
+    """
+    redis = get_redis_client()
+    counts: dict[str, int] = {}
+    async for key in redis.scan_iter(match=f"{_LISTENER_POD_PREFIX}*", count=200):
+        # tp:listener_pod:{listener_id}:{pod_name} — pod names contain no ":",
+        # but listener ids are UUIDs, so split off the known prefix and take the
+        # first remaining segment rather than assuming a field count.
+        rest = (key if isinstance(key, str) else key.decode()).removeprefix(_LISTENER_POD_PREFIX)
+        listener_id = rest.split(":", 1)[0]
+        if listener_id in listener_ids:
+            counts[listener_id] = counts.get(listener_id, 0) + 1
+    return counts
+
+
 async def count_listener_replicas(listener_id: str) -> int:
     """Return the number of pods currently heartbeating for this listener.
 

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -13,6 +13,7 @@
     "description",
     "labels",
     "listener-count",
+    "listener-pod-count",
     "name",
     "owner-email",
     "permission",

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -1237,3 +1237,74 @@ class TestListenerCount:
             assert (status == "online") == (count > 0), (
                 f"status {status!r} disagrees with count {count} for {listeners}"
             )
+
+
+class TestLiveListenerPodCount:
+    """Pods behind a pool's listeners (#1402).
+
+    `listener-count` counts listener identities, and replicas of one Deployment
+    share an identity — so a redundant pair reports one listener. On /ha, the
+    page whose job is finding single points of failure, that read as exactly
+    the failure it was not. These pin the distinction the fix rests on.
+    """
+
+    @staticmethod
+    def _listener(lid: str, *, tracks: bool = True, expired: bool = False) -> dict:
+        exp = datetime.now(UTC) + timedelta(days=-1 if expired else 30)
+        item = {
+            "id": lid,
+            "name": lid,
+            # The heartbeat writes this blindly; cert expiry is what downgrades
+            # it, which is the case the "expired" fixture below exercises.
+            "status": "online",
+            "last_heartbeat": datetime.now(UTC).isoformat(),
+            "certificate_expires_at": exp.isoformat(),
+        }
+        if tracks:
+            item["tracks_pods"] = "1"
+        return item
+
+    async def test_sums_pods_across_listeners(self):
+        from terrapod.api.routers.agent_pools import _live_listener_pod_count
+
+        listeners = [self._listener("aaa"), self._listener("bbb")]
+        with patch(
+            "terrapod.api.routers.agent_pools.agent_pool_service.count_listener_replicas_bulk",
+            AsyncMock(return_value={"aaa": 2, "bbb": 1}),
+        ):
+            assert await _live_listener_pod_count(listeners) == 3
+
+    async def test_unknown_not_zero_when_nothing_tracks_pods(self):
+        # A pre-0.19.0 listener never sends its pod name. Reporting it as zero
+        # pods would render as an outage on a pool that is running fine, which
+        # is the same lie in the opposite direction.
+        from terrapod.api.routers.agent_pools import _live_listener_pod_count
+
+        listeners = [self._listener("old", tracks=False)]
+        assert await _live_listener_pod_count(listeners) is None
+
+    async def test_excludes_listeners_that_cannot_take_work(self):
+        # Same predicate as the listener count, so the two figures always
+        # describe the same set. A cert-expired listener heartbeats but 401s
+        # every call, so its pods are not capacity.
+        from terrapod.api.routers.agent_pools import _live_listener_pod_count
+
+        listeners = [self._listener("good"), self._listener("dead", expired=True)]
+        with patch(
+            "terrapod.api.routers.agent_pools.agent_pool_service.count_listener_replicas_bulk",
+            AsyncMock(return_value={"good": 2}),
+        ) as bulk:
+            assert await _live_listener_pod_count(listeners) == 2
+        assert bulk.await_args.args[0] == {"good"}
+
+    async def test_zero_pods_is_reported_when_tracking(self):
+        # Tracking but no live pod keys IS meaningful: the listener hash is
+        # alive while every pod has stopped heartbeating. That is zero, not
+        # unknown, and the operator should see it.
+        from terrapod.api.routers.agent_pools import _live_listener_pod_count
+
+        with patch(
+            "terrapod.api.routers.agent_pools.agent_pool_service.count_listener_replicas_bulk",
+            AsyncMock(return_value={}),
+        ):
+            assert await _live_listener_pod_count([self._listener("aaa")]) == 0

--- a/services/tests/services/test_agent_pool_service.py
+++ b/services/tests/services/test_agent_pool_service.py
@@ -13,6 +13,7 @@ from terrapod.services.agent_pool_service import (
     _fingerprint_ttl,
     _register_fingerprint,
     count_listener_replicas,
+    count_listener_replicas_bulk,
     create_pool_token,
     generate_join_token,
     heartbeat_listener,
@@ -635,3 +636,60 @@ class TestFingerprintMigrationFallback:
             return_value=mock_redis,
         ):
             assert await is_fingerprint_valid("lid-x", "fp") is False
+
+
+class TestCountListenerReplicasBulk:
+    """Pod counts for many listeners in one scan (#1402).
+
+    The bulk path exists so a pools list does not issue a keyspace scan per
+    pool. These pin the two things that would silently break it: that it
+    buckets keys to the right listener, and that it ignores listeners the
+    caller did not ask about — a shared Redis holds pod keys for every
+    listener, so summing indiscriminately would inflate every pool's count.
+    """
+
+    @pytest.mark.asyncio
+    async def test_buckets_pods_by_listener(self):
+        keys = [
+            "tp:listener_pod:aaa:pod-1",
+            "tp:listener_pod:aaa:pod-2",
+            "tp:listener_pod:bbb:pod-1",
+        ]
+
+        async def fake_scan_iter(match=None, count=None):
+            for k in keys:
+                yield k
+
+        redis = MagicMock()
+        redis.scan_iter = fake_scan_iter
+        with patch("terrapod.services.agent_pool_service.get_redis_client", return_value=redis):
+            counts = await count_listener_replicas_bulk({"aaa", "bbb"})
+        assert counts == {"aaa": 2, "bbb": 1}
+
+    @pytest.mark.asyncio
+    async def test_ignores_listeners_not_asked_for(self):
+        # A listener belonging to a pool the caller cannot see, or simply not
+        # in this page, must not be added to anyone's total.
+        async def fake_scan_iter(match=None, count=None):
+            for k in ["tp:listener_pod:aaa:pod-1", "tp:listener_pod:zzz:pod-9"]:
+                yield k
+
+        redis = MagicMock()
+        redis.scan_iter = fake_scan_iter
+        with patch("terrapod.services.agent_pool_service.get_redis_client", return_value=redis):
+            counts = await count_listener_replicas_bulk({"aaa"})
+        assert counts == {"aaa": 1}
+        assert "zzz" not in counts
+
+    @pytest.mark.asyncio
+    async def test_pod_names_containing_colons_still_bucket(self):
+        # Pod names do not normally contain ":", but the parser must not depend
+        # on that — splitting on the wrong field would attribute pods to a
+        # listener id that does not exist, silently under-counting the real one.
+        async def fake_scan_iter(match=None, count=None):
+            yield "tp:listener_pod:aaa:pod:with:colons"
+
+        redis = MagicMock()
+        redis.scan_iter = fake_scan_iter
+        with patch("terrapod.services.agent_pool_service.get_redis_client", return_value=redis):
+            assert await count_listener_replicas_bulk({"aaa"}) == {"aaa": 1}

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -2972,7 +2972,9 @@
       "online": "المستمع متصل",
       "offline": "لا يوجد مستمع نشط",
       "offlineWarning": "لا يوجد مستمع متصل لـ: {pools}. عمليات التشغيل الموجّهة إلى هذه المجمّعات ستنتظر في الطابور بدلاً من أن تُنفَّذ.",
-      "count": "{count, plural, zero {لا مستمعين} one {مستمع واحد} two {مستمعان} few {# مستمعين} many {# مستمعاً} other {# مستمع}}"
+      "count": "{count, plural, zero {لا مستمعين} one {مستمع واحد} two {مستمعان} few {# مستمعين} many {# مستمعاً} other {# مستمع}}",
+      "countWithPods": "{count, plural, one {مستمع واحد} other {# مستمعين}} · {pods, plural, one {جراب واحد} other {# أجربة}}",
+      "singlePod": "جراب واحد"
     },
     "inbound": "يقبل من النظير",
     "inboundAwaiting": "مُسمّى، بلا سر"

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -6,7 +6,7 @@
     "modules": "الوحدات",
     "providers": "المزوّدون",
     "catalog": "الكتالوج",
-    "agentPools": "تجمّعات الوكلاء",
+    "agentPools": "الوكلاء",
     "admin": "الإدارة",
     "users": "المستخدمون",
     "roles": "الأدوار",
@@ -32,7 +32,8 @@
     "openAccountMenu": "فتح قائمة الحساب",
     "closeMenu": "إغلاق القائمة",
     "ha": "التوافر العالي",
-    "deletedWorkspaces": "مساحات العمل المحذوفة"
+    "deletedWorkspaces": "مساحات العمل المحذوفة",
+    "version": "الإصدار {version}"
   },
   "switcher": {
     "language": "اللغة",

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -6,7 +6,7 @@
     "modules": "Moduly",
     "providers": "Provideři",
     "catalog": "Katalog",
-    "agentPools": "Fondy agentů",
+    "agentPools": "Agenti",
     "admin": "Správa",
     "users": "Uživatelé",
     "roles": "Role",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Otevřít nabídku účtu",
     "closeMenu": "Zavřít nabídku",
     "ha": "Vysoká dostupnost",
-    "deletedWorkspaces": "Smazané pracovní prostory"
+    "deletedWorkspaces": "Smazané pracovní prostory",
+    "version": "Verze {version}"
   },
   "switcher": {
     "language": "Jazyk",

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Žádný živý listener",
       "offlineWarning": "K těmto fondům není připojen žádný listener: {pools}. Běhy směrované do nich se zařadí do fronty místo spuštění.",
-      "count": "{count, plural, one {# listener} few {# listenery} many {# listeneru} other {# listenerů}}"
+      "count": "{count, plural, one {# listener} few {# listenery} many {# listeneru} other {# listenerů}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listenerů}} · {pods, plural, one {# pod} other {# podů}}",
+      "singlePod": "Jediný pod"
     },
     "inbound": "Přijímá od protějšku",
     "inboundAwaiting": "Pojmenováno, bez tajemství"

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -2972,7 +2972,9 @@
       "online": "Gwrandäwr ar-lein",
       "offline": "Dim gwrandäwr byw",
       "offlineWarning": "Nid oes gwrandäwr wedi'i gysylltu ar gyfer: {pools}. Bydd rhediadau a anfonir i'r pyllau hyn yn ciwio yn hytrach na rhedeg.",
-      "count": "{count, plural, one {# gwrandäwr} other {# gwrandäwr}}"
+      "count": "{count, plural, one {# gwrandäwr} other {# gwrandäwr}}",
+      "countWithPods": "{count, plural, one {# gwrandäwr} other {# gwrandawyr}} · {pods, plural, one {# pod} other {# pod}}",
+      "singlePod": "Un pod"
     },
     "inbound": "Derbyn gan y partner",
     "inboundAwaiting": "Wedi'i enwi, dim cyfrinach"

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -6,7 +6,7 @@
     "modules": "Modiwlau",
     "providers": "Darparwyr",
     "catalog": "Catalog",
-    "agentPools": "Pyllau Asiantau",
+    "agentPools": "Asiantau",
     "admin": "Gweinyddu",
     "users": "Defnyddwyr",
     "roles": "Rolau",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Agor dewislen y cyfrif",
     "closeMenu": "Cau'r ddewislen",
     "ha": "Argaeledd uchel",
-    "deletedWorkspaces": "Gweithfannau wedi''u dileu"
+    "deletedWorkspaces": "Gweithfannau wedi''u dileu",
+    "version": "Fersiwn {version}"
   },
   "switcher": {
     "language": "Iaith",

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Ingen levende listener",
       "offlineWarning": "Ingen listener er forbundet for: {pools}. Kørsler til disse puljer sættes i kø i stedet for at køre.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listenere}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Enkelt pod"
     },
     "inbound": "Accepterer fra peer",
     "inboundAwaiting": "Navngivet, ingen hemmelighed"

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -6,7 +6,7 @@
     "modules": "Moduler",
     "providers": "Providere",
     "catalog": "Katalog",
-    "agentPools": "Agentpuljer",
+    "agentPools": "Agenter",
     "admin": "Administration",
     "users": "Brugere",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Åbn kontomenu",
     "closeMenu": "Luk menu",
     "ha": "Høj tilgængelighed",
-    "deletedWorkspaces": "Slettede arbejdsområder"
+    "deletedWorkspaces": "Slettede arbejdsområder",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Sprog",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Kein aktiver Listener",
       "offlineWarning": "Für Folgendes ist kein Listener verbunden: {pools}. Läufe für diese Pools warten in der Warteschlange, statt ausgeführt zu werden.",
-      "count": "{count, plural, one {# Listener} other {# Listener}}"
+      "count": "{count, plural, one {# Listener} other {# Listener}}",
+      "countWithPods": "{count, plural, one {# Listener} other {# Listener}} · {pods, plural, one {# Pod} other {# Pods}}",
+      "singlePod": "Einzelner Pod"
     },
     "inbound": "Akzeptiert vom Partner",
     "inboundAwaiting": "Benannt, kein Secret"

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -5,9 +5,9 @@
     "registry": "Registry",
     "modules": "Module",
     "providers": "Anbieter",
-    "catalog": "Dienstleistungskatalog",
-    "agentPools": "Agent-Pools",
-    "admin": "Verwaltung",
+    "catalog": "Katalog",
+    "agentPools": "Agenten",
+    "admin": "Admin",
     "users": "Benutzer",
     "roles": "Rollen",
     "vcsConnections": "VCS-Verbindungen",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Kontomenü öffnen",
     "closeMenu": "Menü schließen",
     "ha": "Hochverfügbarkeit",
-    "deletedWorkspaces": "Gelöschte Workspaces"
+    "deletedWorkspaces": "Gelöschte Workspaces",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Sprache",

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -2972,7 +2972,9 @@
       "online": "L1573n3r 0nl1n3",
       "offline": "N0 l1v3 l1573n3r",
       "offlineWarning": "N0 l1573n3r 15 c0nn3c73d f0r: {pools}. Run5 r0u73d 70 7h353 p00l5 w1ll qu3u3 r47h3r 7h4n 3x3cu73.",
-      "count": "{count, plural, one {# l1573n3r} other {# l1573n3r5}}"
+      "count": "{count, plural, one {# l1573n3r} other {# l1573n3r5}}",
+      "countWithPods": "{count, plural, one {# l1573n3r} other {# l1573n3r5}} · {pods, plural, one {# p0d} other {# p0d5}}",
+      "singlePod": "51ng13 p0d"
     },
     "inbound": "4cc3p75 fr0m p33r",
     "inboundAwaiting": "N4m3d, n0 53cr37"

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -6,7 +6,7 @@
     "modules": "M0dul35",
     "providers": "Pr0v1d3r5",
     "catalog": "C474l0g",
-    "agentPools": "4g3n7 P00l5",
+    "agentPools": "4g3n75",
     "admin": "4dm1n",
     "users": "U53r5",
     "roles": "R0l35",
@@ -32,7 +32,8 @@
     "openAccountMenu": "0p3n 4cc0un7 m3nu",
     "closeMenu": "Cl053 m3nu",
     "ha": "H1gh 4v41l4b1l17y",
-    "deletedWorkspaces": "D3l373d w0rk5p4c35"
+    "deletedWorkspaces": "D3l373d w0rk5p4c35",
+    "version": "V3r510n {version}"
   },
   "switcher": {
     "language": "L4ngu4g3",

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -6,7 +6,7 @@
     "modules": "Moduls",
     "providers": "Providrs",
     "catalog": "Catalog",
-    "agentPools": "Agent Poolz",
+    "agentPools": "Agentz",
     "admin": "Admin",
     "users": "Userz",
     "roles": "Rolez",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Opun akkount menu",
     "closeMenu": "Cloze menu",
     "ha": "Hai Availabilitee",
-    "deletedWorkspaces": "Deletd Werkspacez"
+    "deletedWorkspaces": "Deletd Werkspacez",
+    "version": "Vershun {version}"
   },
   "switcher": {
     "language": "Langwidge",

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -2972,7 +2972,9 @@
       "online": "Listenr onlien",
       "offline": "No liv listenr",
       "offlineWarning": "No listenr iz connectd fur: {pools}. Runz sent to deze poolz will just sit in da queue insted ov runnin.",
-      "count": "{count, plural, one {# listenr} other {# listenrz}}"
+      "count": "{count, plural, one {# listenr} other {# listenrz}}",
+      "countWithPods": "{count, plural, one {# lisssner} other {# lisssnerz}} · {pods, plural, one {# pod} other {# podz}}",
+      "singlePod": "Only wun pod"
     },
     "inbound": "Takez frum budy",
     "inboundAwaiting": "Namd, no secrit"

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -2972,7 +2972,9 @@
       "online": "Marklar online",
       "offline": "No live marklar",
       "offlineWarning": "No marklar is connected for: {pools}. Marklars routed to these marklars will queue rather than execute.",
-      "count": "{count, plural, one {# marklar} other {# marklars}}"
+      "count": "{count, plural, one {# marklar} other {# marklars}}",
+      "countWithPods": "{count, plural, one {# marklar} other {# marklars}} · {pods, plural, one {# marklar} other {# marklars}}",
+      "singlePod": "Single marklar"
     },
     "inbound": "Accepts from marklar",
     "inboundAwaiting": "Named, no marklar"

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -6,7 +6,7 @@
     "modules": "Marklars",
     "providers": "Marklars",
     "catalog": "Marklar",
-    "agentPools": "Marklar Marklars",
+    "agentPools": "Marklars",
     "admin": "Marklar",
     "users": "Marklars",
     "roles": "Marklars",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Open marklar marklar",
     "closeMenu": "Close marklar",
     "ha": "High marklar",
-    "deletedWorkspaces": "Deleted marklars"
+    "deletedWorkspaces": "Deleted marklars",
+    "version": "Marklar {version}"
   },
   "switcher": {
     "language": "Marklar",

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalog",
-    "agentPools": "Agent Crews",
+    "agentPools": "Crew",
     "admin": "Admin",
     "users": "Crew",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Open yer account menu",
     "closeMenu": "Batten th'' menu",
     "ha": "Ever-Afloat",
-    "deletedWorkspaces": "Scuttled work-decks"
+    "deletedWorkspaces": "Scuttled work-decks",
+    "version": "Ship's mark {version}"
   },
   "switcher": {
     "language": "Tongue",

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -2972,7 +2972,9 @@
       "online": "Hand on watch",
       "offline": "No hand on watch",
       "offlineWarning": "Nary a hand be on watch for: {pools}. Voyages set for these crews will wait at anchor rather than sail.",
-      "count": "{count, plural, one {# hand on watch} other {# hands on watch}}"
+      "count": "{count, plural, one {# hand on watch} other {# hands on watch}}",
+      "countWithPods": "{count, plural, one {# lookout} other {# lookouts}} · {pods, plural, one {# hand} other {# hands}}",
+      "singlePod": "One hand only"
     },
     "inbound": "Accepts from consort",
     "inboundAwaiting": "Named, no token"

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalog",
-    "agentPools": "Pools, Agent",
+    "agentPools": "Agents",
     "admin": "Admin",
     "users": "Users",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "The account menu, open",
     "closeMenu": "The menu, close",
     "ha": "Availability, high",
-    "deletedWorkspaces": "Workspaces deleted"
+    "deletedWorkspaces": "Workspaces deleted",
+    "version": "Version {version}, this is"
   },
   "switcher": {
     "language": "Language",

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -2972,7 +2972,9 @@
       "online": "Online, the listener is",
       "offline": "Live listener, there is none",
       "offlineWarning": "Connected for these, no listener is: {pools}. Queue rather than execute, runs routed to these pools will.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listeners}} · {pods, plural, one {# pod} other {# pods}}, there are",
+      "singlePod": "Single pod, it is"
     },
     "inbound": "From peer, accepts",
     "inboundAwaiting": "Named it is, secret it has not"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalog",
-    "agentPools": "Agent Pools",
+    "agentPools": "Agents",
     "admin": "Admin",
     "users": "Users",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Open account menu",
     "closeMenu": "Close menu",
     "ha": "High availability",
-    "deletedWorkspaces": "Deleted workspaces"
+    "deletedWorkspaces": "Deleted workspaces",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Language",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "No live listener",
       "offlineWarning": "No listener is connected for: {pools}. Runs routed to these pools will queue rather than execute.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listeners}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Single pod"
     },
     "inbound": "Accepts from peer",
     "inboundAwaiting": "Named, no secret"

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -6,7 +6,7 @@
     "modules": "Módulos",
     "providers": "Proveedores",
     "catalog": "Catálogo",
-    "agentPools": "Grupos de agentes",
+    "agentPools": "Agentes",
     "admin": "Administración",
     "users": "Usuarios",
     "roles": "Roles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Abrir menú de cuenta",
     "closeMenu": "Cerrar menú",
     "ha": "Alta disponibilidad",
-    "deletedWorkspaces": "Workspaces eliminados"
+    "deletedWorkspaces": "Workspaces eliminados",
+    "version": "Versión {version}"
   },
   "switcher": {
     "language": "Idioma",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -2972,7 +2972,9 @@
       "online": "Listener en línea",
       "offline": "Sin listener activo",
       "offlineWarning": "No hay ningún listener conectado para: {pools}. Las ejecuciones dirigidas a estos grupos se encolarán en lugar de ejecutarse.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# escucha} other {# escuchas}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Pod único"
     },
     "inbound": "Acepta del par",
     "inboundAwaiting": "Nombrado, sin secreto"

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -6,7 +6,7 @@
     "modules": "ماژول‌ها",
     "providers": "ارائه‌دهندگان",
     "catalog": "کاتالوگ",
-    "agentPools": "استخرهای عامل",
+    "agentPools": "عامل‌ها",
     "admin": "مدیریت",
     "users": "کاربران",
     "roles": "نقش‌ها",
@@ -32,7 +32,8 @@
     "openAccountMenu": "باز کردن منوی حساب",
     "closeMenu": "بستن منو",
     "ha": "دسترس‌پذیری بالا",
-    "deletedWorkspaces": "فضاهای کاری حذف‌شده"
+    "deletedWorkspaces": "فضاهای کاری حذف‌شده",
+    "version": "نسخهٔ {version}"
   },
   "switcher": {
     "language": "زبان",

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -2972,7 +2972,9 @@
       "online": "شنونده آنلاین",
       "offline": "بدون شنونده فعال",
       "offlineWarning": "هیچ شنونده‌ای برای این‌ها متصل نیست: {pools}. اجراهای هدایت‌شده به این استخرها به‌جای اجرا در صف می‌مانند.",
-      "count": "{count} شنونده"
+      "count": "{count} شنونده",
+      "countWithPods": "{count, plural, one {# شنونده} other {# شنونده}} · {pods, plural, one {# پاد} other {# پاد}}",
+      "singlePod": "تک پاد"
     },
     "inbound": "از همتا می‌پذیرد",
     "inboundAwaiting": "نام‌گذاری‌شده، بدون رمز"

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -6,7 +6,7 @@
     "modules": "Moduulit",
     "providers": "Palveluntarjoajat",
     "catalog": "Luettelo",
-    "agentPools": "Agenttipoolit",
+    "agentPools": "Agentit",
     "admin": "Hallinta",
     "users": "Käyttäjät",
     "roles": "Roolit",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Avaa tilivalikko",
     "closeMenu": "Sulje valikko",
     "ha": "Korkea käytettävyys",
-    "deletedWorkspaces": "Poistetut työtilat"
+    "deletedWorkspaces": "Poistetut työtilat",
+    "version": "Versio {version}"
   },
   "switcher": {
     "language": "Kieli",

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -2972,7 +2972,9 @@
       "online": "Kuuntelija verkossa",
       "offline": "Ei elävää kuuntelijaa",
       "offlineWarning": "Yhtään kuuntelijaa ei ole yhdistetty näille: {pools}. Näihin altaisiin ohjatut ajot jäävät jonoon suorittamisen sijaan.",
-      "count": "{count, plural, one {# kuuntelija} other {# kuuntelijaa}}"
+      "count": "{count, plural, one {# kuuntelija} other {# kuuntelijaa}}",
+      "countWithPods": "{count, plural, one {# kuuntelija} other {# kuuntelijaa}} · {pods, plural, one {# podi} other {# podia}}",
+      "singlePod": "Yksi podi"
     },
     "inbound": "Hyväksyy parilta",
     "inboundAwaiting": "Nimetty, ei salaisuutta"

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -2972,7 +2972,9 @@
       "online": "Listener en ligne",
       "offline": "Aucun listener actif",
       "offlineWarning": "Aucun listener n'est connecté pour : {pools}. Les exécutions dirigées vers ces pools resteront en file d'attente.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# écouteur} other {# écouteurs}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Pod unique"
     },
     "inbound": "Accepte du pair",
     "inboundAwaiting": "Nommé, sans secret"

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Fournisseurs",
     "catalog": "Catalogue",
-    "agentPools": "Pools d'agents",
+    "agentPools": "Agents",
     "admin": "Administration",
     "users": "Utilisateurs",
     "roles": "Rôles",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Ouvrir le menu du compte",
     "closeMenu": "Fermer le menu",
     "ha": "Haute disponibilité",
-    "deletedWorkspaces": "Workspaces supprimés"
+    "deletedWorkspaces": "Workspaces supprimés",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Langue",

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -2972,7 +2972,9 @@
       "online": "מאזין מקוון",
       "offline": "אין מאזין פעיל",
       "offlineWarning": "אין מאזין מחובר עבור: {pools}. הרצות שמנותבות למאגרים אלה ימתינו בתור במקום לרוץ.",
-      "count": "{count, plural, one {מאזין אחד} two {שני מאזינים} other {# מאזינים}}"
+      "count": "{count, plural, one {מאזין אחד} two {שני מאזינים} other {# מאזינים}}",
+      "countWithPods": "{count, plural, one {מאזין אחד} other {# מאזינים}} · {pods, plural, one {פוד אחד} other {# פודים}}",
+      "singlePod": "פוד יחיד"
     },
     "inbound": "מקבל מהעמית",
     "inboundAwaiting": "נקוב בשם, ללא סוד"

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -6,7 +6,7 @@
     "modules": "מודולים",
     "providers": "ספקים",
     "catalog": "קטלוג",
-    "agentPools": "מאגרי סוכנים",
+    "agentPools": "סוכנים",
     "admin": "ניהול",
     "users": "משתמשים",
     "roles": "תפקידים",
@@ -32,7 +32,8 @@
     "openAccountMenu": "פתיחת תפריט חשבון",
     "closeMenu": "סגירת תפריט",
     "ha": "זמינות גבוהה",
-    "deletedWorkspaces": "סביבות עבודה שנמחקו"
+    "deletedWorkspaces": "סביבות עבודה שנמחקו",
+    "version": "גרסה {version}"
   },
   "switcher": {
     "language": "שפה",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Nessun listener attivo",
       "offlineWarning": "Nessun listener è connesso per: {pools}. Le esecuzioni indirizzate a questi pool resteranno in coda.",
-      "count": "{count, plural, one {# listener} other {# listener}}"
+      "count": "{count, plural, one {# listener} other {# listener}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listener}} · {pods, plural, one {# pod} other {# pod}}",
+      "singlePod": "Pod singolo"
     },
     "inbound": "Accetta dal peer",
     "inboundAwaiting": "Nominato, senza segreto"

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -6,7 +6,7 @@
     "modules": "Moduli",
     "providers": "Provider",
     "catalog": "Catalogo",
-    "agentPools": "Pool di agenti",
+    "agentPools": "Agenti",
     "admin": "Amministrazione",
     "users": "Utenti",
     "roles": "Ruoli",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Apri menu account",
     "closeMenu": "Chiudi menu",
     "ha": "Alta disponibilità",
-    "deletedWorkspaces": "Workspace eliminati"
+    "deletedWorkspaces": "Workspace eliminati",
+    "version": "Versione {version}"
   },
   "switcher": {
     "language": "Lingua",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -2972,7 +2972,9 @@
       "online": "リスナー稼働中",
       "offline": "稼働中のリスナーなし",
       "offlineWarning": "次のプールにリスナーが接続されていません: {pools}。これらのプールに割り当てられた実行は待機したままになります。",
-      "count": "リスナー {count} 個"
+      "count": "リスナー {count} 個",
+      "countWithPods": "{count, plural, other {リスナー #}} · {pods, plural, other {ポッド #}}",
+      "singlePod": "単一ポッド"
     },
     "inbound": "ピアから受け入れ",
     "inboundAwaiting": "名前のみ、シークレット未設定"

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -6,7 +6,7 @@
     "modules": "モジュール",
     "providers": "プロバイダー",
     "catalog": "カタログ",
-    "agentPools": "エージェントプール",
+    "agentPools": "エージェント",
     "admin": "管理",
     "users": "ユーザー",
     "roles": "ロール",
@@ -32,7 +32,8 @@
     "openAccountMenu": "アカウントメニューを開く",
     "closeMenu": "メニューを閉じる",
     "ha": "高可用性",
-    "deletedWorkspaces": "削除されたワークスペース"
+    "deletedWorkspaces": "削除されたワークスペース",
+    "version": "バージョン {version}"
   },
   "switcher": {
     "language": "言語",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -2972,7 +2972,9 @@
       "online": "리스너 온라인",
       "offline": "활성 리스너 없음",
       "offlineWarning": "다음 풀에 연결된 리스너가 없습니다: {pools}. 이 풀로 보내진 실행은 수행되지 않고 대기합니다.",
-      "count": "리스너 {count}개"
+      "count": "리스너 {count}개",
+      "countWithPods": "{count, plural, other {리스너 #개}} · {pods, plural, other {파드 #개}}",
+      "singlePod": "단일 파드"
     },
     "inbound": "피어로부터 수락",
     "inboundAwaiting": "이름만 있고 시크릿 없음"

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -6,7 +6,7 @@
     "modules": "모듈",
     "providers": "프로바이더",
     "catalog": "카탈로그",
-    "agentPools": "에이전트 풀",
+    "agentPools": "에이전트",
     "admin": "관리자",
     "users": "사용자",
     "roles": "역할",
@@ -32,7 +32,8 @@
     "openAccountMenu": "계정 메뉴 열기",
     "closeMenu": "메뉴 닫기",
     "ha": "고가용성",
-    "deletedWorkspaces": "삭제된 워크스페이스"
+    "deletedWorkspaces": "삭제된 워크스페이스",
+    "version": "버전 {version}"
   },
   "switcher": {
     "language": "언어",

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -6,7 +6,7 @@
     "modules": "Moduli",
     "providers": "Praebitores",
     "catalog": "Catalogus",
-    "agentPools": "Copiae Actorum",
+    "agentPools": "Agentes",
     "admin": "Administratio",
     "users": "Usores",
     "roles": "Partes",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Indicem rationis aperire",
     "closeMenu": "Indicem claudere",
     "ha": "Alta disponibilitas",
-    "deletedWorkspaces": "Loca operis deleta"
+    "deletedWorkspaces": "Loca operis deleta",
+    "version": "Versio {version}"
   },
   "switcher": {
     "language": "Lingua",

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -2972,7 +2972,9 @@
       "online": "Auditor vivus",
       "offline": "Nullus auditor vivus",
       "offlineWarning": "Nullus auditor his coniunctus est: {pools}. Cursus ad has piscinas missi in ordine manebunt neque exsequentur.",
-      "count": "{count, plural, one {# auditor} other {# auditores}}"
+      "count": "{count, plural, one {# auditor} other {# auditores}}",
+      "countWithPods": "{count, plural, one {# auscultator} other {# auscultatores}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Pod singularis"
     },
     "inbound": "A pari accipit",
     "inboundAwaiting": "Nominatum, sine arcano"

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Ingen levende listener",
       "offlineWarning": "Ingen listener er tilkoblet for: {pools}. Kjøringer til disse poolene havner i kø i stedet for å kjøre.",
-      "count": "{count, plural, one {# listener} other {# listenere}}"
+      "count": "{count, plural, one {# listener} other {# listenere}}",
+      "countWithPods": "{count, plural, one {# lytter} other {# lyttere}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Én pod"
     },
     "inbound": "Godtar fra peer",
     "inboundAwaiting": "Navngitt, ingen hemmelighet"

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -6,7 +6,7 @@
     "modules": "Moduler",
     "providers": "Leverandører",
     "catalog": "Katalog",
-    "agentPools": "Agentpuljer",
+    "agentPools": "Agenter",
     "admin": "Admin",
     "users": "Brukere",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Åpne kontomeny",
     "closeMenu": "Lukk meny",
     "ha": "Høy tilgjengelighet",
-    "deletedWorkspaces": "Slettede arbeidsområder"
+    "deletedWorkspaces": "Slettede arbeidsområder",
+    "version": "Versjon {version}"
   },
   "switcher": {
     "language": "Språk",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Geen actieve listener",
       "offlineWarning": "Er is geen listener verbonden voor: {pools}. Runs naar deze pools komen in de wachtrij in plaats van te draaien.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listeners}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Eén pod"
     },
     "inbound": "Accepteert van peer",
     "inboundAwaiting": "Benoemd, geen secret"

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -6,7 +6,7 @@
     "modules": "Modules",
     "providers": "Providers",
     "catalog": "Catalogus",
-    "agentPools": "Agent-pools",
+    "agentPools": "Agents",
     "admin": "Beheer",
     "users": "Gebruikers",
     "roles": "Rollen",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Accountmenu openen",
     "closeMenu": "Menu sluiten",
     "ha": "Hoge beschikbaarheid",
-    "deletedWorkspaces": "Verwijderde workspaces"
+    "deletedWorkspaces": "Verwijderde workspaces",
+    "version": "Versie {version}"
   },
   "switcher": {
     "language": "Taal",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -6,7 +6,7 @@
     "modules": "Moduły",
     "providers": "Dostawcy",
     "catalog": "Katalog",
-    "agentPools": "Pule agentów",
+    "agentPools": "Agenci",
     "admin": "Administracja",
     "users": "Użytkownicy",
     "roles": "Role",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Otwórz menu konta",
     "closeMenu": "Zamknij menu",
     "ha": "Wysoka dostępność",
-    "deletedWorkspaces": "Usunięte przestrzenie robocze"
+    "deletedWorkspaces": "Usunięte przestrzenie robocze",
+    "version": "Wersja {version}"
   },
   "switcher": {
     "language": "Język",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Brak żywego listenera",
       "offlineWarning": "Żaden listener nie jest podłączony do: {pools}. Uruchomienia kierowane do tych pul trafią do kolejki zamiast się wykonać.",
-      "count": "{count, plural, one {# listener} few {# listenery} many {# listenerów} other {# listenera}}"
+      "count": "{count, plural, one {# listener} few {# listenery} many {# listenerów} other {# listenera}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listenery}} · {pods, plural, one {# pod} other {# pody}}",
+      "singlePod": "Jeden pod"
     },
     "inbound": "Akceptuje od partnera",
     "inboundAwaiting": "Nazwany, bez sekretu"

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -2972,7 +2972,9 @@
       "online": "Listener on-line",
       "offline": "Sem listener ativo",
       "offlineWarning": "Nenhum listener está conectado para: {pools}. Execuções direcionadas a esses pools ficarão na fila em vez de rodar.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listeners}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Pod único"
     },
     "inbound": "Aceita do par",
     "inboundAwaiting": "Nomeado, sem segredo"

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -6,8 +6,8 @@
     "modules": "Módulos",
     "providers": "Providers",
     "catalog": "Catálogo",
-    "agentPools": "Agent Pools",
-    "admin": "Administração",
+    "agentPools": "Agentes",
+    "admin": "Admin",
     "users": "Usuários",
     "roles": "Funções",
     "vcsConnections": "Conexões VCS",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Abrir menu da conta",
     "closeMenu": "Fechar menu",
     "ha": "Alta disponibilidade",
-    "deletedWorkspaces": "Workspaces excluídos"
+    "deletedWorkspaces": "Workspaces excluídos",
+    "version": "Versão {version}"
   },
   "switcher": {
     "language": "Idioma",

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Sem listener ativo",
       "offlineWarning": "Não há qualquer listener ligado para: {pools}. As execuções encaminhadas para estes pools ficarão em fila em vez de correr.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# listener} other {# listeners}} · {pods, plural, one {# pod} other {# pods}}",
+      "singlePod": "Pod único"
     },
     "inbound": "Aceita do par",
     "inboundAwaiting": "Nomeado, sem segredo"

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -6,8 +6,8 @@
     "modules": "Módulos",
     "providers": "Providers",
     "catalog": "Catálogo",
-    "agentPools": "Agent Pools",
-    "admin": "Administração",
+    "agentPools": "Agentes",
+    "admin": "Admin",
     "users": "Utilizadores",
     "roles": "Funções",
     "vcsConnections": "Ligações VCS",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Abrir menu da conta",
     "closeMenu": "Fechar menu",
     "ha": "Alta disponibilidade",
-    "deletedWorkspaces": "Workspaces eliminados"
+    "deletedWorkspaces": "Workspaces eliminados",
+    "version": "Versão {version}"
   },
   "switcher": {
     "language": "Idioma",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -2972,7 +2972,9 @@
       "online": "Слушатель в сети",
       "offline": "Нет живого слушателя",
       "offlineWarning": "Ни один слушатель не подключён для: {pools}. Запуски, направленные в эти пулы, встанут в очередь, а не выполнятся.",
-      "count": "{count, plural, one {# слушатель} few {# слушателя} many {# слушателей} other {# слушателя}}"
+      "count": "{count, plural, one {# слушатель} few {# слушателя} many {# слушателей} other {# слушателя}}",
+      "countWithPods": "{count, plural, one {# слушатель} other {# слушателей}} · {pods, plural, one {# под} other {# подов}}",
+      "singlePod": "Один под"
     },
     "inbound": "Принимает от партнёра",
     "inboundAwaiting": "Named, без секрета"

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -6,7 +6,7 @@
     "modules": "Модули",
     "providers": "Провайдеры",
     "catalog": "Каталог",
-    "agentPools": "Пулы агентов",
+    "agentPools": "Агенты",
     "admin": "Администрирование",
     "users": "Пользователи",
     "roles": "Роли",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Открыть меню учётной записи",
     "closeMenu": "Закрыть меню",
     "ha": "Высокая доступность",
-    "deletedWorkspaces": "Удалённые рабочие области"
+    "deletedWorkspaces": "Удалённые рабочие области",
+    "version": "Версия {version}"
   },
   "switcher": {
     "language": "Язык",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -6,7 +6,7 @@
     "modules": "Moduler",
     "providers": "Providers",
     "catalog": "Katalog",
-    "agentPools": "Agentpooler",
+    "agentPools": "Agenter",
     "admin": "Admin",
     "users": "Användare",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Öppna kontomeny",
     "closeMenu": "Stäng meny",
     "ha": "Hög tillgänglighet",
-    "deletedWorkspaces": "Borttagna arbetsytor"
+    "deletedWorkspaces": "Borttagna arbetsytor",
+    "version": "Version {version}"
   },
   "switcher": {
     "language": "Språk",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -2972,7 +2972,9 @@
       "online": "Listener online",
       "offline": "Ingen levande listener",
       "offlineWarning": "Ingen listener är ansluten för: {pools}. Körningar till dessa pooler köas i stället för att köra.",
-      "count": "{count, plural, one {# listener} other {# listeners}}"
+      "count": "{count, plural, one {# listener} other {# listeners}}",
+      "countWithPods": "{count, plural, one {# lyssnare} other {# lyssnare}} · {pods, plural, one {# pod} other {# poddar}}",
+      "singlePod": "En enda pod"
     },
     "inbound": "Accepterar från peer",
     "inboundAwaiting": "Namngiven, ingen hemlighet"

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -2972,7 +2972,9 @@
       "online": "'Ijwl' yIntaH",
       "offline": "pagh 'Ijwl' yIntaH",
       "offlineWarning": "pagh 'Ijwl' rarlu' ghommeyvaD: {pools}. ghommeyvamvaD ngeHbogh QaptaHghachmey qaSbe'; leStaH neH.",
-      "count": "{count} 'Ijwl'"
+      "count": "{count} 'Ijwl'",
+      "countWithPods": "{count, plural, other {# ‘Ijwí’}} · {pods, plural, other {# pod}}",
+      "singlePod": "wa' pod"
     },
     "inbound": "jIHvo' laj",
     "inboundAwaiting": "ponglu', 'ach pegh Hutlh"

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -6,7 +6,7 @@
     "modules": "Segh",
     "providers": "nobwI'pu'",
     "catalog": "tetlh",
-    "agentPools": "Duy bIQ'a'mey",
+    "agentPools": "DuHmey",
     "admin": "che'wI'",
     "users": "lo'wI'pu'",
     "roles": "patlhmey",
@@ -32,7 +32,8 @@
     "openAccountMenu": "lo'wI' tetlh poSmoH",
     "closeMenu": "tetlh SoQmoH",
     "ha": "taH laH",
-    "deletedWorkspaces": "Qumwo'mey Qaw'lu'bogh"
+    "deletedWorkspaces": "Qumwo'mey Qaw'lu'bogh",
+    "version": "mI' {version}"
   },
   "switcher": {
     "language": "Hol",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -2972,7 +2972,9 @@
       "online": "Dinleyici çevrimiçi",
       "offline": "Canlı dinleyici yok",
       "offlineWarning": "Şu havuzlar için bağlı dinleyici yok: {pools}. Bu havuzlara yönlendirilen çalıştırmalar yürütülmek yerine kuyrukta bekler.",
-      "count": "{count} dinleyici"
+      "count": "{count} dinleyici",
+      "countWithPods": "{count, plural, one {# dinleyici} other {# dinleyici}} · {pods, plural, one {# pod} other {# pod}}",
+      "singlePod": "Tek pod"
     },
     "inbound": "Eşten kabul eder",
     "inboundAwaiting": "Adlandırılmış, gizli anahtar yok"

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -6,7 +6,7 @@
     "modules": "Modüller",
     "providers": "Sağlayıcılar",
     "catalog": "Katalog",
-    "agentPools": "Agent Havuzları",
+    "agentPools": "Aracılar",
     "admin": "Yönetim",
     "users": "Kullanıcılar",
     "roles": "Roller",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Hesap menüsünü aç",
     "closeMenu": "Menüyü kapat",
     "ha": "Yüksek erişilebilirlik",
-    "deletedWorkspaces": "Silinmiş çalışma alanları"
+    "deletedWorkspaces": "Silinmiş çalışma alanları",
+    "version": "Sürüm {version}"
   },
   "switcher": {
     "language": "Dil",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -2972,7 +2972,9 @@
       "online": "Слухач у мережі",
       "offline": "Немає живого слухача",
       "offlineWarning": "Жодного слухача не під'єднано для: {pools}. Запуски, спрямовані в ці пули, стануть у чергу, а не виконаються.",
-      "count": "{count, plural, one {# слухач} few {# слухачі} many {# слухачів} other {# слухача}}"
+      "count": "{count, plural, one {# слухач} few {# слухачі} many {# слухачів} other {# слухача}}",
+      "countWithPods": "{count, plural, one {# слухач} other {# слухачів}} · {pods, plural, one {# под} other {# подів}}",
+      "singlePod": "Один под"
     },
     "inbound": "Приймає від партнера",
     "inboundAwaiting": "Названо, без секрета"

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -6,7 +6,7 @@
     "modules": "Модулі",
     "providers": "Провайдери",
     "catalog": "Каталог",
-    "agentPools": "Пули агентів",
+    "agentPools": "Агенти",
     "admin": "Адміністрування",
     "users": "Користувачі",
     "roles": "Ролі",
@@ -32,7 +32,8 @@
     "openAccountMenu": "Відкрити меню облікового запису",
     "closeMenu": "Закрити меню",
     "ha": "Висока доступність",
-    "deletedWorkspaces": "Видалені робочі області"
+    "deletedWorkspaces": "Видалені робочі області",
+    "version": "Версія {version}"
   },
   "switcher": {
     "language": "Мова",

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -2972,7 +2972,9 @@
       "online": "监听器在线",
       "offline": "无在线监听器",
       "offlineWarning": "以下资源池没有连接监听器：{pools}。分配到这些池的运行只会排队而不会执行。",
-      "count": "{count} 个监听器"
+      "count": "{count} 个监听器",
+      "countWithPods": "{count, plural, other {# 个监听器}} · {pods, plural, other {# 个 Pod}}",
+      "singlePod": "单个 Pod"
     },
     "inbound": "接受对端凭据",
     "inboundAwaiting": "已命名，未设密钥"

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -6,7 +6,7 @@
     "modules": "模块",
     "providers": "提供程序",
     "catalog": "目录",
-    "agentPools": "代理池",
+    "agentPools": "代理",
     "admin": "管理",
     "users": "用户",
     "roles": "角色",
@@ -32,7 +32,8 @@
     "openAccountMenu": "打开账户菜单",
     "closeMenu": "关闭菜单",
     "ha": "高可用",
-    "deletedWorkspaces": "已删除的工作区"
+    "deletedWorkspaces": "已删除的工作区",
+    "version": "版本 {version}"
   },
   "switcher": {
     "language": "语言",

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -2972,7 +2972,9 @@
       "online": "監聽器上線",
       "offline": "無線上監聽器",
       "offlineWarning": "以下集區沒有連接監聽器：{pools}。指派到這些集區的執行只會排隊而不會執行。",
-      "count": "{count} 個監聽器"
+      "count": "{count} 個監聽器",
+      "countWithPods": "{count, plural, other {# 個監聽器}} · {pods, plural, other {# 個 Pod}}",
+      "singlePod": "單一 Pod"
     },
     "inbound": "接受對端憑證",
     "inboundAwaiting": "已命名，未設密鑰"

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -6,7 +6,7 @@
     "modules": "模組",
     "providers": "提供者",
     "catalog": "目錄",
-    "agentPools": "代理池",
+    "agentPools": "代理",
     "admin": "管理",
     "users": "使用者",
     "roles": "角色",
@@ -32,7 +32,8 @@
     "openAccountMenu": "開啟帳戶選單",
     "closeMenu": "關閉選單",
     "ha": "高可用性",
-    "deletedWorkspaces": "已刪除的工作區"
+    "deletedWorkspaces": "已刪除的工作區",
+    "version": "版本 {version}"
   },
   "switcher": {
     "language": "語言",

--- a/web/src/app/ha/page.tsx
+++ b/web/src/app/ha/page.tsx
@@ -48,6 +48,7 @@ interface Pool {
   name: string
   status: string
   listeners: number
+  pods: number | null
 }
 
 interface Finding {
@@ -140,6 +141,16 @@ export default function HAPage() {
             // from the same predicate `status` comes from — so the number and
             // the word can never disagree.
             listeners: Number(p.attributes['listener-count'] ?? 0),
+            // Pods, not listener identities (#1402). Replicas of one Deployment
+            // share a listener identity, so a redundant pair reports one
+            // listener — and on the page that exists to find single points of
+            // failure, that read as exactly the failure it is not. Absent means
+            // unknown (a pre-0.19.0 listener does not report its pod), which is
+            // not the same as none, so it stays null rather than becoming 0.
+            pods:
+              p.attributes['listener-pod-count'] === undefined
+                ? null
+                : Number(p.attributes['listener-pod-count']),
           })),
         )
       } else {
@@ -427,9 +438,23 @@ export default function HAPage() {
                           }`}
                         >
                           {p.status === 'online'
-                            ? t('listeners.count', { count: p.listeners })
+                            ? p.pods === null
+                              ? t('listeners.count', { count: p.listeners })
+                              : t('listeners.countWithPods', {
+                                  count: p.listeners,
+                                  pods: p.pods,
+                                })
                             : t('listeners.offline')}
                         </span>
+                        {/* One pod is one eviction away from no runner at all.
+                            Said here rather than left for the reader to infer,
+                            because inferring it is what the identity count made
+                            impossible. */}
+                        {p.status === 'online' && p.pods === 1 && (
+                          <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs text-amber-300">
+                            {t('listeners.singlePod')}
+                          </span>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -623,7 +623,18 @@ export default function NavBar() {
             )
             return (
               <>
-                {/* The probe must be measurable without being part of the
+                <div
+                  ref={barRef}
+                  className="hidden md:flex items-center gap-1 py-2 overflow-hidden"
+                >
+                  {contents(!compact)}
+                </div>
+                {/* Rendered after the visible bar on purpose: a `.first()`
+                    text locator should land on the real one. aria-hidden keeps
+                    this copy out of role queries already, but Playwright's text
+                    engine ignores aria-hidden, so DOM order is what saves a
+                    text-based selector from silently matching a clipped node.
+                    The probe must be measurable without being part of the
                     page. `invisible` alone is not enough: visibility:hidden
                     still takes part in layout, so the always-labelled copy —
                     wider than the bar by definition — extended the document and
@@ -641,12 +652,6 @@ export default function NavBar() {
                   >
                     {contents(true)}
                   </div>
-                </div>
-                <div
-                  ref={barRef}
-                  className="hidden md:flex items-center gap-1 py-2 overflow-hidden"
-                >
-                  {contents(!compact)}
                 </div>
               </>
             )

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, useEffect, useState, useSyncExternalStore } from 'react'
+import { forwardRef, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
@@ -100,43 +100,142 @@ const ACCOUNT_ITEMS: NavItem[] = [
 
 // Help / reference destinations — NOT account items. Grouped separately so
 // the Account menu stays personal (tokens, sessions, log out).
-const HELP_ITEMS: NavItem[] = [
-  { href: '/api-docs', labelKey: 'apiReference', icon: Code },
-  {
-    href: 'https://github.com/mattrobinsonsre/terrapod/blob/main/docs/index.md',
-    labelKey: 'docs',
-    icon: BookOpen,
-    external: true,
-  },
-]
+/**
+ * The git ref whose docs match a running instance.
+ *
+ * Linking at `main` from a released instance is quietly wrong: main documents
+ * whatever has landed since, so an operator on v1.5.1 can be reading about a
+ * flag their build does not have. Release tags are `vX.Y.Z`, and the server
+ * reports the bare version, hence the prefix.
+ *
+ * Anything that is not exactly `X.Y.Z` has no tag to point at — a dev build
+ * reporting `0.0.0`, a pre-release, or no version at all before the discovery
+ * document has loaded — so it falls back to `main`. Guessing a tag that does
+ * not exist would send people to a 404.
+ */
+function docsRef(version: string): string {
+  return /^\d+\.\d+\.\d+$/.test(version) && version !== '0.0.0' ? `v${version}` : 'main'
+}
+
+function helpItems(version: string): NavItem[] {
+  return [
+    { href: '/api-docs', labelKey: 'apiReference', icon: Code },
+    {
+      href: `https://github.com/mattrobinsonsre/terrapod/blob/${docsRef(version)}/docs/index.md`,
+      labelKey: 'docs',
+      icon: BookOpen,
+      external: true,
+    },
+  ]
+}
 
 function isPathActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(href + '/')
 }
 
 /** A top-level desktop bar link (Workspaces, Catalog, Agent Pools, Labels). */
+/**
+ * Whether the toolbar has room for its labels.
+ *
+ * A breakpoint cannot answer this. The bar's required width is not a constant:
+ * labels are translated into 27 languages, and German or Finnish run materially
+ * wider than English. Any hard-coded threshold is wrong for somebody.
+ *
+ * So it is measured — but NOT by measuring the live bar. Two earlier attempts
+ * did, and both were wrong in ways that only showed up on screen:
+ *
+ *   - measuring a bar whose primary group had `flex-1` measures the CONTAINER,
+ *     because a growing child always fills it. It collapsed to icons at 1200px
+ *     with half the bar empty.
+ *   - recording the labelled width once and reusing it captures whatever the
+ *     first paint happened to measure, before webfonts settle. It recorded a
+ *     width that was too small, so the bar stayed labelled past the point it
+ *     fitted and the rightmost control was silently clipped.
+ *
+ * Instead there is a hidden probe: a copy of the bar that ALWAYS renders
+ * labels, laid out but invisible. Its width is the true labelled width, right
+ * now, in this locale, with these fonts. Comparing it against the real bar's
+ * available width is a pure function of the current layout — no stored state to
+ * go stale, and no feedback loop, because the probe never changes when the
+ * visible bar does.
+ */
+function useFitsWithLabels(
+  probeRef: React.RefObject<HTMLDivElement | null>,
+  containerRef: React.RefObject<HTMLDivElement | null>
+) {
+  const [compact, setCompact] = useState(false)
+
+  useLayoutEffect(() => {
+    const probe = probeRef.current
+    const container = containerRef.current
+    if (!probe || !container) return
+
+    const measure = () => setCompact(probe.scrollWidth > container.clientWidth)
+    measure()
+
+    const ro = new ResizeObserver(measure)
+    ro.observe(container)
+    ro.observe(probe) // fires when the labels themselves change width
+    // Webfonts land after first paint and change every label's width.
+    document.fonts?.ready.then(measure).catch(() => {})
+    return () => ro.disconnect()
+  }, [probeRef, containerRef])
+
+  return compact
+}
+
+/**
+ * The label for an icon-only control: a tooltip on hover AND on keyboard focus.
+ *
+ * AGENTS.md forbids hover-only affordances, and this does not break that rule.
+ * Icon-only mode exists only on the desktop bar, which is itself gated at `lg`
+ * — below that the hamburger renders full labels, so a touch device never sees
+ * it. The tooltip appears on focus as well as hover, and the control carries a
+ * real `aria-label` regardless, so the name never depends on pointing at it.
+ */
+function IconLabel({ text, align = 'start' }: { text: string; align?: 'start' | 'end' }) {
+  return (
+    <span
+      role="tooltip"
+      className={`pointer-events-none absolute top-full mt-1.5 z-50 whitespace-nowrap rounded-md border border-slate-700 bg-slate-800 px-2 py-1 text-xs text-slate-200 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 ${
+        align === 'end' ? 'end-0' : 'start-0'
+      }`}
+    >
+      {text}
+    </span>
+  )
+}
+
 function NavLink({
   href,
   icon: Icon,
   label,
+  compact = false,
 }: {
   href: string
   icon: LucideIcon
   label: string
+  compact?: boolean
 }) {
   const pathname = usePathname()
   const active = isPathActive(pathname, href)
   return (
     <Link
       href={href}
-      className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+      // aria-label unconditionally, not only when compact: the accessible name
+      // must not depend on whether the viewport happens to be wide today.
+      aria-label={label}
+      title={undefined}
+      className={`group relative flex items-center gap-2 rounded-lg py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+        compact ? 'px-2' : 'px-3'
+      } ${
         active
           ? 'bg-brand-600/20 text-brand-400'
           : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'
       }`}
     >
       <Icon size={16} />
-      {label}
+      {compact ? <IconLabel text={label} /> : label}
     </Link>
   )
 }
@@ -149,6 +248,8 @@ function NavDropdown({
   active,
   align = 'start',
   footer,
+  header,
+  compact = false,
 }: {
   label: string
   icon: LucideIcon
@@ -156,20 +257,27 @@ function NavDropdown({
   active: boolean
   align?: 'start' | 'end'
   footer?: React.ReactNode
+  header?: React.ReactNode
+  compact?: boolean
 }) {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+          aria-label={label}
+          className={`group relative flex items-center gap-2 rounded-lg py-2 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+            compact ? 'px-2' : 'px-3'
+          } ${
             active
               ? 'bg-brand-600/20 text-brand-400'
               : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800 data-[state=open]:text-slate-200 data-[state=open]:bg-slate-800'
           }`}
         >
           <Icon size={16} />
-          {label}
+          {compact ? <IconLabel text={label} align={align} /> : label}
+          {/* The chevron stays: it is what says "this opens something", which
+              an icon alone does not. It is 14px; the labels were the cost. */}
           <ChevronDown size={14} className="opacity-70" />
         </button>
       </DropdownMenu.Trigger>
@@ -179,6 +287,7 @@ function NavDropdown({
           sideOffset={6}
           className="z-50 min-w-[12rem] rounded-lg border border-slate-700 bg-slate-800 p-1 shadow-xl"
         >
+          {header}
           {items.map((it) => (
             <DropdownMenu.Item key={it.href} asChild>
               <MenuLink item={it} />
@@ -386,47 +495,105 @@ export default function NavBar() {
 
   const registryActive = REGISTRY_ITEMS.some((i) => isPathActive(pathname, i.href))
   const adminActive = adminMenuItems.some((i) => isPathActive(pathname, i.href))
-  const helpActive = HELP_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
+  const HELP = helpItems(version)
+  const helpActive = HELP.some((i) => !i.external && isPathActive(pathname, i.href))
   const accountActive = ACCOUNT_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
+  const barRef = useRef<HTMLDivElement | null>(null)
+  const probeRef = useRef<HTMLDivElement | null>(null)
+  const compact = useFitsWithLabels(probeRef, barRef)
 
-  const accountLabel = email || t('account')
+  // The bar shows an icon, not the identity. You know who you are, and the
+  // address was the single widest thing in the toolbar — 111px for `admin`, and
+  // roughly double that for a corporate address — which made the width at which
+  // the bar stopped fitting depend on WHO WAS LOGGED IN. Moving it into the
+  // menu removes the variable and makes the fit deterministic per locale.
+  const accountLabel = t('account')
 
   return (
     <>
       <SessionExpiryBanner />
       <TokenExpiryBanner />
       <nav className="border-b border-slate-800 bg-slate-900/80 backdrop-blur-sm sticky top-0 z-10">
-        <div className="px-4 sm:px-6 lg:px-8">
+        <div className="px-4 sm:px-6 lg:px-8 relative">
           {/* Desktop nav — enabled at `lg`, not `md`: the full horizontal nav
               (logo + 5 primary items + admin + locale + help + a long account
               email) doesn't fit until ~1024, so below `lg` it would wrap into a
               tall, ugly multi-row bar that (being sticky) also covers page
               content beneath it. Below `lg` we use the clean hamburger instead. */}
-          <div className="hidden lg:flex items-center gap-1 py-2">
+          {/* One definition, rendered twice: the visible bar, and an
+              invisible always-labelled copy that "does it fit?" is asked of.
+              A literal duplicate would be a bug factory — every future edit
+              would have to be made in both, and missing one would silently
+              break the measurement rather than break the build. */}
+          {(() => {
+            const contents = (labelled: boolean) => (
+              <>
             <Link href="/" className="flex items-center gap-2 me-3 flex-shrink-0">
               {/* eslint-disable-next-line @next/next/no-img-element -- a static local SVG at a fixed size — next/image does not optimise SVG without dangerouslyAllowSVG and would add a loader for no benefit */}
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
-              {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
-            <div className="flex items-center gap-1 flex-wrap flex-1">
-              <NavLink href="/workspaces" icon={Layers} label={t('workspaces')} />
-              <NavLink href="/estate" icon={Network} label={t('estate')} />
-              <NavDropdown label={t('registry')} icon={Library} items={REGISTRY_ITEMS} active={registryActive} />
-              <NavLink href="/catalog" icon={LayoutGrid} label={t('catalog')} />
-              <NavLink href="/admin/agent-pools" icon={Server} label={t('agentPools')} />
+            {/* The wordmark is a brand, not the first nav item. Without a
+                divider "Terrapod" reads as though it were one, and the eye has
+                to work out where the navigation actually starts. */}
+            <div className="h-5 w-px bg-slate-700/70 me-3 flex-shrink-0" />
+            <div className="flex items-center gap-1 flex-nowrap flex-shrink-0">
+              <NavLink href="/workspaces" icon={Layers} label={t('workspaces')} compact={!labelled} />
+              <NavLink href="/estate" icon={Network} label={t('estate')} compact={!labelled} />
+              <NavDropdown label={t('registry')} icon={Library} items={REGISTRY_ITEMS} active={registryActive} compact={!labelled} />
+              <NavLink href="/catalog" icon={LayoutGrid} label={t('catalog')} compact={!labelled} />
+              <NavLink href="/admin/agent-pools" icon={Server} label={t('agentPools')} compact={!labelled} />
             </div>
+            <div className="flex-1" />
             {adminOrAudit && (
-              <NavDropdown label={t('admin')} icon={Cog} items={adminMenuItems} active={adminActive} align="end" />
+              <NavDropdown label={t('admin')} icon={Cog} items={adminMenuItems} active={adminActive} align="end" compact={!labelled} />
             )}
             <LocaleSwitcher />
-            <NavDropdown label={t('help')} icon={BookOpen} items={HELP_ITEMS} active={helpActive} align="end" />
+            <NavDropdown label={t('help')} icon={BookOpen} items={HELP} active={helpActive}
+                  align="end"
+                  compact
+                  footer={
+                    version ? (
+                      <>
+                        <DropdownMenu.Separator className="my-1 h-px bg-slate-700" />
+                        {/* Which version you are talking to. It left the
+                            toolbar to make room, and this is where it belongs
+                            anyway — beside the docs link that now points at the
+                            matching tag. Not a menu item: it is not actionable. */}
+                        <div className="px-3 py-2 text-xs text-slate-500">
+                          {t('version', { version })}
+                        </div>
+                      </>
+                    ) : null
+                  }
+                />
             <NavDropdown
               label={accountLabel}
               icon={User}
               items={ACCOUNT_ITEMS}
               active={accountActive}
               align="end"
+              // Icon-only at every width. Help and the account menu are chrome
+              // rather than destinations, and their two labels were most of the
+              // difference between the toolbar fitting a 1152px page and not.
+              compact
+              header={
+                email ? (
+                  <>
+                    {/* Who you are signed in as. Not a menu item — it is not
+                        actionable, so it must not be focusable or announced as
+                        one. It reads as the heading of the menu it belongs to,
+                        which is where an identity belongs. */}
+                    <div className="px-3 py-2">
+                      <div className="text-xs text-slate-500">{t('account')}</div>
+                      <div className="truncate text-sm text-slate-200" title={email}>
+                        {email}
+                      </div>
+                    </div>
+                    <DropdownMenu.Separator className="my-1 h-px bg-slate-700" />
+                  </>
+                ) : null
+              }
               footer={
                 <>
                   <DropdownMenu.Separator className="my-1 h-px bg-slate-700" />
@@ -446,7 +613,28 @@ export default function NavBar() {
             {/* Last in the bar on purpose: it is ambient status about the node
                 you are talking to, not another control in the cluster. */}
             <HAIndicator />
-          </div>
+              </>
+            )
+            return (
+              <>
+                <div
+                  ref={probeRef}
+                  aria-hidden="true"
+                  // @ts-expect-error -- `inert` is valid HTML that React types lag on
+                  inert=""
+                  className="hidden lg:flex items-center gap-1 py-2 absolute invisible pointer-events-none -z-10 whitespace-nowrap"
+                >
+                  {contents(true)}
+                </div>
+                <div
+                  ref={barRef}
+                  className="hidden lg:flex items-center gap-1 py-2 overflow-hidden"
+                >
+                  {contents(!compact)}
+                </div>
+              </>
+            )
+          })()}
 
           {/* Mobile top bar — logo + Account trigger + hamburger (below `lg`) */}
           <div className="lg:hidden flex items-center justify-between h-14">
@@ -454,7 +642,6 @@ export default function NavBar() {
               {/* eslint-disable-next-line @next/next/no-img-element -- a static local SVG at a fixed size — next/image does not optimise SVG without dangerouslyAllowSVG and would add a loader for no benefit */}
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
-              {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
             <div className="flex items-center gap-1">
               <button
@@ -514,7 +701,7 @@ export default function NavBar() {
               )}
 
               <MobileSection label={t('help')} />
-              {HELP_ITEMS.map((it) => (
+              {HELP.map((it) => (
                 <MobileLink key={it.href} item={it} onClick={closeDrawers} />
               ))}
             </MobileDrawer>

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -414,7 +414,7 @@ function MobileDrawer({
   return (
     <div
       id={id}
-      className="lg:hidden fixed top-0 start-0 end-0 h-dvh z-40 bg-slate-900 flex flex-col"
+      className="md:hidden fixed top-0 start-0 end-0 h-dvh z-40 bg-slate-900 flex flex-col"
     >
       <div className="flex items-center justify-between h-14 px-4 border-b border-slate-800 flex-shrink-0">
         <span className="font-bold text-lg text-slate-100">{title}</span>
@@ -520,6 +520,12 @@ export default function NavBar() {
               email) doesn't fit until ~1024, so below `lg` it would wrap into a
               tall, ugly multi-row bar that (being sticky) also covers page
               content beneath it. Below `lg` we use the clean hamburger instead. */}
+          {/* md, not lg: the icon-only bar needs ~650px, so gating the
+              hamburger on lg (1024px) hid a bar that fits, for the whole band
+              between them. The rest of the UI switches to its phone treatment
+              at md — useIsMobile() is `max-width: md`, and the tables flip to
+              cards there — so this is where the nav should switch too, and the
+              two now agree rather than leaving a 256px dead zone. */}
           {/* One definition, rendered twice: the visible bar, and an
               invisible always-labelled copy that "does it fit?" is asked of.
               A literal duplicate would be a bug factory — every future edit
@@ -617,18 +623,28 @@ export default function NavBar() {
             )
             return (
               <>
-                <div
-                  ref={probeRef}
-                  aria-hidden="true"
-                  // @ts-expect-error -- `inert` is valid HTML that React types lag on
-                  inert=""
-                  className="hidden lg:flex items-center gap-1 py-2 absolute invisible pointer-events-none -z-10 whitespace-nowrap"
-                >
-                  {contents(true)}
+                {/* The probe must be measurable without being part of the
+                    page. `invisible` alone is not enough: visibility:hidden
+                    still takes part in layout, so the always-labelled copy —
+                    wider than the bar by definition — extended the document and
+                    gave every width below it a horizontal scrollbar. Clipping
+                    it inside a positioned zero-size box keeps it out of the
+                    document's scroll width; its own scrollWidth still reports
+                    its content width, which is the whole point of it. */}
+                <div className="hidden md:block absolute w-0 h-0 overflow-hidden pointer-events-none -z-10">
+                  <div
+                    ref={probeRef}
+                    aria-hidden="true"
+                    // @ts-expect-error -- `inert` is valid HTML that React types lag on
+                    inert=""
+                    className="flex items-center gap-1 py-2 absolute whitespace-nowrap"
+                  >
+                    {contents(true)}
+                  </div>
                 </div>
                 <div
                   ref={barRef}
-                  className="hidden lg:flex items-center gap-1 py-2 overflow-hidden"
+                  className="hidden md:flex items-center gap-1 py-2 overflow-hidden"
                 >
                   {contents(!compact)}
                 </div>
@@ -637,7 +653,7 @@ export default function NavBar() {
           })()}
 
           {/* Mobile top bar — logo + Account trigger + hamburger (below `lg`) */}
-          <div className="lg:hidden flex items-center justify-between h-14">
+          <div className="md:hidden flex items-center justify-between h-14">
             <Link href="/" className="flex items-center gap-2">
               {/* eslint-disable-next-line @next/next/no-img-element -- a static local SVG at a fixed size — next/image does not optimise SVG without dangerouslyAllowSVG and would add a loader for no benefit */}
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />


### PR DESCRIPTION
/ha showed one listener for a pool whose Deployment runs two replicas. My
first reading was that the replicas were colliding and half the fleet was
invisible; that was wrong, and the corrected version is a smaller fix.

Replicas sharing one identity is the design. Pods of one Deployment share a
listener_id, and fleet size comes from the per-pod presence keys the heartbeat
maintains — and those are correct: the deployment in question reports
replica-count 2 for the listener the page was calling one.

The page never asked. It took `listener-count` off the pool, which counts
listener IDENTITIES, and rendered it as the listener count. So a redundant
pair and a genuinely single pod displayed identically — on the page whose only
job is to answer "is anything a single point of failure right now?". That is
the same failure `single-replica-components` exists to catch for api and web.

Pools now carry `listener-pod-count` alongside `listener-count`, derived from
the same usable-listener predicate so the two figures always describe the same
set. The page shows "1 listener · 2 pods", and flags a pool down to one pod
the way a single-replica component is flagged.

Unknown is kept distinct from zero throughout. A listener on a pre-0.19.0
image never sends its pod name, so its pool omits the attribute rather than
claiming zero pods — inventing an outage on a healthy pool is the same mistake
as hiding one, pointing the other way. Zero IS reported when a listener tracks
pods and none are heartbeating, because that is real.

The count uses a single keyspace scan for the whole list rather than the
existing per-listener helper. Calling that one per pool would put an
O(N)-per-request scan on a list endpoint, which is the shape the workspace
list was fixed out of in #1056.

The component scan still excludes listeners deliberately — they may be in
another cluster, and reporting one as absent because it is merely elsewhere
would be worse than not reporting it. The pod count comes from the heartbeat
data, which already crosses that boundary.

Not added to go-terrapod: the SDK's AgentPool carries neither `status` nor
`listener-count`, so these live-status attributes are outside its typed
surface by existing convention.

Verified on the live stack: the API returns pods=1 for the online pool and
omits the attribute for the offline one, and the page renders
"1 listener · 1 pod" with the single-pod warning — which is the truth there.

Closes #1402