### PR TITLE
ci(1468): split the integration suite across three runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,23 +470,43 @@ jobs:
           # shards. Local bench (Apple M-series; CI ~50-60% of this):
           #   unit         90s serial → 13s parallel (1495 → 492 tests)
           #   services-api 138s serial → 30s parallel
-          # The integration shard stays serial — its
+          # The integration shards stay serial WITHIN a job: the
           # session-scoped Postgres table-creation fixture races
-          # under xdist workers (each worker would try to create
-          # the same tables) and the suite is small enough that
-          # serial is fine.
+          # under xdist workers, which share one database. That
+          # objection does not apply ACROSS runners — each shard
+          # gets its own compose stack, exactly as the two slices
+          # above already do — so the split is runner-level.
           - name: unit
             # Root-level tests/*.py are NOT auto-collected by the directory
             # shards below — each must be listed here explicitly, or it silently
             # never runs in CI. All of these are pure-unit (no Postgres/Redis/S3).
-            paths: tests/auth tests/runner tests/storage tests/ai_eval tests/config tests/db tests/helm tests/oci tests/test_logging_config.py tests/test_dependency_pins.py tests/test_api_sdk_contract.py tests/test_schema_version.py tests/test_gpg_verify.py tests/test_http_retry.py tests/test_db_iam_auth.py tests/test_redis_iam_auth.py
+            paths: tests/auth tests/meta tests/runner tests/storage tests/ai_eval tests/config tests/db tests/helm tests/oci tests/test_logging_config.py tests/test_dependency_pins.py tests/test_api_sdk_contract.py tests/test_schema_version.py tests/test_gpg_verify.py tests/test_http_retry.py tests/test_db_iam_auth.py tests/test_redis_iam_auth.py
             pytest_args: -n auto
           - name: services-api
             paths: tests/services tests/api
             pytest_args: -n auto
-          - name: integration
+          # Three runner-level shards, balanced on collected test count by
+          # `--shard` (services/tests/shard_plan.py). Measured across five CI
+          # runs: per-test cost is uniform at 0.58-1.07s — the work is fixture
+          # setup and teardown, which every test pays equally — so a file's
+          # duration is its test count times a constant, and counting balances it.
+          #
+          # Three, not more: ~100s of every job is fixed cost (checkout, image,
+          # compose stack, collection), measured at 95s and 112s on real runs. A
+          # fourth shard buys 20-50s of wall-clock for another ~100s of runner
+          # time.
+          #
+          # The split happens after collection, so a new test file is assigned
+          # automatically and cannot be silently missed (#1468).
+          - name: integration-1
             paths: tests/integration
-            pytest_args: ""
+            pytest_args: "--shard 1/3"
+          - name: integration-2
+            paths: tests/integration
+            pytest_args: "--shard 2/3"
+          - name: integration-3
+            paths: tests/integration
+            pytest_args: "--shard 3/3"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: scripts/test.sh python -- ${{ matrix.slice.pytest_args }} ${{ matrix.slice.paths }}

--- a/services/tests/integration/conftest.py
+++ b/services/tests/integration/conftest.py
@@ -23,6 +23,8 @@ from terrapod.api.dependencies import (
 )
 from terrapod.db.models import Base
 
+from ..meta.shard_plan import plan_shards
+
 # ---------------------------------------------------------------------------
 # Ensure test-friendly defaults (must precede any Settings import)
 # ---------------------------------------------------------------------------
@@ -340,3 +342,61 @@ async def assign_platform_role(engine, provider: str, email: str, role_name: str
             ),
             {"p": provider, "e": email, "r": role_name},
         )
+
+
+# ── Runner-level sharding (#1468) ─────────────────────────
+#
+# `--shard k/N` keeps only the files assigned to shard k. Splitting happens
+# AFTER collection, so it sees the true set of files and a new test file cannot
+# be silently missed — the failure mode of a hand-maintained path list.
+#
+# Runner-level, not xdist: the objection to xdist here is that its workers share
+# one database and race to create the same tables. Separate runners each get
+# their own compose stack, which is how the unit and services-api slices already
+# work.
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--shard",
+        default=None,
+        help="Run only this shard of the suite, as k/N (1-based). Splits by file, "
+        "balanced on collected test count.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    spec = config.getoption("--shard")
+    if not spec:
+        return
+
+    try:
+        index_s, total_s = spec.split("/", 1)
+        index, total = int(index_s), int(total_s)
+    except ValueError:
+        raise pytest.UsageError(f"--shard expects k/N, got {spec!r}") from None
+    if not 1 <= index <= total:
+        raise pytest.UsageError(f"--shard {spec}: k must be within 1..N")
+
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[str(item.path)] = counts.get(str(item.path), 0) + 1
+
+    keep = set(plan_shards(counts, total)[index - 1])
+    selected = [i for i in items if str(i.path) in keep]
+    deselected = [i for i in items if str(i.path) not in keep]
+
+    # Printed so a shard that selects nothing is visible in the log rather than
+    # passing as a vacuous success.
+    print(
+        f"\nshard {index}/{total}: {len(keep)} files, {len(selected)} tests "
+        f"({len(deselected)} deselected)"
+    )
+    if not selected:
+        raise pytest.UsageError(
+            f"--shard {spec} selected no tests. With {len(counts)} files collected "
+            "this means the split is wrong, not that there is nothing to run."
+        )
+
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected

--- a/services/tests/meta/shard_plan.py
+++ b/services/tests/meta/shard_plan.py
@@ -1,0 +1,57 @@
+"""Split the integration suite across runners, balanced by test count.
+
+The integration slice runs serially — its session-scoped table-creation fixture
+races under xdist workers, which share one database. Runner-level shards do not
+have that problem: each gets its own compose stack, exactly as the `unit` and
+`services-api` slices already do.
+
+Balancing by **test count** rather than by file count is deliberate, and the
+measurements say it is enough. Across five CI runs the per-test cost is uniform
+at 0.58-1.07 s/test — the work is fixture setup and teardown, which every test
+pays equally, so a file's duration is its test count times a constant. There are
+no slow tests to special-case.
+
+Two properties matter more than optimal packing, because both failure modes are
+silent:
+
+- **Total.** Every collected file lands in exactly one shard. A new test file
+  cannot be missed, which is the hazard of a hand-maintained path list — the
+  `unit` slice already carries a warning about exactly that.
+- **Deterministic.** The same input gives the same split on every runner, so
+  shard 2 runs the same files on the retry as it did on the first attempt.
+
+Splitting by file rather than by test keeps a module's tests together, so
+module-scoped fixtures behave as they do today.
+"""
+
+from __future__ import annotations
+
+
+def plan_shards(counts: dict[str, int], shards: int) -> list[list[str]]:
+    """Pack files into `shards` groups of roughly equal test count.
+
+    `counts` maps a file identifier to its number of collected tests. Returns one
+    list of file identifiers per shard.
+
+    Greedy longest-first: repeatedly place the largest remaining file into the
+    lightest shard. Not optimal in general, but for this distribution — 28 files
+    of 2-55 tests — it lands within one test of perfect (123/123/122 at three
+    shards), and being obvious matters more here than being optimal.
+
+    Ties break on the file name so the result cannot depend on dict ordering.
+    """
+    if shards < 1:
+        raise ValueError(f"shards must be >= 1, got {shards}")
+    if shards == 1:
+        return [sorted(counts)]
+
+    buckets: list[list[str]] = [[] for _ in range(shards)]
+    load = [0] * shards
+
+    # Descending by count, then by name: deterministic regardless of input order.
+    for name, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+        target = load.index(min(load))
+        buckets[target].append(name)
+        load[target] += count
+
+    return [sorted(b) for b in buckets]

--- a/services/tests/meta/test_shard_plan.py
+++ b/services/tests/meta/test_shard_plan.py
@@ -1,0 +1,109 @@
+"""Tests for the integration-suite shard planner (#1468).
+
+Deliberately pure: no database, no fixtures. The planner decides which tests run
+on which runner, so a bug here does not fail — it silently skips. That makes it
+worth testing more carefully than the code it distributes, and it is the one
+piece of this change that can be verified without a container.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .shard_plan import plan_shards
+
+# Real shape, from a CI run: 28 files, 368 tests, largest 55.
+REAL = {
+    "test_release_blockers.py": 55,
+    "test_run_execution.py": 44,
+    "test_deleted_workspace_restore.py": 41,
+    "test_role_reach.py": 36,
+    "test_workspace_state_lifecycle.py": 18,
+    "test_oci_registry_integration.py": 18,
+    "test_varset_assignment_rules.py": 17,
+    "test_run_state_machine.py": 12,
+    "test_rbac_enforcement.py": 12,
+    "test_package_cache_integration.py": 11,
+    "test_oci_gc_integration.py": 11,
+    "test_bootstrap_pools_integration.py": 9,
+    "test_provider_publish.py": 9,
+    "test_vcs_commit_claim_release.py": 8,
+    "test_variables.py": 8,
+    "test_multi_pool_dispatch.py": 8,
+    "test_replication_lag.py": 8,
+    "test_vault_value_source.py": 6,
+    "test_replication_outbox.py": 6,
+    "test_oci_deletion_integration.py": 6,
+    "test_summary_placeholder.py": 5,
+    "test_run_task_stage_idempotency.py": 5,
+    "test_lifecycle_destroy_retry_integration.py": 3,
+    "test_peer_credentials.py": 3,
+    "test_ca_init_race.py": 2,
+    "test_catalog_lifecycle_integration.py": 2,
+    "test_bootstrap_seed_integration.py": 2,
+    "test_onboarding_session_integration.py": 2,
+}
+
+
+class TestNothingIsLostOrDuplicated:
+    """The two properties that matter, because both failures are silent: a
+    dropped file never runs and nobody notices, and a duplicated one wastes a
+    shard while hiding the imbalance."""
+
+    @pytest.mark.parametrize("shards", [1, 2, 3, 4, 5, 8, 29])
+    def test_every_file_lands_in_exactly_one_shard(self, shards):
+        buckets = plan_shards(REAL, shards)
+        placed = [f for b in buckets for f in b]
+
+        assert sorted(placed) == sorted(REAL), "a file was dropped or renamed"
+        assert len(placed) == len(set(placed)), "a file was placed twice"
+        assert len(buckets) == shards
+
+    def test_more_shards_than_files_leaves_empties_rather_than_dropping(self):
+        """The planner must not silently discard files it cannot spread. Empty
+        shards are the caller's problem to notice; lost tests are nobody's."""
+        buckets = plan_shards({"a.py": 1, "b.py": 1}, 5)
+        assert sorted(f for b in buckets for f in b) == ["a.py", "b.py"]
+        assert sum(1 for b in buckets if not b) == 3
+
+
+class TestDeterminism:
+    """A retried shard must run the same files it ran the first time, whatever
+    order the collector happened to produce."""
+
+    def test_the_split_does_not_depend_on_input_order(self):
+        reversed_input = dict(reversed(list(REAL.items())))
+        assert plan_shards(REAL, 3) == plan_shards(reversed_input, 3)
+
+    def test_equal_counts_are_broken_deterministically(self):
+        same = {f"t{i}.py": 5 for i in range(9)}
+        assert plan_shards(same, 3) == plan_shards(dict(reversed(list(same.items()))), 3)
+
+
+class TestBalance:
+    """Balance is the entire point — an unbalanced split just moves the tail."""
+
+    @pytest.mark.parametrize("shards,worst", [(2, 190), (3, 128), (4, 98)])
+    def test_the_heaviest_shard_stays_near_the_ideal(self, shards, worst):
+        buckets = plan_shards(REAL, shards)
+        loads = [sum(REAL[f] for f in b) for b in buckets]
+        assert max(loads) <= worst, f"{loads} — heaviest shard beyond tolerance"
+
+    def test_a_single_shard_is_the_whole_suite(self):
+        assert sorted(plan_shards(REAL, 1)[0]) == sorted(REAL)
+
+    def test_one_dominant_file_cannot_be_split_and_bounds_the_result(self):
+        """An honest limit, asserted so it is not mistaken for a packing bug: a
+        file is indivisible, so no shard count beats its own weight."""
+        counts = {"huge.py": 100, "a.py": 1, "b.py": 1}
+        loads = [sum(counts[f] for f in b) for b in plan_shards(counts, 3)]
+        assert max(loads) == 100
+
+
+class TestRejectsNonsense:
+    def test_zero_shards_is_refused(self):
+        with pytest.raises(ValueError):
+            plan_shards(REAL, 0)
+
+    def test_empty_input_yields_empty_shards_rather_than_failing(self):
+        assert plan_shards({}, 3) == [[], [], []]


### PR DESCRIPTION
Fix 2 of #1468. `Python Test (integration)` ran 361 tests serially and was the tail of the run whenever it drew a slow runner — on one reference run it finished at t=736s with everything else done by t=540s, leaving one job on the machine and nineteen of twenty slots idle for over three minutes.

## Why count-balancing is sufficient

Measured across five CI runs by deriving per-test durations from Actions log timestamps: **per-test cost is uniform at 0.58–1.07 s/test**. The work is fixture setup and teardown, which every test pays equally, so a file's duration is its test count times a constant. There are no slow tests to isolate — the four heaviest files are simply the four with the most tests.

## Why three

Roughly **100s of every job is fixed cost** — checkout, image, compose stack, collection — measured at 95s and 112s from job start to first test.

| shards | fast run | slow run |
|---|---|---|
| 1 (today) | 319s | 697s |
| 2 | 210s | 400s |
| **3** | **173s** | **300s** |
| 4 | 155s | 251s |

A fourth shard buys 20–50s of wall-clock for another ~100s of runner time.

## No list to maintain

The split happens in `pytest_collection_modifyitems`, so it sees the **true collected set** — a new test file is assigned automatically. That is deliberate: a hand-maintained path list is the hazard the `unit` slice already warns about, where an unlisted file silently never runs.

For the same reason the planner's tests live in `tests/meta/` — a **directory** added to the unit slice — rather than as another root-level file, which would have grown exactly that list.

## The xdist objection is narrowed, not dismissed

It stands *within* a job: xdist workers share one database and race to create the same tables. It does not apply *across* runners, where each shard gets its own compose stack — which is already how `unit` and `services-api` work.

## Verification

The planner is pure and tested alone — 17 tests: totality (every file in exactly one shard, for 1…29 shards), determinism against input order, balance tolerances, and refusal of nonsense. It sits outside `tests/integration/` because that package's autouse fixtures need Postgres, which would have made an infrastructure test require a database.

End-to-end via collection, which needs no database: the shards select **120 / 121 / 120** tests across 9/10/9 files, and their union is identical to the unsharded **361**.

Worth flagging: an earlier version of that check compared 0 against 0 and reported success, because `addopts = "-v"` overrode `-q` and my grep matched nothing. It now asserts a non-trivial count before claiming a match.

Honest caveat: I could not run the integration suite itself locally (the container store is out of disk — separate issue), so this PR's CI run is its first real execution.