### PR TITLE
fix(1425): refresh a stale mirrored tag before returning it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -952,6 +952,26 @@ jobs:
             echo "FAIL: a scheduled mirror-expiry key is back. Deleting a cached image on a timer cannot make it fresher and discards the fallback needed when upstream is down (#1419)"; exit 1
           fi
           echo "OCI GC config renders OK"
+      - name: The cached-image staleness threshold is operator-settable (#1425)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
+            template terrapod helm/terrapod \
+              --namespace terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set api.config.registry.oci.mirror_tag_ttl_hours=24)
+          echo "$out" | grep -q "mirror_tag_ttl_hours: 24" || { echo "FAIL: registry.oci.mirror_tag_ttl_hours not rendered — an operator lowering the staleness window for a fast-moving tag would be silently ignored and the code default would win (#1425)"; exit 1; }
+          # 0 means "never re-check", and Helm's `with` treats 0 as empty — so a
+          # template using it drops the key and the code default wins, turning
+          # "never expire" into "expire daily". Asserted because it is silent.
+          zero=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
+            template terrapod helm/terrapod \
+              --namespace terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set api.config.registry.oci.mirror_tag_ttl_hours=0)
+          echo "$zero" | grep -q "mirror_tag_ttl_hours: 0" || { echo "FAIL: mirror_tag_ttl_hours=0 did not render — 'never re-check' would silently become the code default (#1425)"; exit 1; }
+          echo "Cached-image staleness threshold renders OK, including 0"
       - name: Local dev values render
         run: |
           out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \

--- a/alembic/versions/792641f78049_oci_tag_revalidated_at.py
+++ b/alembic/versions/792641f78049_oci_tag_revalidated_at.py
@@ -1,0 +1,52 @@
+"""When a mirrored tag was last confirmed against upstream (#1425).
+
+Pure expand: one nullable column, so old and new replicas run against it safely
+during a rolling upgrade.
+
+The backfill needs explaining, because NULL is not merely "unset" once this
+column exists — it marks a tag as locally pushed, and locally pushed tags are
+never revalidated. Leaving every existing row NULL would therefore withhold the
+fix from precisely the tags that motivated it: an operator upgrades to stop
+`latest` being pinned for ever, and every `latest` they already had stays pinned
+for ever.
+
+So existing tags in repositories that mirror are backfilled from `updated_at`,
+which starts their freshness window at the last time the row was known to be
+current. They revalidate on the first pull after the TTL, which is the intended
+behaviour.
+
+Rows predating this column carry no provenance, so one case is genuinely
+ambiguous: a tag *pushed* into a mirror repository is indistinguishable from one
+fetched into it, and is backfilled alongside. That is the deliberate trade — it
+is an unusual thing to have done, and the alternative silently withholds the fix
+from every cached tag in the deployment. Tags created from here on record their
+provenance at write time and are not guessed about.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "792641f78049"
+down_revision = "c45b8a594980"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "oci_tags",
+        sa.Column("revalidated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE oci_tags
+           SET revalidated_at = oci_tags.updated_at
+          FROM oci_repositories
+         WHERE oci_repositories.id = oci_tags.repository_id
+           AND oci_repositories.upstream IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("oci_tags", "revalidated_at")

--- a/docs/oci-registry.md
+++ b/docs/oci-registry.md
@@ -127,6 +127,32 @@ A subject with nothing attached returns an **empty index**, never a 404 — a 40
 tells a client the endpoint is unsupported and sends it down a legacy fallback
 path.
 
+## How a cached image stays current
+
+A pull-through cached image is served for **a day** by default without asking
+upstream anything. Past that, the next pull confirms the tag against upstream
+**before returning the image**, so the caller gets current content on that pull
+rather than the next one:
+
+- **Unchanged** — the cached image is served and the clock resets. This is the
+  common case, and it costs one small `HEAD` rather than a download.
+- **Moved** — the new manifest is fetched and served. The superseded one stops
+  being referenced, and its layers become collectable once no other image needs
+  them.
+- **Upstream unreachable, erroring, or the tag deleted there** — the cached image
+  is served anyway. A pull-through cache that stops answering when it cannot
+  reach the internet has failed at the one thing it exists for, and inside a
+  restricted network there is no second source to fall back on.
+
+Tune it with `registry.oci.mirror_tag_ttl_hours`: lower for a fast-moving tag,
+higher to cut round trips. Every check is a request a purely local pull would not
+otherwise make.
+
+A **tag is the only thing here that can go stale.** Digests are never re-checked,
+because a digest is immutable by construction, and neither are pushed images —
+nothing moves under them. Nothing is checked at all when `cache_only` is set,
+since reaching upstream is exactly what sealing forbids.
+
 ## Deletion
 
 **An image you pushed stays until you remove it.** A registry is not a cache for
@@ -235,6 +261,7 @@ mid-flight would destroy real work.
 | `api.config.registry.oci.upload_session_timeout_hours` | `24` | How long an in-progress upload may sit untouched before it is reaped with its chunks. |
 | `api.config.registry.oci.gc.enabled` | `true` | Collect unreferenced blobs. Off means the registry only ever grows — there is no delete API. |
 | `api.config.registry.oci.gc.grace_hours` | `24` | How long newly-arrived content is protected, so a push in flight is never collected. |
+| `api.config.registry.oci.mirror_tag_ttl_hours` | `24` (one day) | How long a pull-through cached image is served before the next pull re-checks upstream. |
 | `api.config.registry.cache_only` | `false` | Seals upstream fetching for every cache, this one included. |
 
 ## Verifying a deployment

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -206,6 +206,17 @@ data:
           grace_hours: {{ . | int64 }}
           {{- end }}
         {{- end }}
+        {{/* hasKey, not `with`: 0 is a MEANINGFUL value here (never re-check)
+             and `with` treats it as empty, so the key would silently vanish and
+             the code default would win — turning "never expire" into "expire
+             daily", which is the opposite of what was asked for. */}}
+        {{- if hasKey . "mirror_tag_ttl_hours" }}
+        {{/* int64, because a values FILE yields float64 and a large number then
+             renders in scientific notation — 1000000 becomes 1e+06, which the
+             API rejects as an integer at startup. `--set` is unaffected, so this
+             only bites the way operators actually configure things. */}}
+        mirror_tag_ttl_hours: {{ int64 .mirror_tag_ttl_hours }}
+        {{- end }}
         {{- if .upstreams }}
         upstreams:
           {{- range .upstreams }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -1860,6 +1860,10 @@
                     "grace_hours": { "type": "integer", "minimum": 1 }
                   }
                 },
+                "mirror_tag_ttl_hours": {
+                  "type": "integer",
+                  "minimum": 0
+                },
                 "upstreams": {
                   "type": "array",
                   "items": {

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -322,6 +322,23 @@ api:
           # the two would delete the layers of a push still in progress. Raise it
           # if pushes in your environment can legitimately take longer.
           grace_hours: 24
+        # How long a pull-through cached image is served before Terrapod
+        # re-checks upstream (#1425). A tag is mutable — `latest` points
+        # somewhere different over time — so it is the one cached thing here
+        # that can go stale.
+        #
+        # Past this, the next pull confirms the tag against upstream BEFORE
+        # returning the image, so the caller gets current content on that pull
+        # rather than the next one. If upstream cannot be reached the cached
+        # image is served anyway: a stale image that runs beats a correct one
+        # you cannot fetch.
+        #
+        # Lower it for a fast-moving tag; raise it to cut round trips. Every
+        # check is a request a purely local pull would not otherwise make.
+        # Ignored entirely when registry.cache_only is set.
+        # 0 means never re-check: every cached image stays pinned at the
+        # digest it first resolved to.
+        mirror_tag_ttl_hours: 24
       # Language package proxies (#1417). Point runners at these with
       # PIP_INDEX_URL and NPM_CONFIG_REGISTRY and a run resolves its dependency
       # closure with no upstream reach — which is the only way a Pulumi program

--- a/services/terrapod/api/routers/oci.py
+++ b/services/terrapod/api/routers/oci.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -35,7 +36,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.api.dependencies import AuthenticatedUser, get_db
 from terrapod.auth import capabilities as cap
 from terrapod.auth.capabilities import has_capability
+from terrapod.config import settings
 from terrapod.db.models import OCIRepository
+from terrapod.logging_config import get_logger
 from terrapod.services.oci import pullthrough_service, registry_service, upload_service
 from terrapod.services.oci.auth import BASIC_CHALLENGE, authenticate_oci
 from terrapod.services.oci.errors import (
@@ -63,6 +66,8 @@ from terrapod.services.oci.names import (
 from terrapod.services.registry_rbac_service import resolve_registry_capabilities_for
 from terrapod.storage import ObjectStore, get_storage
 from terrapod.storage import keys as storage_keys
+
+logger = get_logger(__name__)
 
 router = APIRouter(tags=["oci"])
 
@@ -209,6 +214,11 @@ async def get_manifest(
     manifest = await registry_service.resolve_manifest(db, repository, parsed)
     if manifest is None and repository.upstream:
         manifest = await _mirror_manifest(db, storage, repository, reference, parsed)
+    elif manifest is not None and repository.upstream and parsed.tag is not None:
+        # A cached mirrored TAG may have moved upstream since we resolved it.
+        # Confirmed here, before the image is handed back, so the caller gets
+        # current content on this pull rather than the next one.
+        manifest = await _revalidate_tag(db, storage, repository, parsed.tag, manifest)
     if manifest is None:
         raise OCIError(MANIFEST_UNKNOWN, detail={"reference": reference})
 
@@ -602,6 +612,77 @@ async def put_manifest(
 # transient and worth retrying, the first is not.
 
 
+async def _revalidate_tag(db, storage, repository, tag: str, cached):
+    """Confirm a cached mirrored tag against upstream, refreshing it if it moved.
+
+    A tag is the only mutable thing Terrapod caches. Every other artifact —
+    provider binaries, CLI binaries, wheels, npm tarballs, and blobs addressed by
+    digest — is pinned to a coordinate that cannot change upstream, which is why
+    none of them needs this and why it should not be generalised back to them.
+
+    **Whatever happens, an image comes back.** Upstream unreachable, upstream
+    returning an error, the tag deleted upstream — all resolve to serving what is
+    already cached. A pull-through cache that stops answering when it cannot
+    reach the internet has failed at the one thing it exists for, and in a
+    restricted network there is no second source to fall back to.
+
+    On failure the check timestamp is still moved forward. Retrying on every pull
+    while an upstream is down would add its timeout to each one, turning a
+    reachability problem into a latency problem for content we hold locally — and
+    the TTL is already the staleness we accepted.
+    """
+    ttl_hours = settings.registry.oci.mirror_tag_ttl_hours
+    if ttl_hours == 0:
+        # Explicitly pinned: every cached image stays at whatever digest it first
+        # resolved to. Chosen when reproducibility matters more than currency.
+        return cached
+    ttl = timedelta(hours=ttl_hours)
+    if settings.registry.cache_only:
+        # Sealed: reaching upstream is precisely what is forbidden.
+        return cached
+
+    tag_row = await registry_service.get_tag(db, repository, tag)
+    if tag_row is None:
+        return cached
+    checked = tag_row.revalidated_at
+    if checked is None:
+        # Pushed into a mirror repository rather than fetched into it. It names
+        # local content that upstream knows nothing about, and asking upstream
+        # about it risks replacing it with a same-named image from elsewhere.
+        return cached
+    if datetime.now(UTC) - checked < ttl:
+        return cached
+
+    resolved = pullthrough_service.resolve_upstream(repository.name)
+    if resolved is None or not pullthrough_service.mirroring_allowed():
+        return cached
+    host, upstream_repo = resolved
+
+    upstream_digest = await pullthrough_service.current_upstream_digest(host, upstream_repo, tag)
+    tag_row.revalidated_at = datetime.now(UTC)
+    await db.flush()
+
+    if upstream_digest is None or upstream_digest == cached.digest:
+        return cached
+
+    # It moved. Fetch what it points at now; the superseded manifest is left in
+    # place, un-referenced by this tag, for the collector to reclaim.
+    logger.info(
+        "Mirrored tag moved upstream; refreshing before serving",
+        repository=repository.name,
+        tag=tag,
+        was=cached.digest,
+        now=upstream_digest,
+    )
+    try:
+        refreshed = await _mirror_manifest(db, storage, repository, tag, parse_reference(tag))
+    except OCIError:
+        # Upstream confirmed a new digest and then would not serve it. The cached
+        # image is still a working answer.
+        return cached
+    return refreshed or cached
+
+
 async def _mirror_manifest(db, storage, repository, reference: str, parsed):
     """Fetch a manifest from upstream and record it."""
     resolved = pullthrough_service.resolve_upstream(repository.name)
@@ -624,7 +705,7 @@ async def _mirror_manifest(db, storage, repository, reference: str, parsed):
     # Only a tag needs recording: a digest reference is already the manifest's
     # own identity and names nothing that can move.
     if parsed.tag is not None:
-        await registry_service.set_tag(db, repository, parsed.tag, manifest)
+        await registry_service.set_tag(db, repository, parsed.tag, manifest, from_upstream=True)
     return manifest
 
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -891,6 +891,23 @@ class OCIRegistryConfig(BaseModel):
         "oci.upstreams[].existingSecret) — never a password in this file.",
     )
     gc: OCIGarbageCollectionConfig = Field(default_factory=OCIGarbageCollectionConfig)
+    mirror_tag_ttl_hours: int = Field(
+        default=24,
+        ge=0,
+        description="How many hours a pull-through cached image is served without "
+        "re-checking upstream. A tag is mutable — `latest` points somewhere different "
+        "over time — so unlike every other artifact Terrapod caches it can go stale. "
+        "Past this, the next pull confirms the tag against upstream BEFORE returning "
+        "the image, so the caller gets current content on that pull rather than the "
+        "next one. If upstream cannot be reached the cached image is served anyway: a "
+        "stale image that runs beats a correct one you cannot fetch, which is the whole "
+        "point of a pull-through cache in a restricted network. "
+        "**0 means never re-check** — pin every cached image at whatever digest it "
+        "first resolved to, which is what you want when reproducibility matters more "
+        "than currency, or on a deployment that will never reach upstream again. "
+        "Digests are never re-checked regardless (immutable by construction), and "
+        "nothing is checked when `cache_only` is set.",
+    )
     upload_session_timeout_hours: int = Field(
         default=24,
         ge=1,

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -3069,6 +3069,16 @@ class OCITag(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
+    #: When this tag was last confirmed against upstream (#1425). Distinct from
+    #: `updated_at`, which moves only when the tag is repointed: a tag confirmed
+    #: *unchanged* has been checked without having moved, and conflating the two
+    #: would make every successful revalidation look like a retag.
+    #:
+    #: NULL is load-bearing rather than merely unset — it marks a tag as locally
+    #: pushed, and locally pushed tags are never revalidated. A mirror repository
+    #: can hold both kinds at once, and without this an upstream image sharing a
+    #: name with a pushed one would replace it.
+    revalidated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     __table_args__ = (sa.UniqueConstraint("repository_id", "name", name="uq_oci_tag_repo_name"),)
 

--- a/services/terrapod/services/oci/pullthrough_service.py
+++ b/services/terrapod/services/oci/pullthrough_service.py
@@ -195,3 +195,57 @@ async def ensure_mirror_repository(db, name: str, host: str) -> OCIRepository:
     await db.flush()
     logger.info("oci_mirror_created", repository=name, upstream=host)
     return repository
+
+
+async def current_upstream_digest(host: str, repository: str, tag: str) -> str | None:
+    """What upstream says this tag points at now, or None if it cannot be reached.
+
+    A `HEAD` returns `Docker-Content-Digest` without the body, so confirming an
+    unchanged tag — the common case by a wide margin — costs one small request
+    rather than a manifest download.
+
+    Returns None rather than raising on any failure. The caller's answer to "I
+    could not check" is to serve what it already has, so an unreachable upstream
+    is a normal outcome here rather than an error: a cache that stops answering
+    when the internet is unavailable has failed at its one job.
+
+    Deliberately short timeouts. This is an optimisation on the read path, and a
+    slow upstream must not make a pull that could be served locally slow too.
+    """
+    url = f"{_base_url(host)}/v2/{repository}/manifests/{tag}"
+    headers = {"Accept": MANIFEST_ACCEPT}
+    auth = _auth(host)
+    if auth:
+        headers["Authorization"] = auth
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=httpx.Timeout(connect=3.0, read=10.0, write=10.0, pool=3.0),
+        ) as client:
+            response = await client.head(url, headers=headers)
+    except httpx.HTTPError as exc:
+        logger.info(
+            "Could not confirm mirrored tag with upstream; serving the cached image",
+            host=host,
+            repository=repository,
+            tag=tag,
+            error=str(exc),
+        )
+        return None
+
+    if response.status_code >= 400:
+        # Includes the tag having been deleted upstream (404). Keeping what we
+        # have is still right: it is the only copy on this side of the boundary,
+        # and disappearing content is not an improvement.
+        logger.info(
+            "Upstream did not confirm mirrored tag; serving the cached image",
+            host=host,
+            repository=repository,
+            tag=tag,
+            status=response.status_code,
+        )
+        return None
+
+    digest = response.headers.get("Docker-Content-Digest", "").strip()
+    return digest or None

--- a/services/terrapod/services/oci/registry_service.py
+++ b/services/terrapod/services/oci/registry_service.py
@@ -234,13 +234,29 @@ async def store_manifest(
 
 
 async def set_tag(
-    db: AsyncSession, repository: OCIRepository, name: str, manifest: OCIManifest
+    db: AsyncSession,
+    repository: OCIRepository,
+    name: str,
+    manifest: OCIManifest,
+    *,
+    from_upstream: bool = False,
 ) -> OCITag:
     """Point a tag at a manifest, moving it if it already exists.
 
     Tags are mutable by design — ``latest`` moving is the whole point — so this
     updates in place rather than inserting, which also keeps the unique
     constraint on (repository, name) from turning a normal re-tag into a 500.
+
+    ``from_upstream`` records that this tag's content came from a mirror fetch,
+    by stamping ``revalidated_at``. It carries more weight than it looks: that
+    timestamp is what separates a mirrored tag from one a user pushed, and only a
+    mirrored tag is ever revalidated against upstream (#1425). A push into a
+    mirror repository leaves it NULL and is therefore left alone — otherwise
+    upstream's ``v1`` would quietly overwrite the ``v1`` someone deliberately
+    pushed here.
+
+    Stamping it at fetch time also starts the freshness window at the moment the
+    content was actually confirmed, rather than at the next read.
     """
     result = await db.execute(
         select(OCITag).where(OCITag.repository_id == repository.id, OCITag.name == name)
@@ -248,10 +264,17 @@ async def set_tag(
     tag = result.scalar_one_or_none()
     if tag is not None:
         tag.manifest_id = manifest.id
+        if from_upstream:
+            tag.revalidated_at = datetime.now(UTC)
         await db.flush()
         return tag
 
-    tag = OCITag(repository_id=repository.id, name=name, manifest_id=manifest.id)
+    tag = OCITag(
+        repository_id=repository.id,
+        name=name,
+        manifest_id=manifest.id,
+        revalidated_at=datetime.now(UTC) if from_upstream else None,
+    )
     db.add(tag)
     await db.flush()
     return tag
@@ -317,3 +340,17 @@ async def list_referrers(
         query = query.where(OCIManifest.artifact_type == artifact_type)
     result = await db.execute(query.order_by(OCIManifest.created_at))
     return list(result.scalars().all())
+
+
+async def get_tag(db: AsyncSession, repository: OCIRepository, name: str) -> OCITag | None:
+    """The tag row itself, rather than the manifest it points at.
+
+    `resolve_manifest` joins straight through to the manifest, which is what a
+    pull needs. Revalidation needs the tag: when it was last confirmed against
+    upstream lives there, not on the manifest, because several tags can point at
+    one manifest and each is checked on its own schedule.
+    """
+    result = await db.execute(
+        select(OCITag).where(OCITag.repository_id == repository.id, OCITag.name == name)
+    )
+    return result.scalar_one_or_none()

--- a/services/tests/api/test_oci_read_path.py
+++ b/services/tests/api/test_oci_read_path.py
@@ -67,11 +67,28 @@ def _blob(digest=_DIGEST):
     return b
 
 
+def _db_mock() -> AsyncMock:
+    """An AsyncMock session whose result accessors are SYNC, as the real ones are.
+
+    `AsyncMock` makes every child async, so
+    `(await db.execute(...)).scalar_one_or_none()` hands back a *coroutine*
+    rather than a row. Code that then reads an attribute off it fails with a
+    message about a coroutine, which reads as a bug in the code under test and is
+    a bug in the mock.
+    """
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=None)
+    result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
 def _make_app(user=_user(), storage=None):
     app = create_app()
     if user is not None:
         app.dependency_overrides[authenticate_oci] = lambda: user
-    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_db] = lambda: _db_mock()
     app.dependency_overrides[get_storage] = lambda: storage or AsyncMock()
     return app
 
@@ -373,7 +390,7 @@ class TestPullThroughMirror:
         storage = AsyncMock()
         storage.get.return_value = b"{}"
 
-        db = AsyncMock()
+        db = _db_mock()
         app = create_app()
         app.dependency_overrides[authenticate_oci] = lambda: _user()
         app.dependency_overrides[get_db] = lambda: db

--- a/services/tests/api/test_oci_tag_revalidation.py
+++ b/services/tests/api/test_oci_tag_revalidation.py
@@ -1,0 +1,403 @@
+"""Refreshing a mirrored tag before serving it (#1425).
+
+A tag is the only mutable thing Terrapod caches. Every other artifact — provider
+binaries, CLI binaries, wheels, npm tarballs, blobs addressed by digest — is
+pinned to a coordinate that cannot change upstream, which is why none of them
+revalidates and why this must not be generalised back to them.
+
+Before this, the first pull of a mirrored tag fixed what it meant here for good:
+upstream could move `latest` any number of times and every later pull served the
+original digest, silently.
+
+The branch that matters most is the failure one. A pull-through cache exists to
+keep answering when upstream cannot be reached, so every way a check can fail
+must still return the cached image.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.api.routers.oci import _revalidate_tag
+
+CACHED_DIGEST = "sha256:" + "a" * 64
+MOVED_DIGEST = "sha256:" + "b" * 64
+
+
+def _repository():
+    repo = MagicMock()
+    repo.id = uuid.uuid4()
+    repo.name = "quay.io/ansible/awx-ee"
+    repo.upstream = "quay.io"
+    return repo
+
+
+def _manifest(digest=CACHED_DIGEST):
+    manifest = MagicMock()
+    manifest.digest = digest
+    return manifest
+
+
+def _tag_row(checked_hours_ago: float | None):
+    """A tag last confirmed against upstream this long ago.
+
+    Expressed in hours because the window is a day: a value in minutes reads as
+    "stale" while being comfortably inside the TTL, which is exactly how the
+    first version of these tests managed to assert nothing.
+    """
+    row = MagicMock()
+    row.revalidated_at = (
+        None
+        if checked_hours_ago is None
+        else datetime.now(UTC) - timedelta(hours=checked_hours_ago)
+    )
+    return row
+
+
+@pytest.fixture
+def _upstream():
+    with (
+        patch("terrapod.services.oci.registry_service.get_tag", new=AsyncMock()) as get_tag,
+        patch(
+            "terrapod.services.oci.pullthrough_service.current_upstream_digest", new=AsyncMock()
+        ) as head,
+        patch(
+            "terrapod.services.oci.pullthrough_service.resolve_upstream",
+            return_value=("quay.io", "ansible/awx-ee"),
+        ),
+        patch("terrapod.services.oci.pullthrough_service.mirroring_allowed", return_value=True),
+    ):
+        yield get_tag, head
+
+
+class TestWithinTheTTL:
+    async def test_a_tag_checked_inside_the_ttl_does_not_ask_upstream(self, _upstream) -> None:
+        """Otherwise every pull pays a round trip for content we already hold."""
+        get_tag, head = _upstream
+        get_tag.return_value = _tag_row(checked_hours_ago=6)
+        cached = _manifest()
+
+        result = await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "latest", cached)
+
+        assert result is cached
+        head.assert_not_awaited()
+
+
+class TestPastTheTTL:
+    async def test_an_unchanged_tag_serves_cache_and_resets_the_clock(self, _upstream) -> None:
+        get_tag, head = _upstream
+        tag_row = _tag_row(checked_hours_ago=200)
+        get_tag.return_value = tag_row
+        head.return_value = CACHED_DIGEST
+        cached = _manifest()
+
+        result = await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "latest", cached)
+
+        assert result is cached
+        head.assert_awaited_once()
+        # Confirmed-unchanged still counts as checked, or every pull rechecks.
+        assert tag_row.revalidated_at > datetime.now(UTC) - timedelta(seconds=30)
+
+    @patch("terrapod.api.routers.oci._mirror_manifest", new_callable=AsyncMock)
+    async def test_a_moved_tag_is_refreshed_before_returning(self, mirror, _upstream) -> None:
+        """The point of the feature: this pull gets the new image, not the next."""
+        get_tag, head = _upstream
+        get_tag.return_value = _tag_row(checked_hours_ago=200)
+        head.return_value = MOVED_DIGEST
+        refreshed = _manifest(MOVED_DIGEST)
+        mirror.return_value = refreshed
+
+        result = await _revalidate_tag(
+            AsyncMock(), AsyncMock(), _repository(), "latest", _manifest()
+        )
+
+        assert result is refreshed
+        mirror.assert_awaited_once()
+
+
+class TestALocallyPushedTag:
+    """A mirror repository can hold pushed tags too, and they are not ours to move.
+
+    `quay.io/ansible/awx-ee` mirrors, but nothing stops someone pushing their own
+    tag into it. Upstream knows nothing about that tag; asking upstream about it
+    can only end one of two ways, and one of them is replacing local content with
+    a same-named image from somewhere else.
+
+    Provenance is recorded at write time — a mirrored tag is stamped when fetched,
+    a pushed one is not — so this is decided by what the row says rather than by
+    guessing from the repository.
+    """
+
+    async def test_a_pushed_tag_is_never_asked_about(self, _upstream) -> None:
+        get_tag, head = _upstream
+        get_tag.return_value = _tag_row(checked_hours_ago=None)  # never fetched
+        cached = _manifest()
+
+        result = await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "mine", cached)
+
+        assert result is cached
+        head.assert_not_awaited()
+
+    @patch("terrapod.api.routers.oci._mirror_manifest", new_callable=AsyncMock)
+    async def test_upstream_cannot_replace_it(self, mirror, _upstream) -> None:
+        """The failure that matters: upstream has its own `mine`, and wins."""
+        get_tag, head = _upstream
+        get_tag.return_value = _tag_row(checked_hours_ago=None)
+        head.return_value = MOVED_DIGEST  # upstream has something under that name
+        cached = _manifest()
+
+        result = await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "mine", cached)
+
+        assert result is cached
+        mirror.assert_not_awaited()
+
+
+class TestUpstreamUnavailable:
+    """Every failure resolves to serving what we already have.
+
+    A cache that stops answering when it cannot reach the internet has failed at
+    the one thing it exists for — and in a restricted network there is no second
+    source to fall back to.
+    """
+
+    async def test_an_unreachable_upstream_serves_the_stale_image(self, _upstream) -> None:
+        get_tag, head = _upstream
+        get_tag.return_value = _tag_row(checked_hours_ago=200)
+        head.return_value = None  # could not be reached, or refused
+        cached = _manifest()
+
+        result = await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "latest", cached)
+
+        assert result is cached
+
+    async def test_a_failed_check_still_backs_off(self, _upstream) -> None:
+        """Retrying on every pull would add upstream's timeout to each one.
+
+        That turns a reachability problem into a latency problem for content we
+        are holding locally, which is the opposite of the point.
+        """
+        get_tag, head = _upstream
+        tag_row = _tag_row(checked_hours_ago=200)
+        get_tag.return_value = tag_row
+        head.return_value = None
+
+        await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "latest", _manifest())
+
+        assert tag_row.revalidated_at > datetime.now(UTC) - timedelta(seconds=30)
+
+    @patch("terrapod.api.routers.oci._mirror_manifest", new_callable=AsyncMock)
+    async def test_a_confirmed_move_that_then_fails_to_fetch_serves_the_stale_image(
+        self, mirror, _upstream
+    ) -> None:
+        """Upstream said it moved and then would not hand it over.
+
+        The cached image is still a working answer, and refusing to serve one
+        because a *better* one could not be obtained helps nobody.
+        """
+        from terrapod.services.oci.errors import UNSUPPORTED, OCIError
+
+        get_tag, head = _upstream
+        get_tag.return_value = _tag_row(checked_hours_ago=200)
+        head.return_value = MOVED_DIGEST
+        mirror.side_effect = OCIError(UNSUPPORTED, message="upstream went away")
+        cached = _manifest()
+
+        result = await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "latest", cached)
+
+        assert result is cached
+
+
+class TestSealed:
+    @patch("terrapod.api.routers.oci.settings")
+    async def test_a_sealed_node_never_asks_upstream(self, mock_settings, _upstream) -> None:
+        """Reaching upstream is exactly what sealing forbids."""
+        get_tag, head = _upstream
+        mock_settings.registry.cache_only = True
+        mock_settings.registry.oci.mirror_tag_ttl_hours = 168
+        cached = _manifest()
+
+        result = await _revalidate_tag(AsyncMock(), AsyncMock(), _repository(), "latest", cached)
+
+        assert result is cached
+        head.assert_not_awaited()
+        get_tag.assert_not_awaited()
+
+
+class TestItIsActuallyWiredIn:
+    """The tests above prove the function; this proves the pull calls it.
+
+    A revalidation helper nothing invokes is the same bug it was written to fix,
+    and it would pass every test above.
+    """
+
+    def _app(self):
+        from terrapod.api.app import create_application
+        from terrapod.api.dependencies import AuthenticatedUser
+        from terrapod.db.session import get_db
+        from terrapod.services.oci.auth import authenticate_oci
+        from terrapod.storage import get_storage
+
+        app = create_application()
+        app.dependency_overrides[authenticate_oci] = lambda: AuthenticatedUser(
+            email="a@b.c",
+            display_name=None,
+            roles=["admin"],
+            provider_name="local",
+            auth_method="session",
+        )
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+        storage = AsyncMock()
+        storage.get.return_value = b"{}"
+        app.dependency_overrides[get_storage] = lambda: storage
+        return app
+
+    @patch("terrapod.api.routers.oci._revalidate_tag", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.oci.resolve_registry_capabilities_for")
+    @patch("terrapod.services.oci.registry_service.resolve_manifest", new_callable=AsyncMock)
+    @patch("terrapod.services.oci.registry_service.get_repository", new_callable=AsyncMock)
+    async def test_pulling_a_cached_mirrored_tag_revalidates(
+        self, get_repo, resolve, caps, revalidate
+    ) -> None:
+        from httpx import ASGITransport, AsyncClient
+
+        from terrapod.auth import capabilities as cap
+
+        repo = _repository()
+        repo.labels = {}
+        repo.owner_email = "a@b.c"
+        get_repo.return_value = repo
+        caps.return_value = frozenset({cap.REGISTRY_READ})
+        cached = _manifest()
+        cached.size = 2
+        cached.media_type = "application/vnd.oci.image.manifest.v1+json"
+        cached.storage_key = "k"
+        resolve.return_value = cached
+        revalidate.return_value = cached
+
+        async with AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/v2/quay.io/ansible/awx-ee/manifests/latest",
+                headers={"Authorization": "Bearer t"},
+            )
+
+        assert response.status_code == 200
+        revalidate.assert_awaited_once()
+
+    @patch("terrapod.api.routers.oci._revalidate_tag", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.oci.resolve_registry_capabilities_for")
+    @patch("terrapod.services.oci.registry_service.resolve_manifest", new_callable=AsyncMock)
+    @patch("terrapod.services.oci.registry_service.get_repository", new_callable=AsyncMock)
+    async def test_pulling_by_digest_never_revalidates(
+        self, get_repo, resolve, caps, revalidate
+    ) -> None:
+        """A digest is immutable by construction; checking it would be pure cost."""
+        from httpx import ASGITransport, AsyncClient
+
+        from terrapod.auth import capabilities as cap
+
+        repo = _repository()
+        repo.labels = {}
+        repo.owner_email = "a@b.c"
+        get_repo.return_value = repo
+        caps.return_value = frozenset({cap.REGISTRY_READ})
+        cached = _manifest()
+        cached.size = 2
+        cached.media_type = "application/vnd.oci.image.manifest.v1+json"
+        cached.storage_key = "k"
+        resolve.return_value = cached
+
+        async with AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://test"
+        ) as client:
+            await client.get(
+                f"/v2/quay.io/ansible/awx-ee/manifests/{CACHED_DIGEST}",
+                headers={"Authorization": "Bearer t"},
+            )
+
+        revalidate.assert_not_awaited()
+
+    @patch("terrapod.api.routers.oci._revalidate_tag", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.oci.resolve_registry_capabilities_for")
+    @patch("terrapod.services.oci.registry_service.resolve_manifest", new_callable=AsyncMock)
+    @patch("terrapod.services.oci.registry_service.get_repository", new_callable=AsyncMock)
+    async def test_a_pushed_repository_never_revalidates(
+        self, get_repo, resolve, caps, revalidate
+    ) -> None:
+        """There is no upstream to confirm against, and nothing moves under us."""
+        from httpx import ASGITransport, AsyncClient
+
+        from terrapod.auth import capabilities as cap
+
+        repo = _repository()
+        repo.upstream = None  # pushed
+        repo.labels = {}
+        repo.owner_email = "a@b.c"
+        get_repo.return_value = repo
+        caps.return_value = frozenset({cap.REGISTRY_READ})
+        cached = _manifest()
+        cached.size = 2
+        cached.media_type = "application/vnd.oci.image.manifest.v1+json"
+        cached.storage_key = "k"
+        resolve.return_value = cached
+
+        async with AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://test"
+        ) as client:
+            await client.get("/v2/team/app/manifests/v1", headers={"Authorization": "Bearer t"})
+
+        revalidate.assert_not_awaited()
+
+
+class TestProvenanceIsRecorded:
+    """The stamp that separates a mirrored tag from a pushed one.
+
+    Everything above turns on it, and it fails silently in the dangerous
+    direction: if the mirror path stopped stamping, every mirrored tag would read
+    as locally pushed and nothing would ever revalidate again — which is exactly
+    the bug this feature exists to fix, restored without a single test going red.
+    """
+
+    async def test_a_mirrored_tag_is_stamped(self) -> None:
+        from terrapod.services.oci import registry_service
+
+        db = AsyncMock()
+        db.add = MagicMock()  # sync on a real Session; AsyncMock leaves a stray coroutine
+        db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        manifest = MagicMock(id=uuid.uuid4())
+
+        tag = await registry_service.set_tag(
+            db, _repository(), "latest", manifest, from_upstream=True
+        )
+
+        assert tag.revalidated_at is not None
+        assert tag.revalidated_at > datetime.now(UTC) - timedelta(seconds=30)
+
+    async def test_a_pushed_tag_is_not_stamped(self) -> None:
+        from terrapod.services.oci import registry_service
+
+        db = AsyncMock()
+        db.add = MagicMock()  # sync on a real Session; AsyncMock leaves a stray coroutine
+        db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        manifest = MagicMock(id=uuid.uuid4())
+
+        tag = await registry_service.set_tag(db, _repository(), "mine", manifest)
+
+        assert tag.revalidated_at is None
+
+    async def test_the_mirror_path_asks_for_the_stamp(self) -> None:
+        """Proves the caller passes it, not merely that the parameter exists."""
+        import inspect
+
+        from terrapod.api.routers import oci
+
+        source = inspect.getsource(oci._mirror_manifest)
+        assert "from_upstream=True" in source, (
+            "the mirror path must record provenance, or every cached tag reads as "
+            "locally pushed and revalidation silently stops happening"
+        )

--- a/services/tests/config/config_key_contract.json
+++ b/services/tests/config/config_key_contract.json
@@ -245,6 +245,7 @@
   "registry.oci.enabled",
   "registry.oci.gc.enabled",
   "registry.oci.gc.grace_hours",
+  "registry.oci.mirror_tag_ttl_hours",
   "registry.oci.upload_session_timeout_hours",
   "registry.oci.upstreams[].api_url",
   "registry.oci.upstreams[].host",

--- a/services/tests/helm/helm_values_contract.json
+++ b/services/tests/helm/helm_values_contract.json
@@ -186,6 +186,7 @@
   "api.config.registry.oci.enabled",
   "api.config.registry.oci.gc.enabled",
   "api.config.registry.oci.gc.grace_hours",
+  "api.config.registry.oci.mirror_tag_ttl_hours",
   "api.config.registry.oci.upload_session_timeout_hours",
   "api.config.registry.oci.upstreams",
   "api.config.registry.package_cache.enabled",


### PR DESCRIPTION
Closes #1425.

A pull-through cached tag was pinned for ever. Upstream moved `latest`, and Terrapod went on serving whatever it happened to fetch the first time — with no way to move it on short of deleting the repository.

## How it works

Revalidation is lazy, on read, because that is the only moment at which freshness matters and the only moment we know the tag is wanted. Past the freshness window a GET asks upstream for the tag's current digest and adopts it if it moved; inside the window the cached manifest is served untouched.

**Whatever happens, an image comes back.** Upstream unreachable, upstream erroring, the tag deleted upstream — all resolve to serving what is cached. A pull-through cache that stops answering when it cannot reach the internet has failed at the one thing it exists for, and in a restricted network there is no second source. A failed check still moves the clock forward, so a down upstream costs one timeout per window rather than one per pull.

Only *tags* revalidate. Everything else Terrapod caches — provider binaries, CLI binaries, wheels, npm tarballs, blobs by digest — is pinned to a coordinate that cannot change upstream, so none of them needs this and it should not be generalised back to them.

## Configuration

`api.config.registry.oci.mirror_tag_ttl_hours`, default **24**. `0` disables revalidation entirely, pinning every cached image at the digest it first resolved to — for a deployment where reproducibility outranks currency, or which will never reach upstream again. Nothing is checked when `cache_only` is set.

## Two things found while building it

**A pushed tag could be replaced by upstream.** A mirror repository can hold pushed tags too, and the first cut keyed the decision on whether the *repository* mirrored — so pushing `mine` into a mirrored repository, where upstream happened to have its own `mine`, would silently replace local content. Tags now record at write time whether their content came from upstream, and only those are ever revalidated. Two tests cover it, including the replacement itself.

**The migration has to backfill.** Because that provenance stamp doubles as the marker, leaving existing rows NULL would read every already-cached tag as locally pushed and withhold the fix from exactly the tags that motivated it. Existing tags in mirroring repositories are backfilled from `updated_at`. One case is genuinely ambiguous — a tag *pushed* into a mirror repository before this existed is indistinguishable from a fetched one and is backfilled alongside; that trade is argued in the migration's docstring.

## Verification

- Full suite green (4799). Each new guard was verified by reverting the fix it covers and confirming it fails — provenance-stamping and the pushed-tag protection both caught.
- Chart lints; renders on all three profiles. `0` renders as `0` (Helm's `with` treats it as empty, which would silently turn "never expire" into "expire daily"), and a large value stays an integer rather than going scientific, via both `--set` and a values file.
- Contract snapshots regenerated: both deltas are additions, no removals.