### PR TITLE
ci: mirror the Playwright image, the last unmirrored third-party pull

### DIFF
--- a/.github/mirror-images.txt
+++ b/.github/mirror-images.txt
@@ -29,3 +29,10 @@ alpine/helm:3.17.2
 semgrep/semgrep:1.117
 localstack/localstack:4
 moby/buildkit:buildx-stable-1
+
+# Not on Docker Hub — the source registry is part of the reference. The eight
+# E2E shards each pull this, and at 0.91GB compressed that is the largest single
+# thing CI fetches. Playwright publishes no browser-specific variant (18,570
+# tags, none Chromium-only), so this mirrors the image as published rather than
+# trimming it; a smaller image would have to be one we build and own.
+mcr.microsoft.com/playwright:v1.58.2-noble

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -93,7 +93,15 @@ jobs:
             flat="${repo//\//-}"
             dst="ghcr.io/${OWNER,,}/mirror/${flat}:${tag}"
             echo "::group::$src -> $dst"
-            if docker buildx imagetools create --tag "$dst" "docker.io/${src}"; then
+            # A source may name its registry (mcr.microsoft.com/...). Docker Hub
+            # references do not, and must keep their explicit docker.io prefix
+            # rather than relying on the daemon's default. The test is whether
+            # the first path segment looks like a host — it contains a dot.
+            case "${src%%/*}" in
+              *.*) full="$src" ;;
+              *)   full="docker.io/${src}" ;;
+            esac
+            if docker buildx imagetools create --tag "$dst" "$full"; then
               docker buildx imagetools inspect "$dst" --format '{{json .Manifest.Digest}}'
             else
               # One image failing must not hide the rest — report them all, then


### PR DESCRIPTION
Step 1 of 2. **This PR only publishes the mirror — it does not point CI at it.**

Every other third-party image CI pulls already goes through the GHCR mirror: node, postgres, python, redis, registry, alpine/helm, semgrep, localstack, buildkit. Playwright did not — and at **0.91GB compressed**, fetched by each of **eight** E2E shards, it is the largest single thing CI pulls.

## The one code change

The copy step hardcoded `docker.io/` as the source registry, and Playwright is on `mcr.microsoft.com`. A source may now name its own registry, detected by its first path segment containing a dot. Docker Hub references keep their explicit `docker.io` prefix rather than falling back to the daemon's default, so nothing about the existing ten entries changes.

Verified against the real validator and flattening logic:

```
mcr.microsoft.com/playwright:v1.58.2-noble
  from: mcr.microsoft.com/playwright:v1.58.2-noble
  to:   ghcr.io/mattrobinsonsre/mirror/mcr.microsoft.com-playwright:v1.58.2-noble
```

## Why the image as published, not a Chromium-only one

Worth recording, because it is the obvious next thought — and it does not work as a *mirror*:

**Playwright publishes no browser-specific variant.** 18,570 tags, none matching chromium. So a smaller image has to be one we **build and own**, tracked against the Playwright version — which is a different thing from a digest-preserving copy, and does not belong in this workflow.

The upside is real though: all 35 E2E projects are Chromium (`Desktop Chrome` ×34, `Pixel 7` ×1). Firefox and WebKit ship in that image and are never launched — roughly two-thirds of the browser payload is dead weight. Whether that justifies owning a build is a question to settle with a measurement **after** this lands, since mirroring alone may gain enough.

## Why it does not wire the call site

The mirrored image does not exist until this merges and the workflow runs. Pointing the shards at it in the same change would send all eight at a tag that is not there. Step 2 follows once the mirror is populated.

Confirmed the `e2e-test" job already has a `Log in to GHCR` step, so consuming the mirror will need no extra auth.