### PR TITLE
ci(1466): re-elect the newest release instead of only declining the badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3109,6 +3109,29 @@ jobs:
             --latest="$latest" \
             --notes-file /tmp/release-notes.md
 
+          # Declining the badge is NOT the same as handing it to someone else.
+          # `make_latest=false` only says "do not force THIS one"; it elects no
+          # replacement, so GitHub falls back to picking by publish date — and the
+          # patch just published is the most recent, so it takes the badge back.
+          #
+          # Observed on v1.5.5: this step logged "v1.5.5 is not the newest release
+          # (v1.6.0 is)", passed --latest=false, ran last of all the release jobs,
+          # and /releases/latest still returned v1.5.5 until it was corrected by
+          # hand (#1466).
+          #
+          # So promote the highest release positively. A no-op when it already holds
+          # the badge, which keeps the ordinary case quiet.
+          if [ "$latest" != "true" ]; then
+            echo "::notice::re-electing $highest as the latest release"
+            # Warn rather than fail. A failure here would fail release-finalize,
+            # and Cleanup Tag would then DELETE the tag — losing a complete,
+            # correct release over a badge. The release is already published and
+            # sound at this point; a wrong badge is visible and fixable by hand,
+            # a deleted tag is not.
+            gh release edit "$highest" --latest=true \
+              || echo "::warning::could not re-elect $highest as latest; $version may hold the badge — fix with: gh release edit $highest --latest=true"
+          fi
+
           gh release upload "$version" \
             dist/terrapod-${chart_version}.tgz \
             dist/sbom-terrapod-api.spdx.json \


### PR DESCRIPTION
Closes #1466.

The #1374 guard computes the right answer and still fails to achieve its purpose. On v1.5.5 it logged

```
v1.5.5 is not the newest release (v1.6.0 is) — not taking the 'Latest' badge
```

passed `--latest=false`, and ran **last** of all the release jobs — so nothing overwrote it. `/releases/latest` still returned **v1.5.5** until I corrected it by hand.

## Why

`make_latest=false` only says *do not force THIS one*. It elects no replacement, so GitHub falls back to picking by **publish date** — and the patch just published is the most recent, so it takes the badge straight back. **Declining is not deferring.**

The fix promotes the highest release positively when this tag is not it. It is a no-op when that release already holds the badge, so the ordinary case stays quiet.

## Deliberately non-fatal

A failure in this call would fail `release-finalize`, and `Cleanup Tag` would then **delete the tag** — losing a complete, correct release over a badge. By that point the release is published and sound: a wrong badge is visible and fixable by hand, a deleted tag is not. The warning carries the exact command to fix it.

## Needs to reach the release branches too

`release-finalize` runs from the branch the tag points at, so a patch cut from `release/v1.5` runs **that branch's** copy of this workflow. Landing it only on `main` would leave the next 1.5 patch repeating exactly what v1.5.5 did. Those follow as separate changes once this is in.