### PR TITLE
chore: guard against silently orphaning container layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ dev:                ## Start Tilt development environment (port 10352)
 dev-down:           ## Stop Tilt
 	tilt down --port 10352
 
+doctor:             ## Report container-store health (orphaned layers, free space)
+	@./scripts/doctor.sh
+
 # ── Evaluation (one-command kind/k3d quickstart) ─────────
 eval:               ## Stand up a throwaway Terrapod for evaluation (kind/k3d)
 	scripts/eval.sh up

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -107,6 +107,50 @@ Docker/Rancher/minikube setup is untouched.
 kind shares the two-store problem but not the fix: `kind load docker-image` is
 reliable, so use that rather than a registry.
 
+## When the container store fills up
+
+`make doctor` reports the health of the local container store. Run it if builds
+start failing oddly, and occasionally regardless.
+
+It exists because of a failure mode that is invisible until it is expensive.
+`podman build` writes a layer's content to disk and then commits its metadata.
+Interrupt it in between — a killed build, a step that times out, a full disk —
+and the layer stays on disk with nothing referencing it.
+
+**Nothing reclaims those layers.** `podman system prune` only removes objects
+podman has metadata for, and `podman system check --repair` cannot see a layer
+it has no record of either; it reports zero orphans even at `--max 1m`. The
+space is unrecoverable short of a full storage reset.
+
+It also accelerates. As the disk fills, metadata writes begin to fail, which
+orphans layers that would otherwise have committed cleanly — so the problem
+feeds itself, and every individual symptom looks like an ordinary build failure.
+
+One workstation reached **9,415 orphaned layers holding roughly 85 GB** before
+anyone noticed, on a 120 GB store that `podman system df` was cheerfully
+reporting as 19 GB of images.
+
+Two guards exist:
+
+- `scripts/lib.sh` refuses to build the test image below
+  `CONTAINER_STORE_MIN_FREE_GB` (default 10). Failing loudly beats filling the
+  store silently. Skipped in CI, where the runner is disposable.
+- `make doctor` compares layer directories on disk against
+  `overlay-layers/layers.json`. That difference is the number that matters, and
+  it is the one no built-in command shows you.
+
+If you are already deep in it, the only complete fix is:
+
+```zsh
+podman system reset      # destroys ALL images, containers and volumes
+```
+
+That includes your k3d cluster, so recreate it with the commands in *Nested
+clusters (k3d / kind)* above, then `make dev`.
+
+Damaged *tracked* layers are a different and much smaller problem — those do
+have metadata, so `podman system check --repair` genuinely fixes them.
+
 ## Day-to-day
 
 - **Live reload** — `tilt up` live-syncs `services/terrapod` and `web/src` into

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Report the health of the local container store.
+#
+# Exists because of a failure mode that is invisible until it is expensive.
+# `podman build` writes a layer's content to disk and then commits its metadata.
+# Interrupt it between the two — a killed build, a timed-out CI step, a full
+# disk — and the layer stays on disk with nothing referencing it.
+#
+# Nothing reclaims those. `podman system prune` only removes objects podman has
+# metadata for, and `podman system check --repair` likewise cannot see a layer
+# it has no record of; it reports zero even with `--max 1m`. The space is gone
+# short of a storage reset.
+#
+# It also accelerates: as the disk fills, metadata writes start failing, which
+# orphans layers that would otherwise have committed cleanly.
+#
+# One workstation reached 9,328 orphaned layers holding ~85 GB before anyone
+# noticed, because every individual symptom looked like an ordinary build
+# failure. This makes the drift visible while it is still small.
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+info "Container store health"
+
+if ! command -v podman >/dev/null 2>&1; then
+  warn "podman not found — nothing to check (this diagnostic is podman-specific)."
+  exit 0
+fi
+
+if ! podman machine ssh true >/dev/null 2>&1; then
+  warn "No running podman machine — skipping."
+  exit 0
+fi
+
+# ── Space ─────────────────────────────────────────────────
+echo
+podman machine ssh 'df -h /var/lib/containers 2>/dev/null | tail -1' 2>/dev/null \
+  | awk '{ printf "  disk:        %s used of %s (%s), %s free\n", $3, $2, $5, $4 }'
+
+# ── Tracked vs on disk ────────────────────────────────────
+# The number that matters. `podman system df` reports only what podman knows
+# about, so it looks healthy while the store is full of layers it has forgotten.
+orphans="$(podman machine ssh 'sudo python3 -c "
+import json, os
+root = \"/var/lib/containers/storage/overlay\"
+try:
+    tracked = {l[\"id\"] for l in json.load(open(\"/var/lib/containers/storage/overlay-layers/layers.json\"))}
+except Exception:
+    tracked = set()
+dirs = [d for d in os.listdir(root) if len(d) == 64]
+print(len(dirs), len(tracked), len([d for d in dirs if d not in tracked]))
+"' 2>/dev/null || true)"
+
+set -- $orphans
+on_disk="${1:-}"; tracked="${2:-}"; orphaned="${3:-}"
+
+if [ -z "$orphaned" ]; then
+  warn "Could not read the layer store (needs a running podman machine with sudo)."
+else
+  printf '  layers:      %s on disk, %s tracked, %s ORPHANED\n' "$on_disk" "$tracked" "$orphaned"
+  echo
+  if [ "$orphaned" -gt 500 ]; then
+    error "$orphaned orphaned layers. These are unreachable by 'podman system prune'"
+    error "and by 'podman system check --repair' — neither can see a layer with no"
+    error "metadata entry. Reclaiming them means 'podman system reset', which also"
+    error "destroys any local k3d cluster; see docs/local-development.md to rebuild."
+    exit 1
+  elif [ "$orphaned" -gt 50 ]; then
+    warn "$orphaned orphaned layers and growing. Worth resetting the store at a"
+    warn "convenient moment, before it becomes expensive."
+  else
+    success "Container store is healthy."
+  fi
+fi
+
+# ── Damaged tracked layers ────────────────────────────────
+# Separate problem, separate fix: these HAVE metadata, so --repair can act.
+echo
+info "Checking tracked layers for damage (this is slow; ^C to skip)"
+if podman system check --quick >/dev/null 2>&1; then
+  success "No damage reported in tracked layers."
+else
+  warn "Damaged tracked layers found. Unlike orphans these are repairable:"
+  warn "  podman system check --repair"
+fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -21,11 +21,49 @@ success() { printf '\033[1;32m==> %s\033[0m\n' "$*"; }
 warn()    { printf '\033[1;33m==> WARNING: %s\033[0m\n' "$*"; }
 error()   { printf '\033[1;31m==> ERROR: %s\033[0m\n' "$*" >&2; }
 
+# ── Container-store health ────────────────────────────────
+
+# Minimum free space, in GB, required in the container store before a build.
+CONTAINER_STORE_MIN_FREE_GB="${CONTAINER_STORE_MIN_FREE_GB:-10}"
+
+# Refuse to build when the container store is nearly full.
+#
+# Running the store out of space does more than fail the build: podman writes a
+# layer's content to disk and then commits its metadata, so a failure between
+# the two leaves the layer on disk with nothing referencing it. Those orphans
+# are invisible to `podman system prune` and to `podman system check` — neither
+# can reclaim what has no metadata entry — so the space is unrecoverable short
+# of a storage reset. It also compounds: the fuller the disk, the more metadata
+# writes fail, and the faster orphans accumulate.
+#
+# One workstation reached 9,328 orphaned layers holding ~85 GB this way. Failing
+# loudly beforehand is cheap; the alternative is silent, permanent loss.
+#
+# Advisory on non-podman engines and in CI, where the runner is disposable.
+check_container_store_space() {
+  command -v podman >/dev/null 2>&1 || return 0
+  [ -n "${CI:-}" ] && return 0
+
+  local avail_kb avail_gb
+  avail_kb="$(podman machine ssh 'df -Pk /var/lib/containers 2>/dev/null | awk "NR==2 {print \$4}"' 2>/dev/null || true)"
+  case "$avail_kb" in ''|*[!0-9]*) return 0 ;; esac   # not a podman machine, or unreadable
+
+  avail_gb=$(( avail_kb / 1024 / 1024 ))
+  if [ "$avail_gb" -lt "$CONTAINER_STORE_MIN_FREE_GB" ]; then
+    error "Container store has only ${avail_gb}GB free (minimum ${CONTAINER_STORE_MIN_FREE_GB}GB)."
+    error "Building now risks orphaning layers that no podman command can reclaim."
+    error "Run 'make doctor' to see the damage, and reclaim space before retrying."
+    return 1
+  fi
+  return 0
+}
+
 # ── Docker helpers ────────────────────────────────────────
 
 # Build the Python test image if needed.
 TEST_IMAGE="${TEST_IMAGE:-terrapod-test:local}"
 ensure_test_image() {
+  check_container_store_space || return 1
   info "Building Python test image ($TEST_IMAGE)..."
   docker build -f "$REPO_ROOT/docker/Dockerfile.test" -t "$TEST_IMAGE" "$REPO_ROOT"
 }


### PR DESCRIPTION
Adds `make doctor` and a free-space preflight, after this workstation lost ~85 GB to a failure mode that no podman command reports.

## What happens

`podman build` writes a layer's content to disk, then commits its metadata. Interrupt it between the two — a killed build, a timed-out step, a full disk — and the layer stays on disk with nothing referencing it.

**Nothing reclaims those.** `podman system prune` only removes objects podman has metadata for. `podman system check --repair` cannot see them either — it reported **zero** orphans here even at `--max 1m`, while 9,415 sat on disk. Short of `podman system reset`, the space is gone.

And it accelerates: as the store fills, metadata writes fail, orphaning layers that would otherwise have committed cleanly. Every individual symptom looks like an ordinary build failure.

## How bad it got before anyone noticed

| | |
|---|---|
| `storage/overlay` on disk | 104.8 GB |
| what `podman system df` reported | 19.45 GB of images |
| layer dirs on disk | 9,685 |
| tracked in `layers.json` | 270 |
| **orphaned** | **9,415** |

Found only by comparing directory counts against `overlay-layers/layers.json` by hand. The count grew by ~90 during the session that diagnosed it, so this is live, not historical.

## The two guards

**`check_container_store_space`** refuses to build the test image below 10 GB free (`CONTAINER_STORE_MIN_FREE_GB`). The damage was never the disk filling — it was filling *silently* and taking the metadata with it. Advisory on non-podman engines, skipped under `CI` where the runner is disposable.

**`make doctor`** reports tracked-versus-on-disk layers, which is the number that matters and the one no built-in command shows. Warns above 50 orphans, fails above 500 — so the drift is visible at a few GB instead of eighty.

Verified both: the guard blocks at the current 3 GB and passes with `CI=true`; `make doctor` correctly reports the 9,415.

Also documents the distinction that cost time here: a damaged **tracked** layer is a different, much smaller problem, and `podman system check --repair` does genuinely fix those.