### PR TITLE
ci: cache e2e node_modules — npm ci was 51% of every E2E shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1886,6 +1886,27 @@ jobs:
       # Image tag MUST track the pinned `@playwright/test` version in
       # e2e/package-lock.json — version skew between client and bundled
       # browsers causes runtime failures.
+      # `npm ci` for this tree is FOUR packages and was taking two minutes — 51%
+      # of the job, against 22s for the tests themselves. The container starts
+      # with an empty npm cache every run, so playwright-core and typescript are
+      # refetched cold each time. Measured at 125.8s here and 54s for the same
+      # command in node:24-alpine; neither is a sane figure for four packages.
+      #
+      # The step below mounts ${{ github.workspace }}/e2e into the container, so
+      # `npm ci` writes node_modules into the RUNNER's workspace — which is what
+      # makes it cacheable from out here at all.
+      #
+      # Keyed on the lockfile hash, so a Playwright bump changes the key and a
+      # stale node_modules can never be restored against a new lockfile. No
+      # restore-keys, deliberately: a partial match is exactly the silent
+      # staleness this must not have.
+      - name: Cache e2e node_modules
+        id: e2e-modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: e2e/node_modules
+          key: e2e-node-modules-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+
       - name: Run Playwright tests
         run: |
           docker run --rm \
@@ -1896,10 +1917,10 @@ jobs:
             -e CI=true \
             -e HOME=/tmp \
             ${PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.58.2-noble} \
-            sh -c "npm ci --ignore-scripts && npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}"
-        # Playwright has per-test timeouts of its own; this is the
-        # outer safety net. npm ci inside the container is ~10 s for
-        # this tree (only @playwright/test + typescript).
+            sh -c "${{ steps.e2e-modules.outputs.cache-hit == 'true' && 'true' || 'npm ci --ignore-scripts' }} && npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}"
+        # Playwright has per-test timeouts of its own; this is the outer
+        # safety net. (This comment used to say npm ci was "~10 s for this
+        # tree" — it was two minutes, and that claim is why nobody looked.)
         timeout-minutes: 10
 
       # Per-shard blob report → merged into one HTML report by `e2e-report`.
@@ -2093,11 +2114,21 @@ jobs:
       # shards ran — blob format is version-sensitive, so deriving it from the
       # lockfile rather than a second hard-coded tag is what stops the two
       # drifting apart.
+      # Same four packages, same 54s. This job runs IN the node container
+      # rather than mounting into one, so node_modules lands at e2e/node_modules
+      # in the workspace either way and the same cache key serves both.
+      - name: Cache e2e node_modules
+        id: e2e-modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: e2e/node_modules
+          key: e2e-node-modules-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+
       - name: Merge into HTML report
         continue-on-error: true
         working-directory: e2e
         run: |
-          npm ci --ignore-scripts
+          [ "${{ steps.e2e-modules.outputs.cache-hit }}" = "true" ] || npm ci --ignore-scripts
           npx playwright merge-reports --reporter html ../all-blob-reports
       - name: Upload merged HTML report
         if: always()


### PR DESCRIPTION
Answers "where is the time going in the 3-minute Playwright step": **`npm ci`, installing four packages, taking two minutes.**

## Where the 246s actually went

| phase | time | share |
|---|---|---|
| setup, artifact download, image loads, stack start, health | 86.6s | 35% |
| **`npm ci` — four packages** | **125.8s** | **51%** |
| global setup | 4.0s | 2% |
| **the tests** | **21.9s** | **9%** |

npm says so itself: `added 4 packages, and audited 5 packages in 2m`.

The comment directly above that step claimed `npm ci inside the container is ~10 s for this tree`. It is twelve times that, and the claim is why nobody looked — so it is **corrected** here rather than deleted.

This also corrects my own earlier framing: I measured the image pull at ~25s and treated the 0.91GB image as the problem. It is a minor term inside the 86.6s.

## Not the Playwright image

The same command on the same lockfile takes **54s** in `node:24-alpine` (the report job). Neither figure is sane for four packages — the container simply starts with an empty npm cache every run, so `playwright-core` and `typescript` are refetched cold.

## Why it is cacheable at all

The shard step mounts `${{ github.workspace }}/e2e` into the container, so `npm ci` writes `node_modules` into the **runner's** workspace. The report job runs *in* a node container rather than mounting into one, but `node_modules` lands in the same path — so a single key serves both.

Keyed on the lockfile hash, with **no `restore-keys`** deliberately: a partial match would restore `node_modules` built for a different Playwright version, and silent staleness is the exact failure this must not have.

## Expected

~126s off each shard, ~50s off the report. Shards run in parallel, so roughly **two minutes off the critical path** — more than the topology changes in #1474 achieved between them.

## Assumptions worth naming

- Everything here is pure JavaScript under `--ignore-scripts`, so a cache saved on the runner is safe inside a container, and safe across the glibc/musl difference between the two jobs' images.
- On a cold key, all nine jobs race to save the same entry. GitHub keeps the first and warns on the rest — noisy for one run, harmless.

## Measured, not predicted

A cold key proves nothing — the first run on this PR missed on every shard and still paid the full two minutes, which is by design. Re-ran one shard against the warm cache:

| | attempt 1 (cold) | attempt 2 (warm) |
|---|---|---|
| Cache step | — | **2s** |
| Run Playwright tests | **176s** | **49s** |
| **Job total** | **246s** | **126s** |

**−127s per shard, a 49% cut**, matching the ~126s predicted. The 49s left in that step is the image pull (~25s) plus the tests (~22s) — only real work remains.

Cache is 6MB. Worth being explicit that the win is on every run *after* a Playwright bump, never on the bump itself.

**Scope:** the cache was saved against `refs/pull/1477/merge`. GitHub scopes caches to the creating branch, with the default branch's caches visible to all — so after this merges, `main` misses once and every PR thereafter restores from it.
