### PR TITLE
ci(1468): stop the merge gate waiting on a job it ignores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3039,7 +3039,17 @@ jobs:
       - build-images-arm64
       - scan-images
       - e2e-test
-      - e2e-report
+      # `e2e-report` is deliberately absent, and must stay absent. It is already
+      # excluded from the `results=()` verdict below (see the reasoning on the
+      # job itself: an artifact-storage failure with no Terrapod code involved
+      # failed a correct release on v1.5.3). Listing it here anyway made
+      # `ci-pass` WAIT for a job whose result it then ignored — 5m35s of a PR
+      # run with one job on the machine and nineteen slots idle, because the
+      # report merges eight Playwright blobs behind a ~2GB image pull.
+      #
+      # The workflow run still finishes it; the required status check no longer
+      # waits for it. Re-adding this line reintroduces the stall silently, since
+      # nothing about the verdict changes (#1468).
       - oci-conformance
       - create-manifests
       - release-create


### PR DESCRIPTION
Fix 1 of #1468. One line (plus a comment explaining why it must stay absent).

`ci-pass` listed `e2e-report` in `needs:` while deliberately omitting it from the `results=()` array that decides pass/fail — so the required status check **waited** for a job whose result could not change the answer. On a PR run that is **5m35s** with one job running and nineteen of twenty slots idle, because the report pulls a ~2GB Playwright image and runs `npm ci` from scratch just to merge eight blob files into an HTML page.

## This does not weaken the E2E gate

| job | what it does | in the verdict? |
|---|---|---|
| `e2e-test` (×8 shards) | actually runs Playwright | **yes** — in `needs` *and* `results=()`, unchanged |
| `e2e-report` | download blobs → `playwright merge-reports` → upload HTML | no — and never was |

A failing E2E test still fails CI. Observed directly today: when `E2E Tests (4/8)` failed on #1455, both that check **and** `CI` went red. That path is untouched.

The tradeoff, stated plainly: if `e2e-report` fails you lose the merged HTML report and read the failure in the shard logs instead.

## Why the exclusion exists

On v1.5.3 a GitHub artifact-storage failure — no Terrapod code involved, artifacts intact per the API, `download-artifact` exhausting its own retries — failed an otherwise correct release, and no rerun could clear it. Keeping the `needs:` edge reintroduced most of that exposure as delay rather than failure.

## Verified before changing

- `Cleanup Tag` does not reference `e2e-report`; line 3042 was the only edge.
- Branch protection requires **only** the `CI` check, so this edge was the whole block.
- YAML still parses; `ci-pass` needs 44 jobs, `e2e-test` retained.

Expected: the `CI` check goes green at t≈720 instead of t=1055 on the reference run. The workflow run itself still finishes the report.