### PR TITLE
fix(1442): do not require an HTTP credential when verifying git config

### DIFF
--- a/services/terrapod/runner/phases/git_auth.py
+++ b/services/terrapod/runner/phases/git_auth.py
@@ -289,7 +289,15 @@ def _verify_git_reads_config(env: dict[str, str]) -> None:
         timeout=30,
         check=False,
     )
-    if probe.returncode != 0 or "credential.helper" not in probe.stdout:
+    # Non-empty output, not a specific key. GIT_CONFIG_GLOBAL *replaces* the
+    # global config, so this lists exactly the file we wrote and nothing else —
+    # empty means git did not read it.
+    #
+    # Deliberately not checking for `credential.helper`: that key is written only
+    # for HTTP credentials, so requiring it would fail every run whose
+    # credentials are all `git_ssh_auth` — which configure a `core.sshCommand`
+    # and no helper at all.
+    if probe.returncode != 0 or not probe.stdout.strip():
         raise GitAuthUnavailable(
             f"git does not read the configuration written to "
             f"{env.get('GIT_CONFIG_GLOBAL', '<unset>')}. Credentials would be "

--- a/services/tests/runner/test_phase_git_auth.py
+++ b/services/tests/runner/test_phase_git_auth.py
@@ -354,3 +354,44 @@ class TestFailuresAreNotSilent:
         ).stdout
         assert "credential.helper" in listed
         assert "tok" not in listed, "the token must not live in gitconfig"
+
+
+class TestSshOnlyCredentialsAreNotBrokenByVerification:
+    """A workspace whose credentials are all `git_ssh_auth` writes a
+    `core.sshCommand` and no `credential.helper` — that key exists only for HTTP.
+
+    An earlier draft of the verification required it, which would have failed
+    every SSH-credential run. Caught before release; this pins it.
+    """
+
+    def test_an_ssh_only_workspace_succeeds(self, tmp_path, monkeypatch) -> None:
+        key = (
+            "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+            "b3BlbnNzaC1rZXktdjEAAAAA\n"
+            "-----END OPENSSH PRIVATE KEY-----\n"
+        )
+        entries = [
+            {
+                "category": "git_ssh_auth",
+                "key": "github.com",
+                "value": json.dumps(
+                    {"private_key": key, "known_hosts": "github.com ssh-ed25519 AAAA"}
+                ),
+            }
+        ]
+        monkeypatch.setattr(git_auth, "_load", lambda: entries)
+
+        env = git_auth.run(base_dir=tmp_path / "gitauth")
+
+        assert env["GIT_CONFIG_GLOBAL"], "ssh-only credentials must still configure git"
+        listed = subprocess.run(
+            ["git", "config", "--global", "--list"],
+            env={**os.environ, **env},
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert "core.sshcommand" in listed.lower()
+        assert "credential.helper" not in listed, (
+            "precondition: ssh-only writes no helper — which is why the check must not require one"
+        )


### PR DESCRIPTION
Follow-up to #1444, found while preparing the v1.5.4 backport.

The verification added there asked whether git could read the configuration by looking for `credential.helper`. That key is written **only when there are HTTP credentials** — a workspace whose credentials are all `git_ssh_auth` gets a `core.sshCommand` and no helper at all.

So the check would have failed **every SSH-credential run**, turning a fix for credentials that silently did nothing into credentials that loudly refuse to run. Caught on the way to tagging it onto two supported release lines.

It now requires the listing to be non-empty instead. `GIT_CONFIG_GLOBAL` *replaces* the global config, so `git config --global --list` shows exactly the file we wrote and nothing else — empty means git did not read it, which is the only thing this check needs to establish.

## Verified on the live stack

A workspace with a `git_http_auth` credential (`rewrite: to_https`) and a config whose module source is a **private** repository over `ssh://` — the reporter's exact shape:

```
git module auth configured  entries=1
Downloading git::ssh://git@github.com/…/terrapod-smoke-submodule.git for private...
- private in .terraform/modules/private
plan completed  has_changes=True
phase complete  exit_code=0
```

The Job also carries the `/home/runner` mount with `readOnlyRootFilesystem: true` intact.

The SSH-only regression has a test that fails against the previous check.