### PR TITLE
chore(1486)!: raise the Kubernetes floor from 1.27 to 1.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ env:
   SEMGREP_IMAGE: ghcr.io/mattrobinsonsre/mirror/semgrep-semgrep:1.117
   BUILDKIT_IMAGE: ghcr.io/mattrobinsonsre/mirror/moby-buildkit:buildx-stable-1
   K3D_REGISTRY_IMAGE: ghcr.io/mattrobinsonsre/mirror/registry:2
+  # The chart's declared floor (Chart.yaml kubeVersion). The eval-boot kind leg
+  # boots exactly this, so the floor is tested rather than asserted — move the two
+  # together.
+  KIND_NODE_IMAGE_TAG: v1.29.14
 
 jobs:
   # ── Prepare ────────────────────────────────────────────
@@ -1491,7 +1495,13 @@ jobs:
             imgs="$imgs $REGISTRY/$i:sha-${sha}-amd64"
           done
           if [ "${{ matrix.tool }}" = "kind" ]; then
-            kind create cluster --name terrapod-eval --wait 120s
+            # Pinned to the chart's declared floor (Chart.yaml kubeVersion, #1486).
+            # Unpinned, kind boots whatever its own default is — current Kubernetes —
+            # so the floor was a claim nothing tested, which is the shape of accidental
+            # promise #1387 set out to fix. The k3d leg stays unpinned on current, so
+            # between them the two legs cover both ends of the supported range.
+            kind create cluster --name terrapod-eval --wait 120s \
+              --image "kindest/node:${KIND_NODE_IMAGE_TAG}"
             if [ "${{ needs.prepare.outputs.is_pr }}" = "true" ]; then
               # Import the build artifacts straight into the node. `kind load
               # docker-image` has to docker-save each image back out of the

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Terrapod runs **only on Kubernetes** (the runner uses the Jobs API). Deploy it o
 
 ### Prerequisites
 
-- A Kubernetes cluster (1.27+). No cluster? `curl -sfL https://get.k3s.io | sh -` gives you one on a single VM, with an ingress controller (Traefik) and storage included.
+- A Kubernetes cluster (1.29+). No cluster? `curl -sfL https://get.k3s.io | sh -` gives you one on a single VM, with an ingress controller (Traefik) and storage included.
 - Helm 3.x
 - **External** PostgreSQL 14+ and Redis 7+ (the chart does not bundle a production-grade datastore; it can deploy in-cluster Postgres/Redis via `postgresql.deploy`/`redis.deploy` for eval/dev only) — use a managed service or run them on the cluster/VM.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,7 +8,7 @@ Terrapod is deployed exclusively via Helm chart on Kubernetes. This guide covers
 
 ## Prerequisites
 
-- Kubernetes 1.27+
+- Kubernetes 1.29+
 - Helm 3.x
 - PostgreSQL 14+ and Redis 7+ — **external, managed** for production. For evaluation/dev the chart can run both in-cluster (`postgresql.deploy=true` / `redis.deploy=true`, single-replica, no HA or backups — **not** for production); see [Database Setup](#database-setup).
 - Object storage (S3, Azure Blob, GCS) or PVC-backed filesystem

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ plan/apply) is off in the eval to keep it small; create an agent pool and set
 
 | Need | Notes |
 |---|---|
-| A Kubernetes cluster (1.27+) | Any conformant cluster. No cluster? Spin up [k3s](https://k3s.io/) on a single VM (below). |
+| A Kubernetes cluster (1.29+) | Any conformant cluster. No cluster? Spin up [k3s](https://k3s.io/) on a single VM (below). |
 | Helm 3.x | `brew install helm` |
 | PostgreSQL 14+ and Redis 7+ | **External** — the chart does not bundle them. Provide a connection URL for each (a managed service, or run them on the cluster/VM). See [Deployment → Database Setup](deployment.md#database-setup). |
 | Storage | Defaults to a PVC-backed filesystem (no extra setup). For S3/Azure/GCS see [Deployment → Storage Backend Setup](deployment.md#storage-backend-setup). |

--- a/helm/terrapod/Chart.yaml
+++ b/helm/terrapod/Chart.yaml
@@ -2,11 +2,19 @@ apiVersion: v2
 name: terrapod
 description: Terrapod - Open-source Terraform Enterprise replacement
 type: application
-# 1.27 is the floor the project actually tests against; the README states the
-# same number. It was previously declared as 1.23, which let the chart install
-# happily on versions nobody has ever exercised — a promise made by accident
-# rather than on purpose (#1387).
-kubeVersion: ">= 1.27.0-0"
+# 1.29 is the floor, and the eval-boot CI job's kind leg is pinned to it so it
+# is genuinely exercised rather than merely declared — k3d stays on current, so
+# the two legs cover both ends of the supported range (#1486). 1.27 went out of
+# upstream support in June 2024 and no managed provider sells it any more, so
+# the old floor described a version nobody could run.
+#
+# The number is stated in the README, docs/getting-started.md and
+# docs/deployment.md; move all four together. It was 1.23 before #1387, which
+# let the chart install happily on versions nobody had ever exercised — a
+# promise made by accident rather than on purpose. Raising the declaration
+# without raising what CI boots would recreate exactly that, which is why the
+# kind pin is part of this change and not a follow-up.
+kubeVersion: ">= 1.29.0-0"
 version: 0.0.0
 appVersion: "0.0.0"
 


### PR DESCRIPTION
Closes #1486. Part of #1407 (phase 6). **Breaking — for 2.0.**

1.27 went out of upstream support in June 2024 and no managed provider sells it now, so the declared floor described a version nobody could run. Sequenced with the Python floor (#1461, landed today) for the reason #1407 gives: a platform floor change wants operator notice, a major is the honest place for one, and meeting both floors once beats being surprised twice.

## Raising the number alone would have been the wrong change

There is no `.Capabilities.KubeVersion` comparison anywhere in the chart, so nothing in the templates straddled the old floor. But **neither eval-boot leg pinned a node image**, so both booted whatever `kind` and `k3d` default to — current Kubernetes. The floor had therefore never been exercised; it was an assertion.

Raising the declaration and leaving that alone would have recreated exactly the accidental promise #1387 set out to remove, at a nicer number.

So the **kind leg is pinned to `kindest/node:v1.29.14`** — the floor itself — while k3d stays unpinned on current. Between them the two legs now cover both ends of the supported range, and the floor is something CI proves rather than something `Chart.yaml` claims. The tag lives in the workflow env beside the other pinned images, with a comment tying it to `Chart.yaml` so the two move together.

Pinning doesn't change our Docker Hub exposure — kind pulled an unmirrored `kindest/node` before this and pulls a different tag of it now.

## Verified

- `helm lint` + `helm template` on all three profiles.
- The gate does what it says: `--kube-version 1.28.0` is now **rejected**, 1.29.0 accepted.
- Against a **real kind cluster running v1.29.14**, `helm install --dry-run` of the eval profile reaches `pending-install` — so the gate accepts a genuine 1.29 API server, not merely the flag.

The full boot is CI's eval-boot job, which now runs on that image; I didn't duplicate it locally, since it needs all five images built and loaded and CI does it on both legs for this PR.

## Scope

The number is stated in four places — `Chart.yaml`, `README.md`, `docs/getting-started.md`, `docs/deployment.md` — and all four move together.

Nothing here adopts post-1.27 API surface. The bump lands inert, so if it strands anyone it can be reasoned about on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UGnHpcHC4dzxXaeDZi5bx
