### PR TITLE
chore(1411): bring v1.5.3 forward to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -876,6 +876,30 @@ jobs:
           # secret env is injected (no existingSecret) — config-channel contract.
           echo "$out" | grep -q "TERRAPOD_SLACK__" && { echo "FAIL: Slack secret env injected when disabled"; exit 1; }
           echo "Stock install renders web + Ingress + bootstrap + hooks_enabled OK"
+      - name: Bootstrap seeds several agent pools without exposing a token (#1411)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
+            template terrapod helm/terrapod \
+              --namespace terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set bootstrap.adminEmail=admin@example.com \
+              --set bootstrap.adminPassword=changeme \
+              --set 'bootstrap.pools[0].name=pool-a' \
+              --set 'bootstrap.pools[0].existingSecret=pool-a-token' \
+              --set 'bootstrap.pools[1].name=pool-b' \
+              --set 'bootstrap.pools[1].existingSecret=pool-b-token' \
+              --set 'bootstrap.pools[1].tokenKey=custom_key')
+          echo "$out" | grep -q 'TERRAPOD_BOOTSTRAP_POOL_COUNT' || { echo "FAIL: pool count not rendered — the CLI would seed nothing (#1411)"; exit 1; }
+          echo "$out" | grep -q 'TERRAPOD_BOOTSTRAP_POOL_1_NAME' || { echo "FAIL: only one pool rendered (#1411)"; exit 1; }
+          echo "$out" | grep -q 'name: "pool-b-token"' || { echo "FAIL: the second pool's Secret is not referenced (#1411)"; exit 1; }
+          echo "$out" | grep -q 'key: "custom_key"' || { echo "FAIL: per-pool tokenKey ignored (#1411)"; exit 1; }
+          # The point of secretKeyRef: no join token may appear as a literal in
+          # the rendered Job, or it lands in the Helm release and in state.
+          if echo "$out" | grep -E 'TERRAPOD_BOOTSTRAP_POOL_[0-9]+_TOKEN' -A 1 | grep -q 'value:'; then
+            echo "FAIL: a join token rendered as a literal value instead of a secretKeyRef (#1411)"; exit 1
+          fi
+          echo "Multi-pool bootstrap renders with tokens by secretKeyRef OK"
       - name: Local dev values render
         run: |
           out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1855,6 +1855,16 @@ jobs:
   # Merges the per-shard Playwright blob reports into a single HTML report,
   # so a failure across 8 shards is triaged from one artifact. Runs even when
   # shards fail (always()) — that's exactly when the merged report is needed.
+  # Merges the shard blob reports into one HTML report for a human to read.
+  #
+  # Deliberately NOT part of `ci-pass`: it asserts nothing about the product. The
+  # test verdict lives in the eight `e2e-test` shards, which are gated. Having
+  # this in the gate meant a GitHub artifact-storage failure — no Terrapod code
+  # involved, artifacts intact per the API, `download-artifact` exhausting its own
+  # retries — could fail a release that was otherwise complete and correct, with
+  # no rerun able to clear it. That happened on v1.5.3.
+  #
+  # Losing the merge costs the pretty report and nothing else.
   e2e-report:
     name: E2E Report
     needs: [prepare, e2e-test]
@@ -1863,12 +1873,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Download blob reports
+        # Keep going if a shard's report cannot be fetched: a partial report is
+        # more useful than none, and this job is not a gate.
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: blob-report-*
           path: all-blob-reports
           merge-multiple: true
       - name: Merge into HTML report
+        continue-on-error: true
         run: |
           docker run --rm \
             -v "${{ github.workspace }}/e2e:/work" \
@@ -2909,7 +2923,6 @@ jobs:
             "${{ needs.scan-images.result }}"
             "${{ needs.e2e-test.result }}"
             "${{ needs.oci-conformance.result }}"
-            "${{ needs.e2e-report.result }}"
             "${{ needs.create-manifests.result }}"
             "${{ needs.release-create.result }}"
             "${{ needs.release-images.result }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -757,16 +757,28 @@ git commit --allow-empty -m "chore: rebuild v1.1.x against a refreshed base imag
 - **Never merge `main`.** The point is the fix without the features; merging
   defeats it and turns a patch into an untested minor. Cherry-pick or write the
   minimal fix — see above — but never merge.
-- **Never merge the release branch back into `main`.** Its commits are already
-  there — that is where they were picked from. Keep the branch; it is where the
-  next patch on that line starts.
+- **Never *merge* the release branch into `main`** — in either direction of
+  travel. Keep the branch; it is where the next patch on that line starts.
+  - When the fix came from `main`, its commits are already there and there is
+    nothing to bring back.
+  - When the fix **originated on the release branch** — because the operators
+    who need it are on that line and the change is patch material — cherry-pick
+    it *into* `main` with `-x`, so the newer line does not regress it at the next
+    upgrade. Do this promptly: a fix that lives only on an older line is a
+    regression waiting for whoever upgrades.
 - **`-x` on every cherry-pick**, and an explicit note on every commit that is
   *not* one. When someone asks in six months whether a fix is in a line, the
   recorded origin is the answer — and where there is no origin to record, say
   so, or the absence reads as an oversight.
-- **A patch stays a patch.** If what you are picking needs a schema migration, a
-  config key, or anything else that changes a public surface, it is not patch
-  material — see [Versioning & support](docs/versioning-and-support.md).
+- **A patch stays a patch.** A schema migration, a new API route or response
+  attribute, a wire-protocol change, or anything that alters what an existing
+  configuration does is not patch material — see
+  [Versioning & support](docs/versioning-and-support.md). An **opt-in** Helm
+  value or config key whose default leaves the deployment behaving exactly as
+  before *is* allowed: the test is whether taking the release can change
+  anything for an operator who does not touch their values, and an unset key
+  cannot. Adding one still means regenerating the values/config contract
+  snapshot on the release branch, which is the usual additive-only check.
 - **Bring the accepted-risk register forward with the patch.**
   `pentest/trivy/.trivyignore` and the audit ignore files describe what we
   accept *now*, and both the release gate and the re-scan read them **from the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -586,8 +586,42 @@ The chart supports up to three Ingresses. See [Split-networking deployments](dep
 | `bootstrap.adminEmail` | | Initial admin email |
 | `bootstrap.adminPassword` | | Initial admin password |
 | `bootstrap.existingSecret` | | K8s secret with admin credentials |
-| `bootstrap.poolName` | `""` | Optional: create an agent pool with this name |
-| `bootstrap.poolToken` | `""` | Optional: raw join token for the pool (generated if omitted) |
+| `bootstrap.poolName` | `""` | Optional: create a single agent pool with this name |
+| `bootstrap.poolToken` | `""` | Its join token, **as a literal in the Job spec** — prefer `poolTokenExistingSecret`. Generated and printed once if omitted |
+| `bootstrap.poolTokenExistingSecret` | `""` | Read `poolName`'s join token from a Secret instead of from values |
+| `bootstrap.poolTokenKey` | `join_token` | Key within that Secret |
+| `bootstrap.pools` | `[]` | Several pools at once — see below. Mutually exclusive with `poolName` |
+
+#### Seeding several agent pools
+
+`bootstrap` writes directly to the database, which makes it the only way to
+register a pool before an API is running. That matters on a green-field install:
+a listener's readiness probe does not pass until it has **joined** a pool, so
+with `helm --wait` the pools have to exist before anything rolls out.
+
+```yaml
+bootstrap:
+  existingSecret: terrapod-admin
+  pools:
+    - name: pool-a
+      existingSecret: pool-a-token   # the raw join token lives in this Secret
+      tokenKey: join_token           # optional, defaults to "join_token"
+    - name: pool-b
+      existingSecret: pool-b-token
+```
+
+Each token reaches the Job by `secretKeyRef`, so it never appears in the Job
+spec, the Helm release, or the state file of whatever applied it. Re-running is a
+no-op, so the Job is safe on every upgrade and you can add a pool to the list
+later without disturbing the others.
+
+**Give every pool its own token.** Join tokens are unique across all pools, so
+two pools sharing one would leave the second without a token at all — its
+listener would never join. The Job refuses to start rather than let that happen,
+naming both pools.
+
+Setting both `pools` and `poolName` fails at template time rather than silently
+ignoring one.
 
 **Security note:** The bootstrap admin credentials are used only for initial setup. After deploying, either change the admin password immediately or configure SSO (OIDC/SAML) and disable local auth (`auth.local_enabled: false`). For production, always use `bootstrap.existingSecret` with a Kubernetes Secret rather than plain-text values in Helm.
 

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -12,9 +12,29 @@ for every public surface below.
 
 | Bump | Meaning |
 |---|---|
-| **PATCH** (`0.58.0 → 0.58.1`) | Bug fixes and security fixes only. No new surface, no behaviour change beyond fixing the bug. Always safe to take. |
+| **PATCH** (`0.58.0 → 0.58.1`) | Bug fixes and security fixes, plus **opt-in configuration** that changes nothing until you set it. No behaviour change for an existing configuration, no new API surface, no schema migration. Always safe to take. |
 | **MINOR** (`0.58.0 → 0.59.0`) | New, **backward-compatible** features. Existing routes, response attributes, wire protocol, SDK methods, Helm values, and config keys keep working unchanged. Additive only. Safe to take without config changes. |
 | **MAJOR** (`0.x → 1.0`, `1.x → 2.0`) | The only release that may contain a **breaking change** to a stable surface — and only after the deprecation window below. Read the migration notes before upgrading. |
+
+> **What "opt-in configuration" means in a PATCH, and what it does not.** A patch
+> may add a Helm value, a config key or an environment variable **whose default
+> leaves the deployment behaving exactly as before**. The test is not whether a
+> release adds surface; it is whether taking it can change anything for an
+> operator who does not touch their values. An unset key cannot.
+>
+> This is narrower than it sounds, and the exclusions are the point. A patch
+> still may not add an API route or a response attribute (a consumer running an
+> older version would face a surface that appears and disappears across a patch),
+> change the runner or listener wire protocol, carry a schema migration, or alter
+> what any existing configuration does. Those remain MINOR.
+>
+> The earlier wording said "no new surface", which conflated *adding a key* with
+> *being risky to take* — and they are not the same thing. It also made the
+> honest fix for a gap in an older release line impossible to ship there: an
+> operator on the previous minor could be left with a mechanism that only works
+> for one of something, told the fix exists, and offered it only via a minor
+> carrying a release of unrelated features. Where the fix is a defaulted-off key,
+> that trade is not worth making.
 
 > **The one exception: closing a security hole.** A MINOR may *tighten* a
 > permission on a surface that was wrongly open, because leaving it open is

--- a/helm/terrapod/templates/job-bootstrap.yaml
+++ b/helm/terrapod/templates/job-bootstrap.yaml
@@ -4,6 +4,24 @@
 {{- $dbAuthMode := (.Values.api.config.database).auth_mode | default "password" }}
 {{- $dbIam := or (eq $dbAuthMode "aws_iam") (eq $dbAuthMode "gcp_iam") (eq $dbAuthMode "azure_ad") }}
 {{- $dbCa := or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
+{{/*
+  Agent pools to seed (#1411). A join token is a credential, so it reaches the
+  Job by `secretKeyRef` and never appears in the Job spec — the same channel the
+  admin password uses, and what the config contract asks for. Names are not
+  secret and are passed as plain values, indexed to pair with their token.
+*/}}
+{{- if and .Values.bootstrap.pools .Values.bootstrap.poolName }}
+{{- fail "bootstrap: set either `pools` or the single-pool `poolName`, not both. Silently ignoring one is how a pool goes missing." }}
+{{- end }}
+{{- $pools := .Values.bootstrap.pools | default list }}
+{{- if and (not $pools) .Values.bootstrap.poolName .Values.bootstrap.poolTokenExistingSecret }}
+{{/* The single-pool form, Secret-backed: the same path as a one-element list. */}}
+{{- $pools = list (dict "name" .Values.bootstrap.poolName "existingSecret" .Values.bootstrap.poolTokenExistingSecret "tokenKey" .Values.bootstrap.poolTokenKey) }}
+{{- end }}
+{{- range $i, $p := $pools }}
+{{- if not $p.name }}{{ fail (printf "bootstrap.pools[%d] has no name" $i) }}{{ end }}
+{{- if not $p.existingSecret }}{{ fail (printf "bootstrap.pools[%d] (%s) has no existingSecret — a join token must come from a Secret, never from values" $i $p.name) }}{{ end }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -85,13 +103,32 @@ spec:
             - name: TERRAPOD_BOOTSTRAP_ADMIN_PASSWORD
               value: {{ .Values.bootstrap.adminPassword | quote }}
             {{- end }}
+            {{- if $pools }}
+            {{/* The count is declared so a hand-written Job cannot leave a gap
+                 in the indices and silently drop a pool; the CLI insists on
+                 finding exactly this many. */}}
+            - name: TERRAPOD_BOOTSTRAP_POOL_COUNT
+              value: {{ len $pools | quote }}
+            {{- range $i, $p := $pools }}
+            - name: {{ printf "TERRAPOD_BOOTSTRAP_POOL_%d_NAME" $i }}
+              value: {{ $p.name | quote }}
+            - name: {{ printf "TERRAPOD_BOOTSTRAP_POOL_%d_TOKEN" $i }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $p.existingSecret | quote }}
+                  key: {{ $p.tokenKey | default "join_token" | quote }}
+            {{- end }}
+            {{- else }}
             {{- if .Values.bootstrap.poolName }}
             - name: TERRAPOD_BOOTSTRAP_POOL_NAME
               value: {{ .Values.bootstrap.poolName | quote }}
             {{- end }}
             {{- if .Values.bootstrap.poolToken }}
+            {{/* Legacy inline token: kept working, but it renders into the Job
+                 spec. Prefer `pools` (or poolTokenExistingSecret), which do not. */}}
             - name: TERRAPOD_BOOTSTRAP_POOL_TOKEN
               value: {{ .Values.bootstrap.poolToken | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.bootstrap.sampleWorkspace }}
             - name: TERRAPOD_BOOTSTRAP_SAMPLE_WORKSPACE

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -763,6 +763,25 @@
         "poolToken": {
           "type": "string"
         },
+        "poolTokenExistingSecret": {
+          "type": "string"
+        },
+        "poolTokenKey": {
+          "type": "string"
+        },
+        "pools": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "existingSecret"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "existingSecret": { "type": "string", "minLength": 1 },
+              "tokenKey": { "type": "string" }
+            }
+          }
+        },
         "sampleWorkspace": {
           "type": "boolean"
         },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -1701,7 +1701,29 @@ migrations:
 #   emailKey: email
 #   passwordKey: password
 #   poolName: ""       # Optional: auto-create an agent pool with this name
-#   poolToken: ""      # Optional: auto-create a join token for the pool
+#   poolToken: ""      # Optional: the pool's join token. Rendered into the Job
+#                      # spec as a literal, so prefer poolTokenExistingSecret
+#                      # (or `pools` below), which do not.
+#   poolTokenExistingSecret: ""  # Preferred: read poolName's join token from a
+#                                # Secret instead of from values.
+#   poolTokenKey: "join_token"   # Key within that Secret.
+#
+#   # Several pools (#1411). bootstrap writes directly to the database, so it is
+#   # the only way to register a pool with no API running yet — and the listener's
+#   # readiness probe does not pass until it has joined one, so on a green-field
+#   # install with `helm --wait` the pools have to exist before anything starts.
+#   #
+#   # Each token is delivered by secretKeyRef and never appears in the Job spec.
+#   # Give every pool its own token: two pools sharing one would leave the second
+#   # unjoinable, so the Job refuses to start rather than let that through.
+#   #
+#   # Mutually exclusive with poolName — setting both fails at template time.
+#   pools:
+#     - name: pool-a
+#       existingSecret: pool-a-token
+#       tokenKey: join_token     # optional, defaults to "join_token"
+#     - name: pool-b
+#       existingSecret: pool-b-token
 #   sampleWorkspace: false      # Eval only: seed a sample workspace + a completed
 #                               # plan-only run so the UI is populated on first login.
 #                               # Do NOT enable in production (it inserts demo data).

--- a/services/terrapod/cli/bootstrap.py
+++ b/services/terrapod/cli/bootstrap.py
@@ -308,7 +308,11 @@ async def _bootstrap_pool(session: AsyncSession, spec: PoolSpec) -> None:
             print(f"Generated join token: {raw_token}")  # noqa: T201 — intentional one-time credential output
             print("IMPORTANT: Save this token now. It will not be shown again.")  # noqa: T201
         else:
-            logger.info("Join token created from TERRAPOD_BOOTSTRAP_POOL_TOKEN")
+            # Deliberately does not name an env var: the token may have come
+            # from the indexed vars or the legacy pair, and a log line that
+            # names the wrong source is worse than one that names none when
+            # someone is working out where a token came from.
+            logger.info("Join token for pool '%s' registered from the supplied value", pool_name)
 
 
 async def _bootstrap_sample_workspace(

--- a/services/terrapod/cli/bootstrap.py
+++ b/services/terrapod/cli/bootstrap.py
@@ -23,6 +23,7 @@ import logging
 import os
 import secrets
 import sys
+from dataclasses import dataclass
 
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -123,22 +124,142 @@ async def bootstrap() -> None:
                 session.add(assignment)
                 logger.info("Assigned admin role to %s (provider: local)", admin_email)
 
-            # ── Agent pool (optional) ───────────────────────────────
-            pool_name = os.environ.get("TERRAPOD_BOOTSTRAP_POOL_NAME", "").strip()
-            if pool_name:
-                await _bootstrap_pool(session, pool_name)
+            # ── Agent pools (optional) ──────────────────────────────
+            pools = _pools_from_environment()
+            _reject_duplicate_tokens(pools)
+            failures: list[str] = []
+            for spec in pools:
+                try:
+                    await _bootstrap_pool(session, spec)
+                except Exception as exc:  # noqa: BLE001 — reported per pool below
+                    # Every pool is attempted. Aborting on the first would hide
+                    # the other failures, and an operator would then discover
+                    # them one install at a time.
+                    logger.error("Pool '%s' failed: %s", spec.name, exc)
+                    failures.append(f"{spec.name}: {exc}")
+
+            # The first pool is the one a sample workspace attaches to; with a
+            # list there has to be an answer and "the first" is the predictable
+            # one.
+            pool_name = pools[0].name if pools else ""
 
             # ── Sample workspace + run (optional; eval profile only) ─
             if os.environ.get("TERRAPOD_BOOTSTRAP_SAMPLE_WORKSPACE", "").strip():
                 await _bootstrap_sample_workspace(session, pool_name, admin_email)
 
+            if failures:
+                # Non-zero so the Job is visibly failed rather than quietly
+                # partial. Everything that succeeded is committed and the run is
+                # idempotent, so fixing the offending Secret and re-running does
+                # only the outstanding work.
+                raise SystemExit(
+                    "bootstrap: "
+                    + str(len(failures))
+                    + " of "
+                    + str(len(pools))
+                    + " pools failed:\n  "
+                    + "\n  ".join(failures)
+                )
+
     await engine.dispose()
     logger.info("Bootstrap complete")
 
 
-async def _bootstrap_pool(session: AsyncSession, pool_name: str) -> None:
+@dataclass(frozen=True)
+class PoolSpec:
+    """One pool to seed, and the token to register for it."""
+
+    name: str
+    #: None means "generate one and print it", which is only reachable from the
+    #: legacy single-pool path — a list entry always supplies a token, because
+    #: printing N generated tokens into a Job's logs is not a way to hand out
+    #: credentials.
+    token: str | None
+
+
+def _pools_from_environment() -> list[PoolSpec]:
+    """Which pools to seed, from either the indexed vars or the legacy pair.
+
+    `TERRAPOD_BOOTSTRAP_POOL_COUNT` declares how many, then each is
+    `TERRAPOD_BOOTSTRAP_POOL_{i}_NAME` and `..._{i}_TOKEN`. The token arrives by
+    `secretKeyRef`, so it is never written into the Job spec — the same channel
+    the admin password uses.
+
+    The count is not redundant. Scanning until the first gap would silently drop
+    every pool after a missing index, and the people this feature is for are
+    hand-writing this Job today — so a gap is exactly the mistake to expect. With
+    a declared count a gap is a loud failure instead.
+
+    A Secret key that does not resolve never reaches here at all: the kubelet
+    fails the container with `CreateContainerConfigError`, which is a clearer
+    signal than anything this could report.
+    """
+    raw_count = os.environ.get("TERRAPOD_BOOTSTRAP_POOL_COUNT", "").strip()
+    if raw_count:
+        try:
+            count = int(raw_count)
+        except ValueError as exc:
+            raise SystemExit(
+                f"TERRAPOD_BOOTSTRAP_POOL_COUNT is not a number: {raw_count!r}"
+            ) from exc
+
+        pools: list[PoolSpec] = []
+        for index in range(count):
+            name = os.environ.get(f"TERRAPOD_BOOTSTRAP_POOL_{index}_NAME", "").strip()
+            token = os.environ.get(f"TERRAPOD_BOOTSTRAP_POOL_{index}_TOKEN", "").strip()
+            if not name:
+                raise SystemExit(
+                    f"TERRAPOD_BOOTSTRAP_POOL_COUNT is {count} but "
+                    f"TERRAPOD_BOOTSTRAP_POOL_{index}_NAME is missing or empty. "
+                    f"Pool indices must run 0..{count - 1} with no gaps."
+                )
+            if not token:
+                raise SystemExit(
+                    f"Pool '{name}': TERRAPOD_BOOTSTRAP_POOL_{index}_TOKEN is empty. "
+                    f"Check the Secret named in bootstrap.pools has the expected key."
+                )
+            pools.append(PoolSpec(name=name, token=token))
+        return pools
+
+    # Legacy single-pool form. Kept working exactly as before.
+    name = os.environ.get("TERRAPOD_BOOTSTRAP_POOL_NAME", "").strip()
+    if not name:
+        return []
+    token = os.environ.get("TERRAPOD_BOOTSTRAP_POOL_TOKEN", "").strip()
+    return [PoolSpec(name=name, token=token or None)]
+
+
+def _reject_duplicate_tokens(pools: list[PoolSpec]) -> None:
+    """Refuse two pools sharing one join token.
+
+    `agent_pool_tokens.token_hash` is unique across **all** pools, and the
+    registration below skips a hash that already exists. With one pool that is
+    harmless idempotency. With a list it is a trap: point two entries at the same
+    Secret — a copy-paste away — and the second pool is created, its token is
+    skipped as "already exists", and that pool ends up with **no** join token at
+    all. Its listener never joins, and the Job reports success.
+
+    So this fails loudly instead. A pool with no token is indistinguishable from
+    a broken deployment later, and far harder to diagnose then.
+    """
+    seen: dict[str, str] = {}
+    for spec in pools:
+        if spec.token is None:
+            continue
+        digest = hashlib.sha256(spec.token.encode()).hexdigest()
+        if digest in seen:
+            raise SystemExit(
+                f"Pools '{seen[digest]}' and '{spec.name}' were given the same join token. "
+                f"Each pool needs its own: a shared token would leave one of them "
+                f"unjoinable while the Job reported success."
+            )
+        seen[digest] = spec.name
+
+
+async def _bootstrap_pool(session: AsyncSession, spec: PoolSpec) -> None:
     """Create an agent pool and join token if they don't already exist."""
-    raw_token = os.environ.get("TERRAPOD_BOOTSTRAP_POOL_TOKEN", "").strip()
+    pool_name = spec.name
+    raw_token = spec.token or ""
     token_generated = False
     if not raw_token:
         raw_token = secrets.token_urlsafe(48)
@@ -164,6 +285,15 @@ async def _bootstrap_pool(session: AsyncSession, pool_name: str) -> None:
     existing_token = result.scalar_one_or_none()
 
     if existing_token:
+        if existing_token.pool_id != pool.id:
+            # The same trap as the pre-flight check, but from a previous run
+            # rather than this one's input: the token is already registered
+            # against a different pool, so registering it here is impossible and
+            # skipping would leave this pool unjoinable.
+            raise RuntimeError(
+                f"its join token is already registered to a different pool. "
+                f"Give pool '{pool_name}' a token of its own."
+            )
         logger.info("Join token already exists for pool '%s', skipping", pool_name)
     else:
         token = AgentPoolToken(

--- a/services/tests/api/test_bootstrap_pools.py
+++ b/services/tests/api/test_bootstrap_pools.py
@@ -1,0 +1,147 @@
+"""Seeding several agent pools from the bootstrap Job (#1411).
+
+bootstrap writes straight to Postgres, which makes it the only way to register a
+pool before an API exists — and the listener's readiness probe does not pass
+until it has joined one, so on a green-field install the pools must exist before
+anything else starts. It handled exactly one, so multi-pool deployments were
+running the CLI in a loop from a hand-written Job.
+
+The tests that matter here are the ones about *not* silently doing the wrong
+thing: a shared token, a gap in the indices, a partial failure. Each of those is
+invisible until a listener fails to join, long after the Job reported success.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from terrapod.cli import bootstrap
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("TERRAPOD_BOOTSTRAP_POOL"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _set(monkeypatch, **values: str) -> None:
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+
+
+class TestReadingTheEnvironment:
+    def test_indexed_pools_are_read_in_order(self, monkeypatch) -> None:
+        _set(
+            monkeypatch,
+            TERRAPOD_BOOTSTRAP_POOL_COUNT="2",
+            TERRAPOD_BOOTSTRAP_POOL_0_NAME="pool-a",
+            TERRAPOD_BOOTSTRAP_POOL_0_TOKEN="tok-a",
+            TERRAPOD_BOOTSTRAP_POOL_1_NAME="pool-b",
+            TERRAPOD_BOOTSTRAP_POOL_1_TOKEN="tok-b",
+        )
+        assert bootstrap._pools_from_environment() == [
+            bootstrap.PoolSpec("pool-a", "tok-a"),
+            bootstrap.PoolSpec("pool-b", "tok-b"),
+        ]
+
+    def test_a_gap_in_the_indices_is_refused(self, monkeypatch) -> None:
+        """Scanning to the first gap would silently drop everything after it.
+
+        The people this feature is for hand-write this Job today, so a gap is
+        exactly the mistake to expect — and losing pool 3 silently is how a
+        listener ends up never joining with nothing to point at.
+        """
+        _set(
+            monkeypatch,
+            TERRAPOD_BOOTSTRAP_POOL_COUNT="3",
+            TERRAPOD_BOOTSTRAP_POOL_0_NAME="a",
+            TERRAPOD_BOOTSTRAP_POOL_0_TOKEN="1",
+            TERRAPOD_BOOTSTRAP_POOL_2_NAME="c",
+            TERRAPOD_BOOTSTRAP_POOL_2_TOKEN="3",
+        )
+        with pytest.raises(SystemExit, match="POOL_1_NAME"):
+            bootstrap._pools_from_environment()
+
+    def test_an_empty_token_is_refused_naming_the_pool(self, monkeypatch) -> None:
+        """Almost always a Secret that lacks the expected key."""
+        _set(
+            monkeypatch,
+            TERRAPOD_BOOTSTRAP_POOL_COUNT="1",
+            TERRAPOD_BOOTSTRAP_POOL_0_NAME="pool-a",
+            TERRAPOD_BOOTSTRAP_POOL_0_TOKEN="",
+        )
+        with pytest.raises(SystemExit, match="pool-a"):
+            bootstrap._pools_from_environment()
+
+    def test_a_non_numeric_count_is_refused(self, monkeypatch) -> None:
+        _set(monkeypatch, TERRAPOD_BOOTSTRAP_POOL_COUNT="lots")
+        with pytest.raises(SystemExit, match="not a number"):
+            bootstrap._pools_from_environment()
+
+    def test_nothing_configured_means_no_pools(self) -> None:
+        assert bootstrap._pools_from_environment() == []
+
+
+class TestBackwardCompatibility:
+    """The single-pool form has to keep behaving exactly as it did."""
+
+    def test_the_legacy_pair_still_works(self, monkeypatch) -> None:
+        _set(
+            monkeypatch,
+            TERRAPOD_BOOTSTRAP_POOL_NAME="legacy",
+            TERRAPOD_BOOTSTRAP_POOL_TOKEN="tok",
+        )
+        assert bootstrap._pools_from_environment() == [bootstrap.PoolSpec("legacy", "tok")]
+
+    def test_a_legacy_pool_with_no_token_still_generates_one(self, monkeypatch) -> None:
+        """`token is None` is what routes to generate-and-print, and that path is
+        deliberately reachable only from the single-pool form: printing N
+        generated tokens into a Job's logs is not a way to hand out credentials."""
+        _set(monkeypatch, TERRAPOD_BOOTSTRAP_POOL_NAME="legacy")
+        assert bootstrap._pools_from_environment() == [bootstrap.PoolSpec("legacy", None)]
+
+    def test_the_indexed_form_wins_when_both_are_somehow_present(self, monkeypatch) -> None:
+        """The chart refuses to render both, but a hand-written Job could set
+        them; preferring the explicit list is the predictable resolution."""
+        _set(
+            monkeypatch,
+            TERRAPOD_BOOTSTRAP_POOL_COUNT="1",
+            TERRAPOD_BOOTSTRAP_POOL_0_NAME="listed",
+            TERRAPOD_BOOTSTRAP_POOL_0_TOKEN="tok",
+            TERRAPOD_BOOTSTRAP_POOL_NAME="legacy",
+        )
+        assert [p.name for p in bootstrap._pools_from_environment()] == ["listed"]
+
+
+class TestDuplicateTokens:
+    """The trap that only exists once this is a list.
+
+    `agent_pool_tokens.token_hash` is unique across *all* pools and registration
+    skips a hash that already exists. Point two pools at the same Secret — a
+    copy-paste away — and the second is created, its token skipped as "already
+    exists", and it ends up with no join token while the Job reports success.
+    """
+
+    def test_two_pools_sharing_a_token_are_refused(self) -> None:
+        pools = [
+            bootstrap.PoolSpec("pool-a", "same-token"),
+            bootstrap.PoolSpec("pool-b", "same-token"),
+        ]
+        with pytest.raises(SystemExit) as exc:
+            bootstrap._reject_duplicate_tokens(pools)
+        # Both names, because "a duplicate exists" is not actionable on its own.
+        assert "pool-a" in str(exc.value) and "pool-b" in str(exc.value)
+
+    def test_distinct_tokens_are_fine(self) -> None:
+        bootstrap._reject_duplicate_tokens(
+            [bootstrap.PoolSpec("a", "one"), bootstrap.PoolSpec("b", "two")]
+        )
+
+    def test_a_pool_awaiting_a_generated_token_is_not_a_duplicate(self) -> None:
+        """Two `None`s are two tokens that do not exist yet, not one shared one."""
+        bootstrap._reject_duplicate_tokens(
+            [bootstrap.PoolSpec("a", None), bootstrap.PoolSpec("b", None)]
+        )

--- a/services/tests/integration/test_bootstrap_pools_integration.py
+++ b/services/tests/integration/test_bootstrap_pools_integration.py
@@ -1,0 +1,104 @@
+"""Seeding several agent pools, against a real Postgres (#1411).
+
+The unit tests cover reading the environment. Everything here needs the database:
+whether pools and their tokens actually land, whether re-running the Job is the
+no-op it claims to be, and what happens when a token is already registered to a
+different pool — which is the case that silently leaves a listener unable to
+join.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from sqlalchemy import func, select
+
+from terrapod.cli.bootstrap import PoolSpec, _bootstrap_pool
+from terrapod.db.models import AgentPool, AgentPoolToken
+from terrapod.db.session import get_db_session
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed(*specs: PoolSpec) -> None:
+    async with get_db_session() as session, session.begin():
+        for spec in specs:
+            await _bootstrap_pool(session, spec)
+
+
+async def _pool_names() -> list[str]:
+    async with get_db_session() as session:
+        rows = await session.execute(select(AgentPool.name).order_by(AgentPool.name))
+        return list(rows.scalars().all())
+
+
+async def _token_count() -> int:
+    async with get_db_session() as session:
+        return await session.scalar(select(func.count()).select_from(AgentPoolToken)) or 0
+
+
+class TestSeedingSeveralPools:
+    async def test_each_pool_is_created_with_its_own_token(self, app) -> None:
+        await _seed(PoolSpec("pool-a", "tok-a"), PoolSpec("pool-b", "tok-b"))
+
+        assert await _pool_names() == ["pool-a", "pool-b"]
+        assert await _token_count() == 2
+
+    async def test_the_token_is_stored_hashed(self, app) -> None:
+        """A join token is a credential; the row must not carry it in the clear."""
+        await _seed(PoolSpec("pool-a", "tok-a"))
+
+        async with get_db_session() as session:
+            token = (await session.execute(select(AgentPoolToken))).scalar_one()
+        assert token.token_hash == hashlib.sha256(b"tok-a").hexdigest()
+        assert "tok-a" not in str(token.__dict__)
+
+    async def test_re_running_is_a_no_op(self, app) -> None:
+        """The Job runs on every upgrade, so this is the common case, not an edge.
+
+        Duplicating pools or tokens on each upgrade would be a slow-motion mess
+        that only shows up weeks later.
+        """
+        await _seed(PoolSpec("pool-a", "tok-a"), PoolSpec("pool-b", "tok-b"))
+        await _seed(PoolSpec("pool-a", "tok-a"), PoolSpec("pool-b", "tok-b"))
+
+        assert await _pool_names() == ["pool-a", "pool-b"]
+        assert await _token_count() == 2
+
+    async def test_a_pool_added_later_joins_the_existing_ones(self, app) -> None:
+        """Growing the list on an upgrade is the whole point of the feature."""
+        await _seed(PoolSpec("pool-a", "tok-a"))
+        await _seed(PoolSpec("pool-a", "tok-a"), PoolSpec("pool-b", "tok-b"))
+
+        assert await _pool_names() == ["pool-a", "pool-b"]
+        assert await _token_count() == 2
+
+
+class TestTokenAlreadyRegisteredElsewhere:
+    """The failure that would otherwise be silent.
+
+    `token_hash` is unique across all pools, and registration skips a hash that
+    already exists. Without this check the second pool is created, its token
+    quietly skipped, and it ends up with none — the Job reports success and a
+    listener never joins, with nothing in the logs pointing at why.
+    """
+
+    async def test_reusing_another_pools_token_is_an_error(self, app) -> None:
+        await _seed(PoolSpec("pool-a", "shared"))
+
+        with pytest.raises(RuntimeError, match="already registered to a different pool"):
+            await _seed(PoolSpec("pool-b", "shared"))
+
+    async def test_the_first_pool_keeps_its_token(self, app) -> None:
+        """The error must not have taken the working pool down with it."""
+        await _seed(PoolSpec("pool-a", "shared"))
+        with pytest.raises(RuntimeError):
+            await _seed(PoolSpec("pool-b", "shared"))
+
+        async with get_db_session() as session:
+            pool = (
+                await session.execute(select(AgentPool).where(AgentPool.name == "pool-a"))
+            ).scalar_one()
+            token = (await session.execute(select(AgentPoolToken))).scalar_one()
+        assert token.pool_id == pool.id

--- a/services/tests/integration/test_bootstrap_pools_integration.py
+++ b/services/tests/integration/test_bootstrap_pools_integration.py
@@ -102,3 +102,45 @@ class TestTokenAlreadyRegisteredElsewhere:
             ).scalar_one()
             token = (await session.execute(select(AgentPoolToken))).scalar_one()
         assert token.pool_id == pool.id
+
+
+class TestPartialFailure:
+    """One bad pool must not hide the others, or take them down with it.
+
+    The pre-flight duplicate check catches a token shared *within* one batch. It
+    cannot see a token already registered from an earlier run, so that lands in
+    the loop — which is exactly the case the per-pool error handling exists for.
+    """
+
+    async def test_the_job_fails_but_the_good_pools_are_still_seeded(self, app) -> None:
+        await _seed(PoolSpec("existing", "already-used"))
+
+        # 'fresh' is fine; 'clashing' reuses the token 'existing' already holds.
+        async with get_db_session() as session, session.begin():
+            failures = []
+            for spec in (PoolSpec("fresh", "its-own"), PoolSpec("clashing", "already-used")):
+                try:
+                    await _bootstrap_pool(session, spec)
+                except RuntimeError as exc:
+                    failures.append(f"{spec.name}: {exc}")
+
+        # The healthy pool landed rather than being rolled back with the bad one,
+        # and the failure names which pool so it is actionable.
+        assert len(failures) == 1 and "clashing" in failures[0]
+        assert "fresh" in await _pool_names()
+
+    async def test_a_rerun_after_fixing_the_token_completes_the_work(self, app) -> None:
+        """Idempotency is what makes 'fix the Secret and re-run' a real answer."""
+        await _seed(PoolSpec("existing", "already-used"), PoolSpec("fresh", "its-own"))
+
+        with pytest.raises(RuntimeError):
+            await _seed(PoolSpec("clashing", "already-used"))
+
+        await _seed(
+            PoolSpec("existing", "already-used"),
+            PoolSpec("fresh", "its-own"),
+            PoolSpec("clashing", "now-its-own"),
+        )
+
+        assert await _pool_names() == ["clashing", "existing", "fresh"]
+        assert await _token_count() == 3


### PR DESCRIPTION
Brings the v1.5.3 patch forward to `main`, plus two corrections the release
exposed.

`v1.5.3` was cut from the 1.5 line because the operators who need multi-pool
bootstrap are on that line. The work therefore *originated* on the release branch
and is cherry-picked here with `-x`, which is the opposite direction from the one
`AGENTS.md` described — see below.

Not included: the `next` 16.3.1 bump that shipped in v1.5.3. Dependabot #1412
already covers `main`, and dragging a release branch's lockfile forward would
defeat the point of keeping the two lines separate.

## What lands

**Multi-pool bootstrap (#1411)** — reported by @the3venthoriz0n, whose write-up
identified both the mechanism and why the alternatives cannot reach it.

`bootstrap` writes straight to Postgres, which makes it the only way to register
an agent pool before an API exists — and a listener's readiness probe does not
pass until it has joined one, so on a green-field install with `helm --wait` the
pools must exist before anything rolls out. It handled exactly one, so anyone
deploying several listeners was running the CLI in a loop from a hand-written
Job, re-implementing the chart's own Job N times.

`bootstrap.pools` is now a list, each token delivered by `secretKeyRef` so it
never appears in the Job spec, the Helm release, or the state of whatever applied
it. The single-pool form keeps working and gains the same option via
`poolTokenExistingSecret` — it was the one credential the chart still took inline.

Two failures that only exist once this is a list are made loud:

- **A shared token.** `token_hash` is unique across all pools and registration
  skips a hash that already exists. Point two pools at the same Secret — a
  copy-paste away — and the second is created, its token skipped, and it ends up
  with none. The Job reports success and a listener never joins. Refused up front
  naming both pools, and again at registration when the clash is with an earlier
  run.
- **A gap in the indices.** Scanning to the first missing index would silently
  drop every pool after it. The count is declared and the CLI insists on finding
  exactly that many.

**The versioning policy** — a PATCH may now add opt-in configuration. The old
wording said "no new surface", which conflated *adding a key* with *being risky
to take*. The exclusions that matter are unchanged: no API surface, no wire
change, no migration, nothing that alters what an existing configuration does.

**The backport procedure**, on two counts. The patch-material rule said a config
key disqualified a change outright, following the old wording. And the direction
rule assumed a fix always originates on `main` — it does not, and a fix left only
on an older line is a regression waiting for whoever upgrades.

**A CI gate correction.** `e2e-report` merges shard reports into an HTML artifact
for humans and asserts nothing about the product, yet it counted toward
`ci-pass`. On v1.5.3 GitHub's artifact storage would not serve the blob reports —
all eight intact and unexpired per the API, no Terrapod code in the failing step,
`download-artifact` exhausting its own retries — and a rerun reproduced it
exactly. That left a red mark on a release whose images and chart were already
published and verified, with no way to clear it. The job is out of the gate and
tolerates a failed download; the verdict still comes from the eight gated shards.

## Verification

The feature was verified end to end against a real database before release,
taking the environment exactly as the chart renders it:

- Two pools seeded; idempotent re-run; a duplicate token refused **before** a
  tokenless pool is created; partial failure landing the healthy pools and naming
  the bad one; the legacy `poolName`+`poolToken` form the eval profile depends
  on; legacy with no token generating and printing one; and the
  `poolTokenExistingSecret` singular path.
- That end-to-end run is also what caught the log line naming the wrong env var —
  neither the unit nor the integration tests read the log.

11 unit tests, 8 integration tests against real Postgres, and Helm render
assertions now permanent in CI, including one that no join token renders as a
literal. Full suite, lint, and all three values profiles green.

The published v1.5.3 chart was pulled and checked to genuinely contain the
wiring, rather than assumed from a green pipeline.
