### PR TITLE
fix: clear the open CodeQL unused-variable alerts

### DIFF
--- a/services/terrapod/api/routers/variables.py
+++ b/services/terrapod/api/routers/variables.py
@@ -809,7 +809,9 @@ async def update_varset_var(
     # Always run it, not only when the caller sends `value-source`: a PATCH that
     # supplies a new `value` on an existing vault variable must still have that
     # value validated as a reference.
-    vsv.value_source, _vault_forced = _apply_value_source(
+    # The sensitive-forcing half is recomputed below from the stored row, so
+    # only the resolved source is wanted here.
+    vsv.value_source, _ = _apply_value_source(
         attrs, vsv.value_source, category=attrs.get("category", vsv.category)
     )
     if vsv.value_source == "vault":

--- a/services/terrapod/services/role_reach_service.py
+++ b/services/terrapod/services/role_reach_service.py
@@ -382,7 +382,9 @@ async def resolve_resource_access(
     granted: list[dict[str, Any]] = []
     denied: list[dict[str, Any]] = []
     for role in roles:
-        verdict, reason = role_match_verdict(role, obj.name, obj.labels or {})
+        # `_entry` recomputes the verdict and carries the reason, which is what
+        # line ~392 reads; only the early-continue needs the verdict here.
+        verdict, _ = role_match_verdict(role, obj.name, obj.labels or {})
         if verdict == MATCH_NONE:
             continue
         entry = _entry(role, axis, kind, obj)

--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -143,7 +143,7 @@ def _build_comment_body(
     (pending / skipped / errored) are skipped — the comment shouldn't
     advertise empty or error rows to PR readers.
     """
-    github_state, _, description = _resolve_status(run_status, plan_only, has_changes)
+    _, _, description = _resolve_status(run_status, plan_only, has_changes)
     emoji = _STATUS_EMOJI.get(run_status, ":grey_question:")
 
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/services/tests/integration/test_release_blockers.py
+++ b/services/tests/integration/test_release_blockers.py
@@ -886,7 +886,7 @@ class TestATransientVaultFailureDoesNotDestroyTheRun:
         set_auth(app, admin_user())
         tag = uuid.uuid4().hex[:8]
         pool_id, listener_id = await _pool_with_listener(client, tag)
-        ws_id, cv_id, run_id = await _agent_run_with_vault_var(client, tag, pool_id)
+        _, _, run_id = await _agent_run_with_vault_var(client, tag, pool_id)
         set_listener_auth(app, listener_id, pool_id.removeprefix("apool-"))
 
         prior = (settings.vault.enabled, settings.vault.instances)
@@ -919,7 +919,7 @@ class TestATransientVaultFailureDoesNotDestroyTheRun:
         set_auth(app, admin_user())
         tag = uuid.uuid4().hex[:8]
         pool_id, listener_id = await _pool_with_listener(client, tag)
-        ws_id, cv_id, run_id = await _agent_run_with_vault_var(client, tag, pool_id)
+        _, _, run_id = await _agent_run_with_vault_var(client, tag, pool_id)
         set_listener_auth(app, listener_id, pool_id.removeprefix("apool-"))
 
         prior = (settings.vault.enabled, settings.vault.instances)
@@ -1139,7 +1139,9 @@ class TestTheVaultValueActuallyReachesTheRunner:
         set_auth(app, admin_user())
         tag = uuid.uuid4().hex[:8]
         pool_id, listener_id = await _pool_with_listener(client, tag)
-        ws_id, cv_id, run_id = await _agent_run_with_vault_var(client, tag, pool_id)
+        # Called for its side effect — the run it creates is claimed below
+        # via the listener, so none of the returned ids are needed here.
+        await _agent_run_with_vault_var(client, tag, pool_id)
         set_listener_auth(app, listener_id, pool_id.removeprefix("apool-"))
 
         prior = (settings.vault.enabled, settings.vault.instances)


### PR DESCRIPTION
Clears all four open alerts on the code-scanning page. All `py/unused-local-variable`, all from recent work of mine.

Three were the same line repeated across three tests, unpacking `ws_id, cv_id, run_id` from a helper called for its side effect. Only one of the three genuinely used none of them — the other two use `run_id` — so it is fixed **per site**. Worth recording why: I first checked usage in one enclosing test and applied that result to all three, which broke the other two with a `NameError`. Per-site is the correct check.

The fourth discarded `_vault_forced`, whose sensitive-forcing half is recomputed below from the stored row.

## A detail worth knowing before someone files the obvious follow-up

CodeQL flags a **leading-underscore** name — `_vault_forced` is precisely what it caught — so an intentionally-unused value must be bare `_`.

Ruff has a rule for this class (`RUF059`, unused-unpacked-variable) and it finds 33 across the tree, but its autofix *prefixes an underscore*, which satisfies ruff and leaves CodeQL still complaining. So enabling RUF059 is not the durable fix it appears to be; aligning them would need `dummy-variable-rgx = "^_$"`, which is a much wider change. Not doing that here.

## Two are in shipped code, not tests

- `vcs_status_dispatcher` discarded `github_state` and kept only `description`.
- `role_reach_service` unpacked `reason` and never used it — correct, because `_entry` recomputes the verdict internally and carries the reason the caller actually reads. It does mean `role_match_verdict` runs twice per role/object pair on the reverse-access path. Cheap pure-function work, so noted rather than restructured.

## Testing

Targeted suites pass (112). The full run is not included because the local container VM has a disk problem being handled separately — CI is the authority here regardless.