### PR TITLE
ci(1468): cut CI wall-clock — no job left running alone at the tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2100,7 +2100,23 @@ jobs:
   # is why each entry is written to be read by someone outside the
   # project.
   scan-images:
-    name: Scan ${{ matrix.image }} (${{ matrix.arch }})
+    # One job per IMAGE, scanning both arches, rather than one per image+arch.
+    #
+    # As 5x2 this was ten jobs that all became eligible at the same instant as
+    # the eight E2E shards, two helm-eval-boot jobs and oci-conformance — 21 jobs
+    # for 20 concurrent slots. The E2E shards lost 27s, 44s and 57s of queue wait
+    # to it, and the shard that waited 44s was the straggler gating E2E Report,
+    # so the contention sat directly on the critical path (#1468).
+    #
+    # Five jobs scan the same images with the same settings and free five slots
+    # at exactly the contended moment. Each takes roughly twice as long (~52-172s
+    # against 26-86s), which is well inside the slack before create-manifests.
+    #
+    # Deliberately NOT solved with `needs: [e2e-test]`. That works today only
+    # because create-manifests is gated behind python-test; once the integration
+    # shard is split, that slack disappears and deferred scans become the new
+    # critical path.
+    name: Scan ${{ matrix.image }}
     needs: [prepare, build-images-amd64, build-images-arm64]
     if: |
       always()
@@ -2115,15 +2131,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
         image: [terrapod-api, terrapod-web, terrapod-runner, terrapod-listener, terrapod-migrations]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      # On branch/tag builds the image lives in GHCR — log in and let Trivy
-      # pull the per-arch tag. On PRs nothing was pushed; the image arrives as
-      # a per-arch artifact from build-images-<arch> and is loaded into the
-      # local daemon below, where Trivy finds it by the same tag.
+      # On branch/tag builds the image lives in GHCR — log in and let Trivy pull
+      # the per-arch tag. On PRs nothing was pushed; the image arrives as a
+      # per-arch artifact from build-images-<arch> and is loaded into the local
+      # daemon below, where Trivy finds it by the same tag.
       - name: Log in to GHCR
         if: needs.prepare.outputs.is_pr != 'true'
         uses: ./.github/actions/ghcr-login
@@ -2131,62 +2146,117 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
 
-      - name: Download image artifact (PR)
+      # ── amd64 ──
+      - name: Download image artifact (amd64, PR)
         if: needs.prepare.outputs.is_pr == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: image-${{ matrix.image }}-${{ matrix.arch }}
+          name: image-${{ matrix.image }}-amd64
           path: /tmp
 
-      - name: Load image (PR)
+      - name: Load image (amd64, PR)
         if: needs.prepare.outputs.is_pr == 'true'
-        run: gunzip -c "/tmp/${{ matrix.image }}-${{ matrix.arch }}.tar.gz" | docker load
+        run: gunzip -c "/tmp/${{ matrix.image }}-amd64.tar.gz" | docker load
 
-      # Human-readable findings step. Always prints the table of CVEs
-      # Trivy would gate on to the action log — so a failure in the
-      # gating step below can be diagnosed without downloading SARIF or
-      # re-running Trivy locally. exit-code: '0' keeps this informational.
-      - name: Trivy findings (table, informational)
+      # Human-readable findings step. Always prints the table of CVEs Trivy would
+      # gate on to the action log — so a failure in the gating step below can be
+      # diagnosed without downloading SARIF or re-running Trivy locally.
+      # exit-code: '0' keeps this informational.
+      - name: Trivy findings (amd64, table, informational)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
-          # The per-arch tag (sha-XXX-arm64) is an OCI index whose only child
-          # is the matrix arch. Without this, Trivy defaults to the runner's
-          # platform (linux/amd64) when pulling the image from GHCR on branch/
-          # tag builds and fails with "no child with platform linux/amd64".
-          # (PR builds load the image into the local daemon, so they never hit
-          # the remote-pull default — which is why this only broke on main.)
-          # Trivy reads TRIVY_PLATFORM as the --platform flag.
-          TRIVY_PLATFORM: linux/${{ matrix.arch }}
+          # The per-arch tag (sha-XXX-amd64) is an OCI index whose only child is
+          # that arch. Without this, Trivy defaults to the runner's platform when
+          # pulling from GHCR on branch/tag builds and fails with "no child with
+          # platform linux/amd64". Trivy reads TRIVY_PLATFORM as --platform.
+          TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-${{ matrix.arch }}
+          image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-amd64
           format: table
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           trivyignores: pentest/trivy/.trivyignore
           exit-code: '0'
 
-      - name: Scan with Trivy
+      - name: Scan with Trivy (amd64)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
-          # See the note on the informational step above — pin the pulled
-          # platform to the matrix arch so the arm64 scan resolves its child.
-          TRIVY_PLATFORM: linux/${{ matrix.arch }}
+          TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-${{ matrix.arch }}
+          image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-amd64
           format: sarif
-          output: trivy-${{ matrix.image }}-${{ matrix.arch }}.sarif
+          output: trivy-${{ matrix.image }}-amd64.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           trivyignores: pentest/trivy/.trivyignore
           exit-code: '1'
           limit-severities-for-sarif: true
 
-      - name: Upload SARIF
+      # The category MUST stay distinct per image AND arch: code scanning keys
+      # results on it, so a shared category would have one arch silently
+      # overwrite the other's findings.
+      - name: Upload SARIF (amd64)
         if: always()
         uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
-          sarif_file: trivy-${{ matrix.image }}-${{ matrix.arch }}.sarif
-          category: trivy-${{ matrix.image }}-${{ matrix.arch }}
+          sarif_file: trivy-${{ matrix.image }}-amd64.sarif
+          category: trivy-${{ matrix.image }}-amd64
+
+      # ── arm64 ──
+      - name: Download image artifact (arm64, PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: image-${{ matrix.image }}-arm64
+          path: /tmp
+
+      - name: Load image (arm64, PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        run: gunzip -c "/tmp/${{ matrix.image }}-arm64.tar.gz" | docker load
+
+      # Human-readable findings step. Always prints the table of CVEs Trivy would
+      # gate on to the action log — so a failure in the gating step below can be
+      # diagnosed without downloading SARIF or re-running Trivy locally.
+      # exit-code: '0' keeps this informational.
+      - name: Trivy findings (arm64, table, informational)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          # The per-arch tag (sha-XXX-arm64) is an OCI index whose only child is
+          # that arch. Without this, Trivy defaults to the runner's platform when
+          # pulling from GHCR on branch/tag builds and fails with "no child with
+          # platform linux/amd64". Trivy reads TRIVY_PLATFORM as --platform.
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-arm64
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: pentest/trivy/.trivyignore
+          exit-code: '0'
+
+      - name: Scan with Trivy (arm64)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-arm64
+          format: sarif
+          output: trivy-${{ matrix.image }}-arm64.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: pentest/trivy/.trivyignore
+          exit-code: '1'
+          limit-severities-for-sarif: true
+
+      # The category MUST stay distinct per image AND arch: code scanning keys
+      # results on it, so a shared category would have one arch silently
+      # overwrite the other's findings.
+      - name: Upload SARIF (arm64)
+        if: always()
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        with:
+          sarif_file: trivy-${{ matrix.image }}-arm64.sarif
+          category: trivy-${{ matrix.image }}-arm64
 
   # ── Create Multi-Arch Manifests ────────────────────────
   create-manifests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,23 +470,43 @@ jobs:
           # shards. Local bench (Apple M-series; CI ~50-60% of this):
           #   unit         90s serial → 13s parallel (1495 → 492 tests)
           #   services-api 138s serial → 30s parallel
-          # The integration shard stays serial — its
+          # The integration shards stay serial WITHIN a job: the
           # session-scoped Postgres table-creation fixture races
-          # under xdist workers (each worker would try to create
-          # the same tables) and the suite is small enough that
-          # serial is fine.
+          # under xdist workers, which share one database. That
+          # objection does not apply ACROSS runners — each shard
+          # gets its own compose stack, exactly as the two slices
+          # above already do — so the split is runner-level.
           - name: unit
             # Root-level tests/*.py are NOT auto-collected by the directory
             # shards below — each must be listed here explicitly, or it silently
             # never runs in CI. All of these are pure-unit (no Postgres/Redis/S3).
-            paths: tests/auth tests/runner tests/storage tests/ai_eval tests/config tests/db tests/helm tests/oci tests/test_logging_config.py tests/test_dependency_pins.py tests/test_api_sdk_contract.py tests/test_schema_version.py tests/test_gpg_verify.py tests/test_http_retry.py tests/test_db_iam_auth.py tests/test_redis_iam_auth.py
+            paths: tests/auth tests/meta tests/runner tests/storage tests/ai_eval tests/config tests/db tests/helm tests/oci tests/test_logging_config.py tests/test_dependency_pins.py tests/test_api_sdk_contract.py tests/test_schema_version.py tests/test_gpg_verify.py tests/test_http_retry.py tests/test_db_iam_auth.py tests/test_redis_iam_auth.py
             pytest_args: -n auto
           - name: services-api
             paths: tests/services tests/api
             pytest_args: -n auto
-          - name: integration
+          # Three runner-level shards, balanced on collected test count by
+          # `--shard` (services/tests/shard_plan.py). Measured across five CI
+          # runs: per-test cost is uniform at 0.58-1.07s — the work is fixture
+          # setup and teardown, which every test pays equally — so a file's
+          # duration is its test count times a constant, and counting balances it.
+          #
+          # Three, not more: ~100s of every job is fixed cost (checkout, image,
+          # compose stack, collection), measured at 95s and 112s on real runs. A
+          # fourth shard buys 20-50s of wall-clock for another ~100s of runner
+          # time.
+          #
+          # The split happens after collection, so a new test file is assigned
+          # automatically and cannot be silently missed (#1468).
+          - name: integration-1
             paths: tests/integration
-            pytest_args: ""
+            pytest_args: "--shard 1/3"
+          - name: integration-2
+            paths: tests/integration
+            pytest_args: "--shard 2/3"
+          - name: integration-3
+            paths: tests/integration
+            pytest_args: "--shard 3/3"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: scripts/test.sh python -- ${{ matrix.slice.pytest_args }} ${{ matrix.slice.paths }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2056,6 +2056,9 @@ jobs:
     needs: [prepare, e2e-test]
     if: always() && needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    # Literal, not ${{ env.* }}: the env context is NOT available in a job's
+    # `container:`. Same mirrored image the lint jobs use.
+    container: ghcr.io/mattrobinsonsre/mirror/node:24-alpine
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Download blob reports
@@ -2067,16 +2070,25 @@ jobs:
           pattern: blob-report-*
           path: all-blob-reports
           merge-multiple: true
+      # Merging blob reports is pure Node — it reads the shards' blob files and
+      # renders HTML. It needs the @playwright/test PACKAGE, not browsers, and
+      # `--ignore-scripts` already skipped Playwright's browser-download
+      # postinstall — so the ~2GB mcr.microsoft.com/playwright image this used to
+      # pull supplied browsers that were never installed and never used. That
+      # pull was most of the job's 257-335s.
+      #
+      # The mirrored node image is the same one the lint jobs use (~50MB), and
+      # the install is six packages / 14MB. Version fidelity comes from
+      # e2e/package-lock.json, which pins @playwright/test to the same 1.58.2 the
+      # shards ran — blob format is version-sensitive, so deriving it from the
+      # lockfile rather than a second hard-coded tag is what stops the two
+      # drifting apart.
       - name: Merge into HTML report
         continue-on-error: true
+        working-directory: e2e
         run: |
-          docker run --rm \
-            -v "${{ github.workspace }}/e2e:/work" \
-            -v "${{ github.workspace }}/all-blob-reports:/work/all-blob-reports" \
-            -w /work \
-            -e HOME=/tmp \
-            mcr.microsoft.com/playwright:v1.58.2-noble \
-            sh -c "npm ci --ignore-scripts && npx playwright merge-reports --reporter html ./all-blob-reports"
+          npm ci --ignore-scripts
+          npx playwright merge-reports --reporter html ../all-blob-reports
       - name: Upload merged HTML report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3039,7 +3039,17 @@ jobs:
       - build-images-arm64
       - scan-images
       - e2e-test
-      - e2e-report
+      # `e2e-report` is deliberately absent, and must stay absent. It is already
+      # excluded from the `results=()` verdict below (see the reasoning on the
+      # job itself: an artifact-storage failure with no Terrapod code involved
+      # failed a correct release on v1.5.3). Listing it here anyway made
+      # `ci-pass` WAIT for a job whose result it then ignored — 5m35s of a PR
+      # run with one job on the machine and nineteen slots idle, because the
+      # report merges eight Playwright blobs behind a ~2GB image pull.
+      #
+      # The workflow run still finishes it; the required status check no longer
+      # waits for it. Re-adding this line reintroduces the stall silently, since
+      # nothing about the verdict changes (#1468).
       - oci-conformance
       - create-manifests
       - release-create

--- a/services/tests/integration/conftest.py
+++ b/services/tests/integration/conftest.py
@@ -23,6 +23,8 @@ from terrapod.api.dependencies import (
 )
 from terrapod.db.models import Base
 
+from ..meta.shard_plan import plan_shards
+
 # ---------------------------------------------------------------------------
 # Ensure test-friendly defaults (must precede any Settings import)
 # ---------------------------------------------------------------------------
@@ -340,3 +342,61 @@ async def assign_platform_role(engine, provider: str, email: str, role_name: str
             ),
             {"p": provider, "e": email, "r": role_name},
         )
+
+
+# ── Runner-level sharding (#1468) ─────────────────────────
+#
+# `--shard k/N` keeps only the files assigned to shard k. Splitting happens
+# AFTER collection, so it sees the true set of files and a new test file cannot
+# be silently missed — the failure mode of a hand-maintained path list.
+#
+# Runner-level, not xdist: the objection to xdist here is that its workers share
+# one database and race to create the same tables. Separate runners each get
+# their own compose stack, which is how the unit and services-api slices already
+# work.
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--shard",
+        default=None,
+        help="Run only this shard of the suite, as k/N (1-based). Splits by file, "
+        "balanced on collected test count.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    spec = config.getoption("--shard")
+    if not spec:
+        return
+
+    try:
+        index_s, total_s = spec.split("/", 1)
+        index, total = int(index_s), int(total_s)
+    except ValueError:
+        raise pytest.UsageError(f"--shard expects k/N, got {spec!r}") from None
+    if not 1 <= index <= total:
+        raise pytest.UsageError(f"--shard {spec}: k must be within 1..N")
+
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[str(item.path)] = counts.get(str(item.path), 0) + 1
+
+    keep = set(plan_shards(counts, total)[index - 1])
+    selected = [i for i in items if str(i.path) in keep]
+    deselected = [i for i in items if str(i.path) not in keep]
+
+    # Printed so a shard that selects nothing is visible in the log rather than
+    # passing as a vacuous success.
+    print(
+        f"\nshard {index}/{total}: {len(keep)} files, {len(selected)} tests "
+        f"({len(deselected)} deselected)"
+    )
+    if not selected:
+        raise pytest.UsageError(
+            f"--shard {spec} selected no tests. With {len(counts)} files collected "
+            "this means the split is wrong, not that there is nothing to run."
+        )
+
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected

--- a/services/tests/meta/shard_plan.py
+++ b/services/tests/meta/shard_plan.py
@@ -1,0 +1,57 @@
+"""Split the integration suite across runners, balanced by test count.
+
+The integration slice runs serially — its session-scoped table-creation fixture
+races under xdist workers, which share one database. Runner-level shards do not
+have that problem: each gets its own compose stack, exactly as the `unit` and
+`services-api` slices already do.
+
+Balancing by **test count** rather than by file count is deliberate, and the
+measurements say it is enough. Across five CI runs the per-test cost is uniform
+at 0.58-1.07 s/test — the work is fixture setup and teardown, which every test
+pays equally, so a file's duration is its test count times a constant. There are
+no slow tests to special-case.
+
+Two properties matter more than optimal packing, because both failure modes are
+silent:
+
+- **Total.** Every collected file lands in exactly one shard. A new test file
+  cannot be missed, which is the hazard of a hand-maintained path list — the
+  `unit` slice already carries a warning about exactly that.
+- **Deterministic.** The same input gives the same split on every runner, so
+  shard 2 runs the same files on the retry as it did on the first attempt.
+
+Splitting by file rather than by test keeps a module's tests together, so
+module-scoped fixtures behave as they do today.
+"""
+
+from __future__ import annotations
+
+
+def plan_shards(counts: dict[str, int], shards: int) -> list[list[str]]:
+    """Pack files into `shards` groups of roughly equal test count.
+
+    `counts` maps a file identifier to its number of collected tests. Returns one
+    list of file identifiers per shard.
+
+    Greedy longest-first: repeatedly place the largest remaining file into the
+    lightest shard. Not optimal in general, but for this distribution — 28 files
+    of 2-55 tests — it lands within one test of perfect (123/123/122 at three
+    shards), and being obvious matters more here than being optimal.
+
+    Ties break on the file name so the result cannot depend on dict ordering.
+    """
+    if shards < 1:
+        raise ValueError(f"shards must be >= 1, got {shards}")
+    if shards == 1:
+        return [sorted(counts)]
+
+    buckets: list[list[str]] = [[] for _ in range(shards)]
+    load = [0] * shards
+
+    # Descending by count, then by name: deterministic regardless of input order.
+    for name, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+        target = load.index(min(load))
+        buckets[target].append(name)
+        load[target] += count
+
+    return [sorted(b) for b in buckets]

--- a/services/tests/meta/test_shard_plan.py
+++ b/services/tests/meta/test_shard_plan.py
@@ -1,0 +1,109 @@
+"""Tests for the integration-suite shard planner (#1468).
+
+Deliberately pure: no database, no fixtures. The planner decides which tests run
+on which runner, so a bug here does not fail — it silently skips. That makes it
+worth testing more carefully than the code it distributes, and it is the one
+piece of this change that can be verified without a container.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .shard_plan import plan_shards
+
+# Real shape, from a CI run: 28 files, 368 tests, largest 55.
+REAL = {
+    "test_release_blockers.py": 55,
+    "test_run_execution.py": 44,
+    "test_deleted_workspace_restore.py": 41,
+    "test_role_reach.py": 36,
+    "test_workspace_state_lifecycle.py": 18,
+    "test_oci_registry_integration.py": 18,
+    "test_varset_assignment_rules.py": 17,
+    "test_run_state_machine.py": 12,
+    "test_rbac_enforcement.py": 12,
+    "test_package_cache_integration.py": 11,
+    "test_oci_gc_integration.py": 11,
+    "test_bootstrap_pools_integration.py": 9,
+    "test_provider_publish.py": 9,
+    "test_vcs_commit_claim_release.py": 8,
+    "test_variables.py": 8,
+    "test_multi_pool_dispatch.py": 8,
+    "test_replication_lag.py": 8,
+    "test_vault_value_source.py": 6,
+    "test_replication_outbox.py": 6,
+    "test_oci_deletion_integration.py": 6,
+    "test_summary_placeholder.py": 5,
+    "test_run_task_stage_idempotency.py": 5,
+    "test_lifecycle_destroy_retry_integration.py": 3,
+    "test_peer_credentials.py": 3,
+    "test_ca_init_race.py": 2,
+    "test_catalog_lifecycle_integration.py": 2,
+    "test_bootstrap_seed_integration.py": 2,
+    "test_onboarding_session_integration.py": 2,
+}
+
+
+class TestNothingIsLostOrDuplicated:
+    """The two properties that matter, because both failures are silent: a
+    dropped file never runs and nobody notices, and a duplicated one wastes a
+    shard while hiding the imbalance."""
+
+    @pytest.mark.parametrize("shards", [1, 2, 3, 4, 5, 8, 29])
+    def test_every_file_lands_in_exactly_one_shard(self, shards):
+        buckets = plan_shards(REAL, shards)
+        placed = [f for b in buckets for f in b]
+
+        assert sorted(placed) == sorted(REAL), "a file was dropped or renamed"
+        assert len(placed) == len(set(placed)), "a file was placed twice"
+        assert len(buckets) == shards
+
+    def test_more_shards_than_files_leaves_empties_rather_than_dropping(self):
+        """The planner must not silently discard files it cannot spread. Empty
+        shards are the caller's problem to notice; lost tests are nobody's."""
+        buckets = plan_shards({"a.py": 1, "b.py": 1}, 5)
+        assert sorted(f for b in buckets for f in b) == ["a.py", "b.py"]
+        assert sum(1 for b in buckets if not b) == 3
+
+
+class TestDeterminism:
+    """A retried shard must run the same files it ran the first time, whatever
+    order the collector happened to produce."""
+
+    def test_the_split_does_not_depend_on_input_order(self):
+        reversed_input = dict(reversed(list(REAL.items())))
+        assert plan_shards(REAL, 3) == plan_shards(reversed_input, 3)
+
+    def test_equal_counts_are_broken_deterministically(self):
+        same = {f"t{i}.py": 5 for i in range(9)}
+        assert plan_shards(same, 3) == plan_shards(dict(reversed(list(same.items()))), 3)
+
+
+class TestBalance:
+    """Balance is the entire point — an unbalanced split just moves the tail."""
+
+    @pytest.mark.parametrize("shards,worst", [(2, 190), (3, 128), (4, 98)])
+    def test_the_heaviest_shard_stays_near_the_ideal(self, shards, worst):
+        buckets = plan_shards(REAL, shards)
+        loads = [sum(REAL[f] for f in b) for b in buckets]
+        assert max(loads) <= worst, f"{loads} — heaviest shard beyond tolerance"
+
+    def test_a_single_shard_is_the_whole_suite(self):
+        assert sorted(plan_shards(REAL, 1)[0]) == sorted(REAL)
+
+    def test_one_dominant_file_cannot_be_split_and_bounds_the_result(self):
+        """An honest limit, asserted so it is not mistaken for a packing bug: a
+        file is indivisible, so no shard count beats its own weight."""
+        counts = {"huge.py": 100, "a.py": 1, "b.py": 1}
+        loads = [sum(counts[f] for f in b) for b in plan_shards(counts, 3)]
+        assert max(loads) == 100
+
+
+class TestRejectsNonsense:
+    def test_zero_shards_is_refused(self):
+        with pytest.raises(ValueError):
+            plan_shards(REAL, 0)
+
+    def test_empty_input_yields_empty_shards_rather_than_failing(self):
+        assert plan_shards({}, 3) == [[], [], []]


### PR DESCRIPTION
Closes #1468 (fixes 1, 2 and 3a).

CI wall-clock is 13 min on `main` and up to 21 min on PRs, and both numbers are dominated by **one job running alone at the tail** — a different job depending on the run. For the last several minutes of every run, 19 of 20 slots sit idle.

Measured from per-job `created_at`/`started_at`/`completed_at`, and from per-test durations derived from Actions log timestamps across five runs.

## The tail alternates, which is why all three are here

| run | tail |
|---|---|
| [33801697811](https://github.com/mattrobinsonsre/terrapod/actions/runs/33801697811) | `Python Test (integration)` — ends t=736s, everything else done by t=540s |
| [33851827389](https://github.com/mattrobinsonsre/terrapod/actions/runs/33851827389) | `E2E Report` — **alone for 257s**; integration wasn't in the last eight jobs at all |

Whichever of the two draws the slow runner becomes the tail. Fixing one alone just hands the tail to the other.

## Fix 1 — `ci-pass` waited on a job it ignores

`ci-pass` listed `e2e-report` in `needs:` while deliberately omitting it from the `results=()` array that decides pass/fail. The required check waited **5m35s** for a job whose result could not change the answer — merging eight blob files into an HTML page behind a ~2GB image pull.

**This does not weaken the E2E gate.** `e2e-test` (the eight shards that actually run Playwright) stays in both `needs` and `results`. Observed on #1455 earlier today: when `E2E Tests (4/8)` failed, both it and `CI` went red.

The exclusion exists because on v1.5.3 a GitHub artifact-storage failure — no Terrapod code involved — failed an otherwise correct release, with no rerun able to clear it. Keeping the `needs:` edge reintroduced that exposure as delay rather than failure.

## Fix 2 — the integration suite runs on three runners

361 tests, serial, and the tail whenever it drew a slow runner.

**Balanced on test count, because the data says that is enough:** per-test cost is uniform at **0.58–1.07 s/test**. The work is fixture setup and teardown, which every test pays equally, so a file's duration is its test count times a constant. The four heaviest files are simply the four with the most tests — there are no slow tests to isolate.

**Three, not more:** ~100s of every job is fixed cost (checkout, image, compose stack, collection), measured at 95s and 112s from job start to first test.

| shards | fast run | slow run |
|---|---|---|
| 1 (today) | 319s | 697s |
| **3** | **173s** | **300s** |
| 4 | 155s | 251s |

**No list to maintain.** The split happens in `pytest_collection_modifyitems`, so it sees the true collected set and a new test file is assigned automatically — a hand-maintained path list is the hazard the `unit` slice already warns about. For the same reason the planner's tests live in `tests/meta/`, a **directory** added to that slice, rather than another root-level file that would have grown that very list.

**The xdist objection is narrowed, not dismissed.** It stands *within* a job: workers share one database and race to create the same tables. It does not apply *across* runners, where each shard gets its own compose stack — already how `unit` and `services-api` work.

## Fix 3a — ten scan jobs contending with the critical path

`scan-images` was 5 images × 2 arches: ten jobs eligible at the same instant as eight E2E shards, two `helm-eval-boot` jobs and `oci-conformance` — 21 jobs for 20 slots. The E2E shards lost 27s, 44s and 57s of queue wait, and the one that waited 44s was the straggler gating `E2E Report`.

Now five jobs, each scanning both arches. The SARIF `category` stays distinct per image **and** arch — code scanning keys on it, so a shared category would have one arch silently overwrite the other's findings. That is why the arch steps are duplicated rather than looped.

Deliberately not `needs: [e2e-test]`: that works today only because `create-manifests` is gated behind `python-test`, and Fix 2 removes that slack.

## Also: `e2e-report` no longer pulls a 2GB browser image

The secondary item #1468 parked until the job was off the gate — worth doing now that it is, since it still occupies a runner and still delays the workflow's own completion.

It ran `docker run mcr.microsoft.com/playwright:v1.58.2-noble` (~2GB) to merge eight blob files into an HTML page, and that pull was most of the 257–335s.

Merging is **pure Node**: it reads blob files and renders HTML. It needs the `@playwright/test` *package*, not browsers — and the command already passed `--ignore-scripts`, which skips Playwright's browser-download postinstall. So the browsers that image exists to provide were never installed and never used.

Now runs in the mirrored `node:24-alpine` the lint jobs already use (~50MB). Verified locally: `@playwright/test@1.58.2` installs with `--ignore-scripts` to **14MB** with no browsers, and `playwright merge-reports` runs against it.

Version fidelity improves rather than degrades: it now comes from `e2e/package-lock.json`, which resolves to the same **1.58.2** the shards ran. Blob format is version-sensitive, and the previous arrangement had that version written down twice — the lockfile and a hard-coded image tag — which is exactly how the two drift apart.

Output path unchanged: the merge runs in `e2e/` and writes `e2e/playwright-report/`, which is what the upload step expects.

## Verification

- Planner tested alone — 17 tests: totality (every file in exactly one shard, 1…29 shards), determinism against input order, balance tolerances, refusal of nonsense.
- Shards partition the suite exactly: **120 / 121 / 120** tests, union identical to the unsharded **361**. (An earlier version of that check compared 0 against 0 and reported success, because `addopts = "-v"` overrode `-q`; it now asserts a non-trivial count first.)
- `e2e-report` absent from `needs`, `e2e-test` retained; `Cleanup Tag` never referenced it; branch protection requires only `CI`.
- `scan-images` 10 → 5, categories unique, all other references by job **id**, so the six wiring points the release checklist requires are untouched.
- YAML parses.

**Honest caveat:** I could not run the integration suite locally — the container store is out of disk (#1470) — so this PR's CI run is the first real execution of the sharding.

Fix 4 (duration-balanced E2E shards) is left for a follow-up; it only pays off once the tail is gone, which is what this does.

