### PR TITLE
fix(1446): let Eval Boot gate the release it already runs on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2793,7 +2793,7 @@ jobs:
 
   release-finalize:
     name: Release — Finalize (notes + chart + SBOMs)
-    needs: [prepare, release-create, release-images, release-provider, release-migrate, release-publish, release-query, release-mcp]
+    needs: [prepare, helm-eval-boot, release-create, release-images, release-provider, release-migrate, release-publish, release-query, release-mcp]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
@@ -2804,6 +2804,7 @@ jobs:
       && needs.release-publish.result == 'success'
       && needs.release-query.result == 'success'
       && needs.release-mcp.result == 'success'
+      && (needs.helm-eval-boot.result == 'success' || needs.helm-eval-boot.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2910,11 +2911,11 @@ jobs:
   # ── Cleanup Tag on Failure ─────────────────────────────
   cleanup-tag:
     name: Cleanup Tag
-    needs: [prepare, quality-gate, build-images-amd64, build-images-arm64, build-query, scan-images, create-manifests, release-create, release-images, release-provider, release-migrate, release-publish, release-query, release-mcp, release-finalize]
+    needs: [prepare, quality-gate, helm-eval-boot, build-images-amd64, build-images-arm64, build-query, scan-images, create-manifests, release-create, release-images, release-provider, release-migrate, release-publish, release-query, release-mcp, release-finalize]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
-      && (needs.quality-gate.result == 'failure' || needs.build-images-amd64.result == 'failure' || needs.build-images-arm64.result == 'failure' || needs.build-query.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-create.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-publish.result == 'failure' || needs.release-query.result == 'failure' || needs.release-mcp.result == 'failure' || needs.release-finalize.result == 'failure')
+      && (needs.quality-gate.result == 'failure' || needs.helm-eval-boot.result == 'failure' || needs.build-images-amd64.result == 'failure' || needs.build-images-arm64.result == 'failure' || needs.build-query.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-create.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-publish.result == 'failure' || needs.release-query.result == 'failure' || needs.release-mcp.result == 'failure' || needs.release-finalize.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Closes #1446.

`helm-eval-boot` is the only job that installs the chart and drives a plan through a real listener into a real runner Job. **On a tag it ran and gated nothing** — referenced only in `ci-pass`, and neither `release-finalize` nor `cleanup-tag` needs that. A failed boot published the release and left the tag in place.

It runs on tags whenever the commit has no images yet: every backport cherry-pick, and every `--allow-empty` rebuild commit. **Both of today's patch releases qualified**, and Eval Boot passed on both while gating neither — so the hole was live, not theoretical.

## The four wirings

| place | change |
|---|---|
| `release-finalize.needs` | + `helm-eval-boot` |
| `release-finalize.if` | + `(result == 'success' \|\| result == 'skipped')` |
| `cleanup-tag.needs` | + `helm-eval-boot` |
| `cleanup-tag.if` | + `\|\| result == 'failure'` |

**A skipped result counts as success, deliberately.** The `images_exist` path legitimately skips the job, and requiring `success` alone would refuse to publish any tag cut on an already-built commit — the common case for a normal release. Getting this wrong would have turned a gap into an outage.

## Why gate rather than disable

The issue offered both. Skipping on tags would run the most thorough check in CI on every pull request and never on the artefact anyone installs.

`v1.4.3` is the argument: an empty commit whose entire purpose was that images get rebuilt against a refreshed base. Eval Boot booting those images is the only evidence the rebuild produced a working stack.

## Cost, stated plainly

This puts a 25-minute-ceiling two-tool matrix job on the release path, so flakiness there becomes a blocked release rather than a red square. The kind/k3d leg has form — the `image import` hang that took eleven minutes to time out before #976 — so this wants watching, not blind trust.

## Also

The checklist that should have caught this is written for `release-*` artifact jobs, and this job slipped past by not being named like one. I've broadened it locally to key on **whether a job runs on a tag** rather than its name. That checklist currently lives in the gitignored notes rather than `AGENTS.md` — it reads like a genuine contributor convention and contains nothing internal, so it may belong in the committed guide. Happy to move it in a follow-up if you agree.