### PR TITLE
fix(1426): render every integer config value as an integer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -854,6 +854,41 @@ jobs:
             exit 1
           fi
 
+      - name: No config value renders in scientific notation (#1426)
+        run: |
+          # A values FILE yields float64, and Go renders a large float64 as
+          # `1e+06` — which Pydantic refuses as an integer, so the API will not
+          # boot. `--set` produces an int64 and cannot reproduce it, so this must
+          # go through a file.
+          #
+          # Asserted as a CLASS rather than per key: any numeric setting added
+          # later is covered without anyone remembering to extend this.
+          cat > /tmp/big-values.yaml <<'YAML'
+          api:
+            config:
+              artifact_retention:
+                binary_cache_retention_days: 1000000
+                provider_cache_retention_days: 1000000
+              auth:
+                api_token_max_ttl_hours: 1000000
+              agent_pools:
+                listener_cert_ttl_seconds: 1000000
+              registry:
+                oci:
+                  upload_session_timeout_hours: 1000000
+          YAML
+          out=$(docker run --rm -v "$PWD:/chart" -v /tmp/big-values.yaml:/tmp/big-values.yaml -w /chart \
+            "${HELM_IMAGE:-alpine/helm:3.17.2}" template terrapod helm/terrapod \
+              --namespace terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              -f /tmp/big-values.yaml)
+          if echo "$out" | grep -vE '^\s*#' | grep -qE ':\s*[0-9]+(\.[0-9]+)?e\+[0-9]+\s*$'; then
+            echo "FAIL: a config value rendered in scientific notation — the API will refuse it as an integer at startup. Wrap the render in | int64 (#1426):"
+            echo "$out" | grep -E ':\s*[0-9]+(\.[0-9]+)?e\+[0-9]+\s*$'
+            exit 1
+          fi
+          echo "No config value renders in scientific notation OK"
       - name: Stock install renders a working stack (web + Ingress + bootstrap)
         run: |
           out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -35,13 +35,13 @@ data:
     {{- end }}
     {{- if .Values.api.config.database }}
     database:
-      pool_size: {{ .Values.api.config.database.pool_size | default 10 }}
-      max_overflow: {{ .Values.api.config.database.max_overflow | default 20 }}
+      pool_size: {{ .Values.api.config.database.pool_size | default 10 | int64 }}
+      max_overflow: {{ .Values.api.config.database.max_overflow | default 20 | int64 }}
       pool_pre_ping: {{ .Values.api.config.database.pool_pre_ping | default true }}
-      pool_recycle: {{ .Values.api.config.database.pool_recycle | default 1800 }}
-      pool_timeout: {{ .Values.api.config.database.pool_timeout | default 30 }}
-      connect_timeout: {{ .Values.api.config.database.connect_timeout | default 10 }}
-      command_timeout: {{ .Values.api.config.database.command_timeout | default 30 }}
+      pool_recycle: {{ .Values.api.config.database.pool_recycle | default 1800 | int64 }}
+      pool_timeout: {{ .Values.api.config.database.pool_timeout | default 30 | int64 }}
+      connect_timeout: {{ .Values.api.config.database.connect_timeout | default 10 | int64 }}
+      command_timeout: {{ .Values.api.config.database.command_timeout | default 30 | int64 }}
       auth_mode: {{ .Values.api.config.database.auth_mode | default "password" | quote }}
       aws_iam_region: {{ .Values.api.config.database.aws_iam_region | default "" | quote }}
       ssl_mode: {{ .Values.api.config.database.ssl_mode | default "" | quote }}
@@ -70,7 +70,7 @@ data:
         {{- if .Values.api.config.storage.s3.endpoint_url }}
         endpoint_url: {{ .Values.api.config.storage.s3.endpoint_url | quote }}
         {{- end }}
-        presigned_url_expiry_seconds: {{ .Values.api.config.storage.s3.presigned_url_expiry_seconds }}
+        presigned_url_expiry_seconds: {{ .Values.api.config.storage.s3.presigned_url_expiry_seconds | int64 }}
       {{- end }}
       {{- if eq .Values.api.config.storage.backend "azure" }}
       azure:
@@ -79,7 +79,7 @@ data:
         {{- if .Values.api.config.storage.azure.prefix }}
         prefix: {{ .Values.api.config.storage.azure.prefix | quote }}
         {{- end }}
-        presigned_url_expiry_seconds: {{ .Values.api.config.storage.azure.presigned_url_expiry_seconds }}
+        presigned_url_expiry_seconds: {{ .Values.api.config.storage.azure.presigned_url_expiry_seconds | int64 }}
       {{- end }}
       {{- if eq .Values.api.config.storage.backend "gcs" }}
       gcs:
@@ -93,12 +93,12 @@ data:
         {{- if .Values.api.config.storage.gcs.service_account_email }}
         service_account_email: {{ .Values.api.config.storage.gcs.service_account_email | quote }}
         {{- end }}
-        presigned_url_expiry_seconds: {{ .Values.api.config.storage.gcs.presigned_url_expiry_seconds }}
+        presigned_url_expiry_seconds: {{ .Values.api.config.storage.gcs.presigned_url_expiry_seconds | int64 }}
       {{- end }}
       {{- if eq .Values.api.config.storage.backend "filesystem" }}
       filesystem:
         root_dir: {{ .Values.api.config.storage.filesystem.root_dir | quote }}
-        presigned_url_expiry_seconds: {{ .Values.api.config.storage.filesystem.presigned_url_expiry_seconds }}
+        presigned_url_expiry_seconds: {{ .Values.api.config.storage.filesystem.presigned_url_expiry_seconds | int64 }}
         {{- if .Values.api.config.storage.filesystem.base_url }}
         base_url: {{ .Values.api.config.storage.filesystem.base_url | quote }}
         {{- end }}
@@ -109,14 +109,14 @@ data:
       {{- if .Values.api.config.auth.callback_base_url }}
       callback_base_url: {{ .Values.api.config.auth.callback_base_url | quote }}
       {{- end }}
-      session_ttl_hours: {{ .Values.api.config.auth.session_ttl_hours | default 12 }}
-      api_token_max_ttl_hours: {{ .Values.api.config.auth.api_token_max_ttl_hours | default 8760 }}
+      session_ttl_hours: {{ .Values.api.config.auth.session_ttl_hours | default 12 | int64 }}
+      api_token_max_ttl_hours: {{ .Values.api.config.auth.api_token_max_ttl_hours | default 8760 | int64 }}
       {{- /* Rendered directly (no `| default`): 0 is meaningful for these and
              Helm's `default` would silently rewrite a configured 0 to the default. */}}
-      login_token_ttl_hours: {{ .Values.api.config.auth.login_token_ttl_hours }}
-      service_token_max_ttl_hours: {{ .Values.api.config.auth.service_token_max_ttl_hours }}
-      token_expiry_warning_days: {{ .Values.api.config.auth.token_expiry_warning_days }}
-      bound_token_idle_days: {{ .Values.api.config.auth.bound_token_idle_days }}
+      login_token_ttl_hours: {{ .Values.api.config.auth.login_token_ttl_hours | int64 }}
+      service_token_max_ttl_hours: {{ .Values.api.config.auth.service_token_max_ttl_hours | int64 }}
+      token_expiry_warning_days: {{ .Values.api.config.auth.token_expiry_warning_days | int64 }}
+      bound_token_idle_days: {{ .Values.api.config.auth.bound_token_idle_days | int64 }}
       {{- if .Values.api.config.auth.require_external_sso_for_roles }}
       require_external_sso_for_roles:
         {{- range .Values.api.config.auth.require_external_sso_for_roles }}
@@ -197,13 +197,13 @@ data:
       oci:
         enabled: {{ .enabled }}
         {{- with .upload_session_timeout_hours }}
-        upload_session_timeout_hours: {{ . }}
+        upload_session_timeout_hours: {{ . | int64 }}
         {{- end }}
         {{- with .gc }}
         gc:
           enabled: {{ .enabled }}
           {{- with .grace_hours }}
-          grace_hours: {{ . }}
+          grace_hours: {{ . | int64 }}
           {{- end }}
         {{- end }}
         {{- if .upstreams }}
@@ -338,8 +338,8 @@ data:
       probe_url:
         internal: {{ .Values.api.config.ha.probe_url.internal | default "" | quote }}
         external: {{ .Values.api.config.ha.probe_url.external | default "" | quote }}
-      probe_interval_seconds: {{ .Values.api.config.ha.probe_interval_seconds | default 60 }}
-      probe_threshold: {{ .Values.api.config.ha.probe_threshold | default 3 }}
+      probe_interval_seconds: {{ .Values.api.config.ha.probe_interval_seconds | default 60 | int64 }}
+      probe_threshold: {{ .Values.api.config.ha.probe_threshold | default 3 | int64 }}
       {{- with .Values.api.config.ha.peer }}
       peer:
         url: {{ .url | default "" | quote }}
@@ -358,7 +358,7 @@ data:
       {{- with .Values.api.config.ha.component_status }}
       component_status:
         enabled: {{ .enabled | default false }}
-        interval_seconds: {{ .interval_seconds | default 60 }}
+        interval_seconds: {{ .interval_seconds | default 60 | int64 }}
         read_nodes: {{ .read_nodes | default false }}
         namespace: {{ .namespace | default "" | quote }}
         instance: {{ .instance | default $.Release.Name | quote }}
@@ -366,14 +366,14 @@ data:
       {{- with .Values.api.config.ha.replication }}
       replication:
         enabled: {{ .enabled | default false }}
-        interval_seconds: {{ .interval_seconds | default 60 }}
-        batch_size: {{ .batch_size | default 500 }}
-        retention_days: {{ .retention_days | default 7 }}
+        interval_seconds: {{ .interval_seconds | default 60 | int64 }}
+        batch_size: {{ .batch_size | default 500 | int64 }}
+        retention_days: {{ .retention_days | default 7 | int64 }}
       {{- end }}
       {{- with .Values.api.config.ha.blobs }}
       blobs:
         mode: {{ .mode | default "verify" | quote }}
-        interval_seconds: {{ .interval_seconds | default 300 }}
+        interval_seconds: {{ .interval_seconds | default 300 | int64 }}
         concurrency: {{ .concurrency | default 4 }}
         {{- /* Two traps in one line each.
                No `| default`: 0 is meaningful for both (it disables the throttle
@@ -399,8 +399,8 @@ data:
     {{- if .Values.api.config.vcs }}
     vcs:
       enabled: {{ .Values.api.config.vcs.enabled }}
-      poll_interval_seconds: {{ .Values.api.config.vcs.poll_interval_seconds | default 60 }}
-      module_poll_interval_seconds: {{ .Values.api.config.vcs.module_poll_interval_seconds | default 300 }}
+      poll_interval_seconds: {{ .Values.api.config.vcs.poll_interval_seconds | default 60 | int64 }}
+      module_poll_interval_seconds: {{ .Values.api.config.vcs.module_poll_interval_seconds | default 300 | int64 }}
       # tmpdir tracks the ephemeralStorage mountPath so the VCS poller writes
       # streamed tarballs onto the PVC, not pod memory. Override
       # api.config.vcs.tmpdir if you remount the PVC elsewhere.
@@ -414,23 +414,23 @@ data:
     {{- end }}
     {{- if .Values.api.config.audit }}
     audit:
-      retention_days: {{ .Values.api.config.audit.retention_days | default 90 }}
+      retention_days: {{ .Values.api.config.audit.retention_days | default 90 | int64 }}
     {{- end }}
     {{- if .Values.api.config.agent_pools }}
     agent_pools:
-      listener_cert_ttl_seconds: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 }}
+      listener_cert_ttl_seconds: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 | int64 }}
       {{- with .Values.api.config.agent_pools.default_join_token_max_uses }}
-      default_join_token_max_uses: {{ . }}
+      default_join_token_max_uses: {{ . | int64 }}
       {{- end }}
       {{- with .Values.api.config.agent_pools.default_join_token_ttl_seconds }}
-      default_join_token_ttl_seconds: {{ . }}
+      default_join_token_ttl_seconds: {{ . | int64 }}
       {{- end }}
     {{- end }}
     {{- if .Values.api.config.drift_detection }}
     drift_detection:
       enabled: {{ .Values.api.config.drift_detection.enabled }}
-      poll_interval_seconds: {{ .Values.api.config.drift_detection.poll_interval_seconds | default 300 }}
-      min_workspace_interval_seconds: {{ .Values.api.config.drift_detection.min_workspace_interval_seconds | default 3600 }}
+      poll_interval_seconds: {{ .Values.api.config.drift_detection.poll_interval_seconds | default 300 | int64 }}
+      min_workspace_interval_seconds: {{ .Values.api.config.drift_detection.min_workspace_interval_seconds | default 3600 | int64 }}
     {{- end }}
     {{- if .Values.api.config.slack }}
     slack:
@@ -445,8 +445,8 @@ data:
     {{- if .Values.api.config.notifications }}
     notifications:
       enabled: {{ .Values.api.config.notifications.enabled }}
-      delivery_timeout_seconds: {{ .Values.api.config.notifications.delivery_timeout_seconds | default 30 }}
-      max_delivery_responses: {{ .Values.api.config.notifications.max_delivery_responses | default 10 }}
+      delivery_timeout_seconds: {{ .Values.api.config.notifications.delivery_timeout_seconds | default 30 | int64 }}
+      max_delivery_responses: {{ .Values.api.config.notifications.max_delivery_responses | default 10 | int64 }}
       {{- if .Values.api.config.notifications.smtp }}
       smtp:
         {{- if .Values.api.config.notifications.smtp.host }}
@@ -481,22 +481,22 @@ data:
     {{- if .Values.api.config.artifact_retention }}
     artifact_retention:
       enabled: {{ .Values.api.config.artifact_retention.enabled }}
-      poll_interval_seconds: {{ .Values.api.config.artifact_retention.poll_interval_seconds | default 86400 }}
-      batch_size: {{ .Values.api.config.artifact_retention.batch_size | default 100 }}
-      state_versions_keep: {{ .Values.api.config.artifact_retention.state_versions_keep | default 20 }}
-      run_artifacts_retention_days: {{ .Values.api.config.artifact_retention.run_artifacts_retention_days | default 90 }}
-      config_versions_retention_days: {{ .Values.api.config.artifact_retention.config_versions_retention_days | default 90 }}
-      provider_cache_retention_days: {{ .Values.api.config.artifact_retention.provider_cache_retention_days | default 30 }}
-      binary_cache_retention_days: {{ .Values.api.config.artifact_retention.binary_cache_retention_days | default 30 }}
-      package_cache_retention_days: {{ .Values.api.config.artifact_retention.package_cache_retention_days | default 30 }}
-      module_overrides_retention_days: {{ .Values.api.config.artifact_retention.module_overrides_retention_days | default 14 }}
-      deleted_workspace_retention_days: {{ .Values.api.config.artifact_retention.deleted_workspace_retention_days | default 30 }}
+      poll_interval_seconds: {{ .Values.api.config.artifact_retention.poll_interval_seconds | default 86400 | int64 }}
+      batch_size: {{ .Values.api.config.artifact_retention.batch_size | default 100 | int64 }}
+      state_versions_keep: {{ .Values.api.config.artifact_retention.state_versions_keep | default 20 | int64 }}
+      run_artifacts_retention_days: {{ .Values.api.config.artifact_retention.run_artifacts_retention_days | default 90 | int64 }}
+      config_versions_retention_days: {{ .Values.api.config.artifact_retention.config_versions_retention_days | default 90 | int64 }}
+      provider_cache_retention_days: {{ .Values.api.config.artifact_retention.provider_cache_retention_days | default 30 | int64 }}
+      binary_cache_retention_days: {{ .Values.api.config.artifact_retention.binary_cache_retention_days | default 30 | int64 }}
+      package_cache_retention_days: {{ .Values.api.config.artifact_retention.package_cache_retention_days | default 30 | int64 }}
+      module_overrides_retention_days: {{ .Values.api.config.artifact_retention.module_overrides_retention_days | default 14 | int64 }}
+      deleted_workspace_retention_days: {{ .Values.api.config.artifact_retention.deleted_workspace_retention_days | default 30 | int64 }}
     {{- end }}
     {{- if .Values.backup }}
     backup:
       prefix: {{ .Values.backup.prefix | default "backups/" | quote }}
       retention_keep: {{ (.Values.backup.retention).keep | default 0 }}
-      retention_days: {{ (.Values.backup.retention).days | default 0 }}
+      retention_days: {{ (.Values.backup.retention).days | default 0 | int64 }}
     {{- end }}
     {{- if .Values.api.config.encryption }}
     # App-layer encryption at rest (#553) — non-secret config only; the static
@@ -650,10 +650,10 @@ data:
       enabled: {{ .Values.api.config.rate_limit.enabled }}
       {{- /* Rendered directly (no `| default`): 0 means "unlimited" for these
              rates and Helm's `default` would silently rewrite a configured 0. */}}
-      requests_per_minute: {{ .Values.api.config.rate_limit.requests_per_minute }}
-      authenticated_requests_per_minute: {{ .Values.api.config.rate_limit.authenticated_requests_per_minute }}
-      runner_requests_per_minute: {{ .Values.api.config.rate_limit.runner_requests_per_minute }}
-      auth_requests_per_minute: {{ .Values.api.config.rate_limit.auth_requests_per_minute }}
-      distinct_credentials_per_minute: {{ .Values.api.config.rate_limit.distinct_credentials_per_minute }}
+      requests_per_minute: {{ .Values.api.config.rate_limit.requests_per_minute | int64 }}
+      authenticated_requests_per_minute: {{ .Values.api.config.rate_limit.authenticated_requests_per_minute | int64 }}
+      runner_requests_per_minute: {{ .Values.api.config.rate_limit.runner_requests_per_minute | int64 }}
+      auth_requests_per_minute: {{ .Values.api.config.rate_limit.auth_requests_per_minute | int64 }}
+      distinct_credentials_per_minute: {{ .Values.api.config.rate_limit.distinct_credentials_per_minute | int64 }}
     {{- end }}
 {{- end }}

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -42,7 +42,7 @@ data:
     credentials_secret_name: {{ include "terrapod.listenerCredentialsSecretName" . | quote }}
     health_port: {{ .Values.listener.healthPort | default 8081 }}
     public_api_url: {{ .Values.listener.publicApiUrl | default .Values.api.config.external_url | default "" | quote }}
-    listener_cert_ttl_seconds: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 }}
+    listener_cert_ttl_seconds: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 | int64 }}
     heartbeat_interval: {{ .Values.listener.heartbeatInterval | default 60 }}
     max_concurrent: {{ .Values.listener.maxConcurrent | default 3 }}
     poll_interval: {{ .Values.listener.pollInterval | default 30 }}


### PR DESCRIPTION
`binary_cache_retention_days: 1000000` in a values file rendered as
`binary_cache_retention_days: 1e+06`. Pydantic refuses that as an integer, so the
API does not start — and the error names a validation failure rather than the
chart that produced it.

## Why it went unnoticed

`--set` is fine: Helm's strvals parser produces an int64. A **values file** goes
through YAML, yields a float64, and Go renders a large float64 in exponent form.
So the mechanism operators actually configure with is the one that breaks, and
the one most testing reaches for cannot reproduce it.

Every default is small, so nothing hit it in practice. It is waiting for the
first operator with a long retention window or a large token TTL.

## Scope

**52 render sites** across `configmap-api.yaml` and `configmap-runner.yaml` now
cast through `| int64`.

That cast was already the remedy here — it appears twice in `configmap-api.yaml`
with a comment describing exactly this failure, applied to a byte size and a
token budget after someone was bitten. This applies it as a class instead of one
key at a time.

Rendered output is **byte-identical** for every values profile; `int64` changes
nothing for values that were already rendering as integers.

## The guard

Asserted as a class rather than per key:

> no rendered config value may match scientific notation

so any numeric setting added later is covered without someone remembering to
extend the test. It goes through a values file, because `--set` cannot reproduce
the bug.

Verified by reverting a single cast and confirming the assertion fails.

## Found by

Adding `registry.oci.mirror_tag_ttl_hours` (#1425), where the same bug appeared
alongside a second one on the same key: Helm's `with` treats `0` as empty, so
`mirror_tag_ttl_hours: 0` — which means "never re-check" — rendered nothing and
silently became the code default. Both are fixed there; this PR is the other 51
sites.

Closes #1426
