### PR TITLE
ci: pull the Playwright image from the mirror (reliability, not speed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,16 @@ env:
   NODE_IMAGE: ghcr.io/mattrobinsonsre/mirror/node:24-alpine
   POSTGRES_IMAGE: ghcr.io/mattrobinsonsre/mirror/postgres:16-alpine
   REDIS_IMAGE: ghcr.io/mattrobinsonsre/mirror/redis:7-alpine
+  # The largest single thing CI pulls: 0.91GB compressed, fetched by each of the
+  # eight E2E shards. Mirrored in #1475 for the same reason as the rest — CI
+  # should not depend on a third-party registry being reachable.
+  #
+  # This tag must stay in step with e2e/package-lock.json, which pins
+  # @playwright/test to the version these browsers belong to. A mismatch fails
+  # loudly (Playwright refuses a browser revision it does not expect) rather
+  # than silently, but the two are still written down twice and that is the
+  # thing to watch when bumping either.
+  PLAYWRIGHT_IMAGE: ghcr.io/mattrobinsonsre/mirror/mcr.microsoft.com-playwright:v1.58.2-noble
   LOCALSTACK_IMAGE: ghcr.io/mattrobinsonsre/mirror/localstack-localstack:4
   HELM_IMAGE: ghcr.io/mattrobinsonsre/mirror/alpine-helm:3.17.2
   PY_IMAGE: ghcr.io/mattrobinsonsre/mirror/python:3.13-slim
@@ -1885,7 +1895,7 @@ jobs:
             -w /work \
             -e CI=true \
             -e HOME=/tmp \
-            mcr.microsoft.com/playwright:v1.58.2-noble \
+            ${PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.58.2-noble} \
             sh -c "npm ci --ignore-scripts && npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}"
         # Playwright has per-test timeouts of its own; this is the
         # outer safety net. npm ci inside the container is ~10 s for


### PR DESCRIPTION
Step 2 of 2, following #1475.

The mirror is populated — I verified the tag resolves as a **multi-arch index (amd64 + arm64)** before referencing it, because pointing eight shards at a tag that is not there fails all of them at once. The mirror run reported `mirrored 11 images` (was 10).

Follows the pattern the other mirrored images already use: a workflow-level env var CI sets, with the upstream reference kept as the shell fallback so the step still works anywhere the env is unset. The `e2e-test` job already has a `Log in to GHCR` step, so this needs no extra auth.

## Measured: this is a reliability change, not a speed one

I expected a pull-time gain and there is none. Playwright pull duration, isolated from log timestamps across all eight shards:

| | shard durations | median |
|---|---|---|
| before (upstream MCR) | 24.1, 24.2, 24.3, 24.3, 24.5, 24.5, 24.8, 31.3 | **24.4s** |
| after (GHCR mirror) | 23.9, 24.0, 24.3, 24.4, 24.8, 29.2, 30.0, 32.7 | **24.6s** |

0.2s apart, well inside the noise. Obvious in hindsight: MCR and GHCR are both Azure-fronted and GitHub runners are on Azure, so it is the same bytes over the same network.

**What it does buy** is what the other ten mirrors buy: CI no longer depends on a third-party registry being reachable, so an MCR hiccup cannot red a PR that has nothing to do with it. That is the stated purpose in `.github/mirror-images.txt`, and it stands on its own.

## The size question, settled with a number

Worth recording so nobody re-opens it on the "0.91GB image" framing, as I nearly did:

**The pull is ~25 seconds**, and the shards run in parallel — so it is ~25s of wall-clock, not eight times that. Against a 300–430s shard, the image is roughly **6–8% of the job**.

So a Chromium-only image — which all 35 E2E projects would allow, since Firefox and WebKit are never launched — has a ceiling of maybe 15s off a job of several minutes, in exchange for an artifact we build, own, and keep in step with every Playwright bump. **Not worth it on this evidence.**

## One thing to watch

The Playwright version is now written down twice: this tag, and `e2e/package-lock.json`, which pins `@playwright/test` to the version these browsers belong to. A mismatch fails loudly rather than silently — Playwright refuses a browser revision it does not expect — but they still have to move together.
