### PR TITLE
test(1493): assert the event id the test created, not a literal

### DIFF
--- a/services/tests/integration/test_replication_lag.py
+++ b/services/tests/integration/test_replication_lag.py
@@ -18,24 +18,33 @@ from terrapod.db.session import get_db_session
 from terrapod.services import replication
 
 
-async def _seed(count: int, *, first_age_minutes: int = 0) -> None:
+async def _seed(count: int, *, first_age_minutes: int = 0) -> int:
+    """Insert `count` events; return the id of the newest.
+
+    Returning the id matters. The conftest truncates between tests with
+    `CASCADE` but not `RESTART IDENTITY`, so rows are cleared while the sequence
+    keeps climbing — meaning a test cannot know what id its first row will get,
+    and one that hard-codes it is asserting something it does not own (#1493).
+    """
     async with get_db_session() as db:
         base = datetime.now(UTC) - timedelta(minutes=first_age_minutes)
-        for i in range(count):
-            db.add(
-                ReplicationEvent(
-                    entity_class="workspaces",
-                    entity_id=f"ws-{i}",
-                    op="upsert",
-                    occurred_at=base + timedelta(seconds=i),
-                )
+        events = [
+            ReplicationEvent(
+                entity_class="workspaces",
+                entity_id=f"ws-{i}",
+                op="upsert",
+                occurred_at=base + timedelta(seconds=i),
             )
+            for i in range(count)
+        ]
+        db.add_all(events)
         await db.commit()
+        return max(event.id for event in events)
 
 
 class TestTheLeaderSaysWhereItsStreamEnds:
     async def test_a_capped_page_still_reports_the_newest_event_id(self, app):
-        await _seed(5)
+        newest = await _seed(5)
 
         async with get_db_session() as db:
             page = await replication.read_events(db, after=0, limit=2)
@@ -44,7 +53,7 @@ class TestTheLeaderSaysWhereItsStreamEnds:
         assert page.cursor < page.latest_id, (
             "the cursor alone cannot say how far behind; that is why latest_id exists"
         )
-        assert page.latest_id == 5
+        assert page.latest_id == newest
 
     async def test_the_oldest_unapplied_timestamp_is_the_first_row_handed_back(self, app):
         await _seed(3, first_age_minutes=10)


### PR DESCRIPTION
Closes #1493. Test-only.

`test_a_capped_page_still_reports_the_newest_event_id` seeded five events and asserted `page.latest_id == 5`. That holds only while the `replication_events` sequence starts at 1 for that test — which is not a property of the code under test, but of how many rows anything else happened to insert first.

## The mechanism

`services/tests/integration/conftest.py` truncates between tests with `CASCADE` but **not `RESTART IDENTITY`** (:57), so rows are cleared while `nextval` keeps climbing. `create_all` (:168) is a no-op against tables that already exist. So a session that never reaches its `drop_all` teardown (:177) hands the next one both its tables and its advanced sequence.

Observed after killing a `make test` mid-integration and re-running:

```
AssertionError: assert 455 == 5
  +  where 455 = EventPage(events=[{'id': 451, ...
```

CI never sees it: #1468 gives the integration tier its own job against a fresh database.

## The fix

`_seed` returns the newest id it inserted; the assertion compares to that. The property under test is unchanged — *a capped page still reports the newest event id, which is why `latest_id` exists separately from `cursor`* — and only the dependency on an id the test does not own goes away.

## Why not `RESTART IDENTITY`

It would also work, and makes the fixture honest about restoring a clean slate. Not done here for two reasons: it changes behaviour for every integration test at once, and — more to the point — it would *enable* more tests to depend on absolute id values, which is the direction this bug argues against.

Worth revisiting if others share the assumption. A grep says this was the only one: the file's two other id assertions already compare against a captured value or to `0` on an empty table.

## Verification, honestly

**I could not reconstruct the interrupted-session state on demand** — killed sessions still ran their teardown, leaving no tables behind — so this is *not* backed by a before/after reproduction, and I am not going to imply otherwise.

What it rests on: the captured traceback above, the mechanism read directly out of `conftest.py`, and the fact that comparing against a captured id is correct under every sequence state while comparing against a literal is correct only under one.

The integration tier passes (363).
