### PR TITLE
chore: clear the open code-scanning alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -31,6 +31,15 @@ paths-ignore:
   # so the AI risk-analysis prompt has something to flag). Not product code,
   # never deployed — excluded from code scanning entirely (see also .semgrepignore).
   - services/ai_eval
+  # scripts/ is build, CI and developer tooling — linting, the eval stack, the
+  # release re-scan, and the protocol captures that drive real clients at a
+  # logging stub. No Dockerfile COPYs it, so none of it ships in an image or is
+  # reachable by anyone but whoever runs it. Alerts here are about a throwaway
+  # stub's return style, not about anything a deployment exposes, and they crowd
+  # out the product findings the tab exists to surface.
+  #
+  # Semgrep still scans it (see .semgrepignore, which excludes only ai_eval), so
+  # this narrows one tool's noise rather than leaving the directory unanalysed.
 
 query-filters:
   - exclude:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,19 @@ updates:
       # Lift together with the fastapi hold above, as one migration.
       - dependency-name: starlette
         versions: [">=1.4"]
+      # python-hcl2 8.x changes the shape of what it parses, and the module
+      # registry reads that shape. Block labels and string values come back
+      # with their surrounding quotes where 7.x gave them bare, and blocks
+      # carry a `__is_block__` marker. Module interface extraction reads
+      # variable names and descriptions straight out of that structure, so
+      # v8 breaks it — the parser tests caught it (#1497, closed unmerged).
+      #
+      # Supporting v8 is work rather than a wall: strip the quotes, ignore
+      # the marker. Nothing needs it today, and a widened range would take
+      # v8 silently on the next resolve. Version-scoped so 7.x patches
+      # still arrive.
+      - dependency-name: python-hcl2
+        versions: [">=8"]
 
   - package-ecosystem: npm
     directory: /web

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -116,7 +116,26 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-target-version = "py314"
+# Deliberately behind the interpreter floor, which is 3.14 since #1461.
+#
+# At py314 ruff's formatter emits PEP 758 — `except (A, B):` becomes
+# `except A, B:` — and **CodeQL cannot parse that**. It reads the Python 2
+# meaning, where the second name is a binding target, and reports
+# `py/uninitialized-local-variable` against a local it thinks was invented.
+# Two of those landed on `api/dependencies.py`, at error severity, on the
+# authentication path. The code is correct; the scanner cannot read it.
+#
+# The alternative was excluding `py/uninitialized-local-variable` in
+# codeql-config.yml. That is worse: the rule catches genuine use-before-
+# assignment across all product code, and turning it off repo-wide to work
+# around a parser gap trades a real safety net for a syntax preference.
+#
+# So ruff keeps emitting syntax every tool in the chain can read. Raise this
+# when CodeQL supports PEP 758 — the interpreter floor is not what is holding
+# it back. (This is NOT the backport argument that was made and rejected when
+# the floor moved; that one did not survive scrutiny. This is about the
+# scanner.)
+target-version = "py313"
 line-length = 100
 # Alembic migrations are auto-generated with the conventional revision-vars-
 # before-imports layout (E402) and are not hand-linted. (They're now present in

--- a/services/terrapod/api/credentials.py
+++ b/services/terrapod/api/credentials.py
@@ -59,7 +59,7 @@ def extract_credential(request: Request, *, allow_token_scheme: bool = False) ->
     if scheme == "basic":
         try:
             decoded = base64.b64decode(value.strip(), validate=True).decode("utf-8")
-        except binascii.Error, UnicodeDecodeError, ValueError:
+        except (binascii.Error, UnicodeDecodeError, ValueError):
             # Malformed base64 is indistinguishable from a wrong password as far
             # as the client is concerned, and saying which would be a small
             # oracle. Treated as "no credential".

--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -300,7 +300,7 @@ async def authenticate_request(request: Request) -> AuthenticatedUser:
     )
 
 
-async def authenticate_listener(request: Request) -> ListenerIdentity:
+async def authenticate_listener(request: Request) -> "ListenerIdentity":
     """Authenticate a listener via certificate, looking up identity in Redis.
 
     Like authenticate_request but for certificate-based listener auth.
@@ -335,7 +335,7 @@ async def authenticate_listener(request: Request) -> ListenerIdentity:
     ca = get_ca()
     try:
         ca.ca_cert.public_key().verify(cert.signature, cert.tbs_certificate_bytes)
-    except InvalidSignature, Exception:
+    except (InvalidSignature, Exception):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Certificate not signed by this CA",
@@ -532,7 +532,7 @@ async def get_listener_identity(
             cert.signature,
             cert.tbs_certificate_bytes,
         )
-    except InvalidSignature, Exception:
+    except (InvalidSignature, Exception):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Certificate not signed by this CA",

--- a/services/terrapod/api/pagination.py
+++ b/services/terrapod/api/pagination.py
@@ -43,7 +43,7 @@ def parse_page_params(request: Request | None) -> tuple[int, int | None]:
         raw = request.query_params.get(key) if request is not None else None
         try:
             return int(raw) if raw is not None else None
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return None
 
     size = _int("page[size]")

--- a/services/terrapod/api/routers/config_versions.py
+++ b/services/terrapod/api/routers/config_versions.py
@@ -315,7 +315,7 @@ async def mint_download_ticket(
     requested_ttl = attrs.get("ttl-seconds", download_tickets.DEFAULT_TTL_SECONDS)
     try:
         requested_ttl = int(requested_ttl)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         requested_ttl = download_tickets.DEFAULT_TTL_SECONDS
 
     ticket = download_tickets.mint_ticket(

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -457,7 +457,7 @@ def _summarize_cost_file(path: str) -> tuple[str | None, float | None, float | N
             float(total["min"]) if total.get("min") is not None else None,
             float(total["max"]) if total.get("max") is not None else None,
         )
-    except OSError, ValueError, KeyError, TypeError:
+    except (OSError, ValueError, KeyError, TypeError):
         return None
 
 
@@ -1035,7 +1035,7 @@ async def post_onboarding_query_results(
     session = await _get_onboarding_session_for_run(run_id, db)
     try:
         payload = await request.json()
-    except ValueError, UnicodeDecodeError:
+    except (ValueError, UnicodeDecodeError):
         raise HTTPException(status_code=422, detail="body must be JSON") from None
     if not isinstance(payload, dict):
         raise HTTPException(status_code=422, detail="body must be a JSON object")

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -327,7 +327,7 @@ def _parse_plan_expiry(value) -> int | None:
         return None
     try:
         seconds = int(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         raise HTTPException(
             status_code=422, detail="plan-expiry-seconds must be an integer"
         ) from None
@@ -1410,7 +1410,7 @@ async def _runner_state_read_allowed(
         return False
     try:
         run_uuid = uuid.UUID(user.run_id)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return False
     row = (await db.execute(select(Run.workspace_id).where(Run.id == run_uuid))).first()
     if row is None:
@@ -2576,7 +2576,7 @@ async def lock_workspace(
     try:
         raw = await request.body()
         lock_info = json_mod.loads(raw) if raw else {}
-    except json_mod.JSONDecodeError, ValueError:
+    except (json_mod.JSONDecodeError, ValueError):
         lock_info = {}
 
     lock_id = lock_info.get("ID", f"lock-{user.email}")

--- a/services/terrapod/api/routers/workspace_extensions.py
+++ b/services/terrapod/api/routers/workspace_extensions.py
@@ -477,7 +477,7 @@ async def post_architecture_critique_message(
         attrs = body["data"]["attributes"]
         content = str(attrs["content"] or "").strip()
         locale = str(attrs["locale"]) if attrs.get("locale") else None
-    except KeyError, TypeError, ValueError:
+    except (KeyError, TypeError, ValueError):
         raise HTTPException(status_code=400, detail="malformed body") from None
     if not content:
         raise HTTPException(status_code=422, detail="content is required")

--- a/services/terrapod/auth/ca.py
+++ b/services/terrapod/auth/ca.py
@@ -21,7 +21,7 @@ from terrapod.logging_config import get_logger
 logger = get_logger(__name__)
 
 # Module-level CA singleton, initialized in lifespan
-_ca: CertificateAuthority | None = None
+_ca: "CertificateAuthority | None" = None
 
 
 class CertificateAuthority:
@@ -53,7 +53,7 @@ class CertificateAuthority:
         cls,
         common_name: str = "Terrapod Certificate Authority",
         validity_days: int = 3650,
-    ) -> CertificateAuthority:
+    ) -> "CertificateAuthority":
         """Generate a new CA certificate and Ed25519 key pair."""
         private_key = ed25519.Ed25519PrivateKey.generate()
         public_key = private_key.public_key()
@@ -109,7 +109,7 @@ class CertificateAuthority:
         return cls(ca_cert=cert, ca_key=private_key)
 
     @classmethod
-    def load(cls, cert_pem: bytes, key_pem: bytes) -> CertificateAuthority:
+    def load(cls, cert_pem: bytes, key_pem: bytes) -> "CertificateAuthority":
         """Load CA from PEM-encoded certificate and key."""
         cert = x509.load_pem_x509_certificate(cert_pem)
         key = serialization.load_pem_private_key(key_pem, password=None)

--- a/services/terrapod/auth/connectors/oidc.py
+++ b/services/terrapod/auth/connectors/oidc.py
@@ -198,7 +198,7 @@ class OIDCConnector(SSOConnector):
         if id_token_exp is not None:
             try:
                 id_token_expires_at = datetime.fromtimestamp(int(id_token_exp), tz=UTC)
-            except ValueError, TypeError, OSError:
+            except (ValueError, TypeError, OSError):
                 logger.warning(
                     "Failed to parse id_token exp claim", provider=self.name, exp=id_token_exp
                 )

--- a/services/terrapod/auth/download_tickets.py
+++ b/services/terrapod/auth/download_tickets.py
@@ -130,7 +130,7 @@ def verify_ticket(ticket: str) -> TicketPayload | None:
     try:
         ttl = int(ttl_str)
         ts = int(ts_str)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
 
     expires_at = ts + ttl
@@ -144,7 +144,7 @@ def verify_ticket(ticket: str) -> TicketPayload | None:
 
     try:
         email = _b64decode(email_b64)
-    except ValueError, UnicodeDecodeError:
+    except (ValueError, UnicodeDecodeError):
         # Bogus email blob — the HMAC said it was authentic, but the
         # encoding is junk. Treat as a malformed ticket.
         return None

--- a/services/terrapod/auth/passwords.py
+++ b/services/terrapod/auth/passwords.py
@@ -95,7 +95,7 @@ def _verify_password_sync(password: str, password_hash: str) -> bool:
         computed_hash = hash_bytes.hex()
 
         return secrets.compare_digest(computed_hash, stored_hash)
-    except ValueError, IndexError:
+    except (ValueError, IndexError):
         return False
 
 

--- a/services/terrapod/auth/runner_tokens.py
+++ b/services/terrapod/auth/runner_tokens.py
@@ -61,7 +61,7 @@ def verify_runner_token(token: str) -> str | None:
     try:
         ttl = int(ttl_str)
         ts = int(ts_str)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
 
     # Check expiry

--- a/services/terrapod/auth/sessions.py
+++ b/services/terrapod/auth/sessions.py
@@ -166,7 +166,7 @@ def _should_refresh_session(session: Session) -> bool:
     try:
         last_active = datetime.fromisoformat(session.last_active_at)
         return (now_utc() - last_active).total_seconds() > SESSION_REFRESH_INTERVAL
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return True  # If we can't parse, refresh to be safe
 
 

--- a/services/terrapod/cli/preflight.py
+++ b/services/terrapod/cli/preflight.py
@@ -46,15 +46,15 @@ class _Check:
         self.ok: bool | None = None
         self.detail = ""
 
-    def passed(self, detail: str) -> _Check:
+    def passed(self, detail: str) -> "_Check":
         self.ok, self.detail = True, detail
         return self
 
-    def failed(self, detail: str) -> _Check:
+    def failed(self, detail: str) -> "_Check":
         self.ok, self.detail = False, detail
         return self
 
-    def skipped(self, detail: str) -> _Check:
+    def skipped(self, detail: str) -> "_Check":
         self.ok, self.detail = None, detail
         return self
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -2020,7 +2020,7 @@ class HAConfig(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _auto_needs_a_probe_url(self) -> HAConfig:
+    def _auto_needs_a_probe_url(self) -> "HAConfig":
         # `auto` with nowhere to probe is incoherent, not a state to fail
         # passive into — catching it here beats going silently inert.
         if self.role == "auto" and not (self.probe_url.internal or self.probe_url.external):
@@ -2034,7 +2034,7 @@ class HAConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _replication_needs_a_peer(self) -> HAConfig:
+    def _replication_needs_a_peer(self) -> "HAConfig":
         # Enabled-but-unreachable would look configured while replicating
         # nothing, and the operator would find out at promotion.
         if self.replication.enabled:
@@ -2703,7 +2703,7 @@ class RedisConfig(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _require_iam_fields(self) -> RedisConfig:
+    def _require_iam_fields(self) -> "RedisConfig":
         """Fail fast on misconfigured IAM auth instead of an opaque connect error."""
         if self.auth_mode in ("aws_iam", "gcp_iam", "azure_ad") and not self.username:
             raise ValueError(f"redis.username is required for auth_mode={self.auth_mode!r}")

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -242,7 +242,9 @@ class AgentPool(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    tokens: Mapped[list[AgentPoolToken]] = relationship(back_populates="pool", passive_deletes=True)
+    tokens: Mapped[list["AgentPoolToken"]] = relationship(
+        back_populates="pool", passive_deletes=True
+    )
 
 
 class AgentPoolToken(Base):
@@ -321,7 +323,7 @@ class Workspace(Base):
     # keys: deleting a pool detaches it from every workspace by CASCADE, with no
     # application-side sweeping to forget. Resolve via
     # `pool_set.workspace_pool_ids()` rather than walking the links by hand.
-    agent_pool_links: Mapped[list[WorkspaceAgentPool]] = relationship(
+    agent_pool_links: Mapped[list["WorkspaceAgentPool"]] = relationship(
         cascade="all, delete-orphan",
         lazy="selectin",
         order_by="WorkspaceAgentPool.ordinal",
@@ -353,7 +355,7 @@ class Workspace(Base):
         ForeignKey("vcs_connections.id", ondelete="SET NULL"),
         nullable=True,
     )
-    vcs_connection: Mapped[VCSConnection | None] = relationship(
+    vcs_connection: Mapped["VCSConnection | None"] = relationship(
         "VCSConnection", foreign_keys=[vcs_connection_id], lazy="joined"
     )
     vcs_repo_url: Mapped[str] = mapped_column(String(500), nullable=False, default="")
@@ -549,13 +551,15 @@ class Workspace(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    state_versions: Mapped[list[StateVersion]] = relationship(
+    state_versions: Mapped[list["StateVersion"]] = relationship(
         back_populates="workspace", cascade="all, delete-orphan"
     )
-    variables: Mapped[list[Variable]] = relationship(
+    variables: Mapped[list["Variable"]] = relationship(
         back_populates="workspace", cascade="all, delete-orphan"
     )
-    runs: Mapped[list[Run]] = relationship(back_populates="workspace", cascade="all, delete-orphan")
+    runs: Mapped[list["Run"]] = relationship(
+        back_populates="workspace", cascade="all, delete-orphan"
+    )
 
     __table_args__ = (sa.UniqueConstraint("name", name="uq_workspaces"),)
 
@@ -648,10 +652,10 @@ class RegistryModule(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    versions: Mapped[list[RegistryModuleVersion]] = relationship(
+    versions: Mapped[list["RegistryModuleVersion"]] = relationship(
         back_populates="module", cascade="all, delete-orphan"
     )
-    workspace_links: Mapped[list[ModuleWorkspaceLink]] = relationship(
+    workspace_links: Mapped[list["ModuleWorkspaceLink"]] = relationship(
         back_populates="module", cascade="all, delete-orphan"
     )
 
@@ -843,7 +847,7 @@ class RegistryProvider(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    versions: Mapped[list[RegistryProviderVersion]] = relationship(
+    versions: Mapped[list["RegistryProviderVersion"]] = relationship(
         back_populates="provider", cascade="all, delete-orphan"
     )
 
@@ -913,7 +917,7 @@ class RegistryProviderVersion(Base):
     )
 
     provider: Mapped[RegistryProvider] = relationship(back_populates="versions")
-    platforms: Mapped[list[RegistryProviderPlatform]] = relationship(
+    platforms: Mapped[list["RegistryProviderPlatform"]] = relationship(
         back_populates="version", cascade="all, delete-orphan"
     )
     gpg_key: Mapped[GPGKey | None] = relationship()
@@ -987,7 +991,7 @@ class RegistryCollection(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    versions: Mapped[list[RegistryCollectionVersion]] = relationship(
+    versions: Mapped[list["RegistryCollectionVersion"]] = relationship(
         back_populates="collection", cascade="all, delete-orphan"
     )
 
@@ -1507,10 +1511,10 @@ class VariableSet(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    variables: Mapped[list[VariableSetVariable]] = relationship(
+    variables: Mapped[list["VariableSetVariable"]] = relationship(
         back_populates="variable_set", cascade="all, delete-orphan"
     )
-    workspace_assignments: Mapped[list[VariableSetWorkspace]] = relationship(
+    workspace_assignments: Mapped[list["VariableSetWorkspace"]] = relationship(
         cascade="all, delete-orphan"
     )
 
@@ -1658,7 +1662,7 @@ class ExecutionHook(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    workspace_assignments: Mapped[list[ExecutionHookWorkspace]] = relationship(
+    workspace_assignments: Mapped[list["ExecutionHookWorkspace"]] = relationship(
         cascade="all, delete-orphan"
     )
 
@@ -2197,7 +2201,7 @@ class TaskStage(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    results: Mapped[list[TaskStageResult]] = relationship(
+    results: Mapped[list["TaskStageResult"]] = relationship(
         back_populates="task_stage", cascade="all, delete-orphan"
     )
 
@@ -2316,7 +2320,7 @@ class PolicySet(Base):
         DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
-    policies: Mapped[list[Policy]] = relationship(
+    policies: Mapped[list["Policy"]] = relationship(
         back_populates="policy_set", cascade="all, delete-orphan"
     )
 

--- a/services/terrapod/runner/exec_subprocess.py
+++ b/services/terrapod/runner/exec_subprocess.py
@@ -169,7 +169,7 @@ def run(
                 try:
                     sys.stdout.buffer.write(chunk)
                     sys.stdout.buffer.flush()
-                except BrokenPipeError, OSError:
+                except (BrokenPipeError, OSError):
                     pass
     finally:
         if log_fh is not None:

--- a/services/terrapod/runner/job_entrypoint.py
+++ b/services/terrapod/runner/job_entrypoint.py
@@ -96,7 +96,7 @@ def _configure_stdio() -> None:
     for stream in (sys.stdout, sys.stderr):
         try:
             stream.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
-        except AttributeError, OSError:
+        except (AttributeError, OSError):
             # Wrapped (e.g. pytest capture) — best-effort only.
             pass
 
@@ -107,7 +107,7 @@ def _flush_stdio() -> None:
     for stream in (sys.stdout, sys.stderr):
         try:
             stream.flush()
-        except BrokenPipeError, OSError, ValueError:
+        except (BrokenPipeError, OSError, ValueError):
             pass
 
 
@@ -145,7 +145,7 @@ def _install_signal_logger() -> None:
     for s in (signal.SIGTERM, signal.SIGQUIT):
         try:
             signal.signal(s, _handle)
-        except ValueError, OSError:
+        except (ValueError, OSError):
             pass
 
 

--- a/services/terrapod/runner/phases/backend_backstop.py
+++ b/services/terrapod/runner/phases/backend_backstop.py
@@ -34,7 +34,7 @@ def verify_local_backend(strip_dir: Path) -> str:
         with state_path.open() as f:
             data = json.load(f)
         backend_type = data.get("backend", {}).get("type") or "MISSING"
-    except FileNotFoundError, OSError, json.JSONDecodeError:
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
         backend_type = "MISSING"
 
     if backend_type != "local":

--- a/services/terrapod/runner/phases/log_capture.py
+++ b/services/terrapod/runner/phases/log_capture.py
@@ -74,12 +74,12 @@ class LogCapture:
             # block buffer if PYTHONUNBUFFERED isn't set in the env.
             try:
                 sys.stdout.flush()
-            except BrokenPipeError, OSError, ValueError:
+            except (BrokenPipeError, OSError, ValueError):
                 pass
             try:
                 self._fh.write(s.encode("utf-8", errors="replace"))  # type: ignore[union-attr]
                 self._fh.flush()  # type: ignore[union-attr]
-            except OSError, AttributeError:
+            except (OSError, AttributeError):
                 pass
             return n
 
@@ -87,12 +87,12 @@ class LogCapture:
             n = self._orig_stderr_write(s)
             try:
                 sys.stderr.flush()
-            except BrokenPipeError, OSError, ValueError:
+            except (BrokenPipeError, OSError, ValueError):
                 pass
             try:
                 self._fh.write(s.encode("utf-8", errors="replace"))  # type: ignore[union-attr]
                 self._fh.flush()  # type: ignore[union-attr]
-            except OSError, AttributeError:
+            except (OSError, AttributeError):
                 pass
             return n
 

--- a/services/terrapod/runner/phases/opa.py
+++ b/services/terrapod/runner/phases/opa.py
@@ -85,7 +85,7 @@ def _extract_deny_warn(opa_output: str) -> tuple[list[str], list[str]]:
     """
     try:
         parsed = json.loads(opa_output)
-    except json.JSONDecodeError, TypeError:
+    except (json.JSONDecodeError, TypeError):
         return [], []
     results = parsed.get("result") or []
     if not results:

--- a/services/terrapod/runner/phases/platform_tool.py
+++ b/services/terrapod/runner/phases/platform_tool.py
@@ -114,7 +114,7 @@ def fetch_versions(cfg: RunnerConfig, *, client: httpx.Client | None = None) -> 
                 f"(HTTP {resp.status_code})"
             )
         attrs = (resp.json().get("data") or {}).get("attributes") or {}
-    except PlatformToolError, PlatformToolsUnsupported:
+    except (PlatformToolError, PlatformToolsUnsupported):
         raise
     except Exception as exc:  # noqa: BLE001 — network/JSON, all equally fatal here
         raise PlatformToolError(f"could not read the pinned platform-tool versions: {exc}") from exc

--- a/services/terrapod/runner/phases/resource_profile.py
+++ b/services/terrapod/runner/phases/resource_profile.py
@@ -25,7 +25,7 @@ logger = structlog.get_logger("runner.resource_profile")
 def _read_int(path: Path) -> int | None:
     try:
         return int(path.read_text().strip())
-    except FileNotFoundError, OSError, ValueError:
+    except (FileNotFoundError, OSError, ValueError):
         return None
 
 
@@ -33,13 +33,13 @@ def _read_cpu_usage_usec(stat_path: Path) -> int | None:
     """Parse `usage_usec` from /sys/fs/cgroup/cpu.stat."""
     try:
         text = stat_path.read_text()
-    except FileNotFoundError, OSError:
+    except (FileNotFoundError, OSError):
         return None
     for line in text.splitlines():
         if line.startswith("usage_usec "):
             try:
                 return int(line.split(maxsplit=1)[1])
-            except IndexError, ValueError:
+            except (IndexError, ValueError):
                 return None
     return None
 

--- a/services/terrapod/runner/phases/tf_args.py
+++ b/services/terrapod/runner/phases/tf_args.py
@@ -48,6 +48,6 @@ def init_supports_var_file(binary: str) -> bool:
             text=True,
             timeout=10,
         )
-    except FileNotFoundError, subprocess.TimeoutExpired:
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
     return "-var-file" in (result.stdout + result.stderr)

--- a/services/terrapod/services/architecture_critic_service.py
+++ b/services/terrapod/services/architecture_critic_service.py
@@ -353,7 +353,7 @@ async def _load_state_compact(sv: StateVersion) -> tuple[list[dict], list[dict],
 
     try:
         return await asyncio.to_thread(_parse, data)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         logger.warning("architecture critic: state parse failed", state_version_id=str(sv.id))
         return None
 
@@ -662,7 +662,7 @@ async def handle_architecture_critique(payload: dict) -> None:
         # prefix, so strip it first — otherwise a normal ws-… regenerate
         # would silently no-op here.
         workspace_id = uuid.UUID(str(payload["workspace_id"]).removeprefix("ws-"))
-    except KeyError, ValueError:
+    except (KeyError, ValueError):
         logger.warning("invalid architecture_critique payload", payload=payload)
         return
     await generate_critique(workspace_id, force=bool(payload.get("force")))

--- a/services/terrapod/services/catalog_service.py
+++ b/services/terrapod/services/catalog_service.py
@@ -112,7 +112,7 @@ def _coerce_default(raw: object) -> object:
     if isinstance(raw, str):
         try:
             return json.loads(raw)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return raw
     return raw
 

--- a/services/terrapod/services/cost/fleet_resolver.py
+++ b/services/terrapod/services/cost/fleet_resolver.py
@@ -98,7 +98,7 @@ def _as_count(v: Any, default: float = 1.0) -> float:
     try:
         n = float(v)
         return n if n >= 0 else default
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return default
 
 

--- a/services/terrapod/services/cost/pricer.py
+++ b/services/terrapod/services/cost/pricer.py
@@ -270,7 +270,7 @@ def _apply_size_tier(entry: Entry, products: list[Product], resource_ms: MatchSe
         return products
     try:
         size = float(found[1])
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return products
     candidates: list[tuple[float, Product]] = []
     for p in products:
@@ -279,7 +279,7 @@ def _apply_size_tier(entry: Entry, products: list[Product], resource_ms: MatchSe
             continue
         try:
             cap = float(tm[1])
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             continue
         if cap >= size:
             candidates.append((cap, p))
@@ -364,7 +364,7 @@ def _cost_band(
 
     try:
         return (_at(int(lo)), _at(int(ty)), _at(int(hi)))
-    except ResourceMissingAttr, AssertionError:
+    except (ResourceMissingAttr, AssertionError):
         return None
 
 
@@ -401,7 +401,7 @@ def _count_factor(entry: Entry, resource_ms: MatchSet) -> float:
         # count of 0 means the component contributes nothing. Absent/unparseable
         # still fall back to ``default`` above.
         return max(0.0, float(raw) / divisor)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return default
 
 
@@ -464,7 +464,7 @@ def price(
             entry = entry_by_key[key]
             try:
                 group_pps = _quote_group(resource_ms, entry, group_products)
-            except ResourceMissingAttr, AssertionError:
+            except (ResourceMissingAttr, AssertionError):
                 # Pathological product/usage combo — treat this resource as
                 # unpriced rather than crashing the whole estimate.
                 continue

--- a/services/terrapod/services/cost/pricesheet_db.py
+++ b/services/terrapod/services/cost/pricesheet_db.py
@@ -241,7 +241,7 @@ class PricesheetIndex:
                     price=_parse_price_type(price_type, float(price)),
                     ccy=ccy,
                 )
-            except EmptyMatchSet, ValueError:
+            except (EmptyMatchSet, ValueError):
                 continue
 
     def close(self) -> None:

--- a/services/terrapod/services/cost_summariser.py
+++ b/services/terrapod/services/cost_summariser.py
@@ -209,7 +209,7 @@ async def handle_ai_cost_summary(payload: dict) -> None:
 
     try:
         run_id = uuid.UUID(payload["run_id"])
-    except KeyError, ValueError:
+    except (KeyError, ValueError):
         logger.warning("Invalid ai_cost_summary payload", payload=payload)
         return
 

--- a/services/terrapod/services/git_auth_service.py
+++ b/services/terrapod/services/git_auth_service.py
@@ -52,7 +52,7 @@ async def resolve_git_auth(db: AsyncSession, resolved: list) -> list[dict]:
             continue
         try:
             cred = json.loads(v.value)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             logger.warning("git-auth variable has a non-JSON value; skipping", key=v.key)
             continue
 

--- a/services/terrapod/services/onboarding_ai_service.py
+++ b/services/terrapod/services/onboarding_ai_service.py
@@ -230,7 +230,7 @@ async def handle_onboarding_polish(payload: dict) -> None:
 
     try:
         session_id = uuid.UUID(payload["session_id"])
-    except KeyError, ValueError:
+    except (KeyError, ValueError):
         logger.warning("invalid onboarding_polish payload", payload=payload)
         return
 

--- a/services/terrapod/services/onboarding_service.py
+++ b/services/terrapod/services/onboarding_service.py
@@ -89,7 +89,7 @@ async def get_cached_surface(
         return None
     try:
         return json.loads(raw)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
 
 

--- a/services/terrapod/services/plan_summary.py
+++ b/services/terrapod/services/plan_summary.py
@@ -36,7 +36,7 @@ def summarize_plan_json(body: bytes) -> dict[str, int] | None:
     """
     try:
         data = json.loads(body)
-    except ValueError, json.JSONDecodeError:
+    except (ValueError, json.JSONDecodeError):
         return None
     if not isinstance(data, dict):
         return None

--- a/services/terrapod/services/pool_set.py
+++ b/services/terrapod/services/pool_set.py
@@ -36,7 +36,7 @@ def _coerce(value: Any) -> uuid.UUID | None:
         return value
     try:
         return uuid.UUID(str(value).removeprefix("apool-"))
-    except ValueError, AttributeError:
+    except (ValueError, AttributeError):
         return None
 
 

--- a/services/terrapod/services/registry_module_service.py
+++ b/services/terrapod/services/registry_module_service.py
@@ -286,7 +286,7 @@ async def get_module_download_url(
 
         try:
             run = await db.get(Run, uuid.UUID(run_id))
-        except ValueError, AttributeError:
+        except (ValueError, AttributeError):
             run = None
         if run and run.module_overrides:
             coord = f"{namespace}/{name}/{provider}"

--- a/services/terrapod/services/replication.py
+++ b/services/terrapod/services/replication.py
@@ -152,7 +152,7 @@ def decode_entity_id(spec: ReplicatedClass, entity_id: str) -> list[str] | None:
     try:
         padded = entity_id + "=" * (-len(entity_id) % 4)
         parts = json.loads(base64.urlsafe_b64decode(padded.encode()))
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
     if not isinstance(parts, list) or len(parts) != len(spec.pk_attrs):
         return None

--- a/services/terrapod/services/run_task_service.py
+++ b/services/terrapod/services/run_task_service.py
@@ -70,7 +70,7 @@ def verify_callback_token(token: str) -> uuid.UUID | None:
     try:
         result_id = uuid.UUID(result_id_str)
         ts = int(ts_str)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
 
     # Check expiry

--- a/services/terrapod/services/state_graph_service.py
+++ b/services/terrapod/services/state_graph_service.py
@@ -270,7 +270,7 @@ async def derive_state_graph(
 
     try:
         graph = await asyncio.to_thread(_parse_and_build, data)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         logger.warning("state_graph_parse_failed", state_version_id=str(target.id))
         return _empty(sv_meta)
 

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -159,7 +159,7 @@ def _fit_plan_json(data: bytes, max_bytes: int) -> str:
         return data.decode("utf-8", errors="replace")
     try:
         plan = json.loads(data)
-    except json.JSONDecodeError, ValueError:
+    except (json.JSONDecodeError, ValueError):
         return data[:max_bytes].decode("utf-8", errors="replace") + "\n[... truncated ...]"
     if not isinstance(plan, dict):
         return data[:max_bytes].decode("utf-8", errors="replace") + "\n[... truncated ...]"
@@ -1325,7 +1325,7 @@ async def _summarise_one(payload: dict, _slack: dict) -> None:
 
     try:
         run_id = uuid.UUID(payload["run_id"])
-    except KeyError, ValueError:
+    except (KeyError, ValueError):
         logger.warning("Invalid ai_plan_summary payload", payload=payload)
         return
 

--- a/services/terrapod/services/summary_translation.py
+++ b/services/terrapod/services/summary_translation.py
@@ -307,7 +307,7 @@ async def translate_summary(
 
     try:
         payload = json.loads(cached)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
 
     tf = payload.get("factors", [])
@@ -382,7 +382,7 @@ async def translate_cost_summary(
 
     try:
         payload = json.loads(cached)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
 
     te = payload.get("estimated", [])
@@ -484,7 +484,7 @@ async def translate_architecture_critique(
 
     try:
         payload = json.loads(cached)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return None
 
     out_arch = dict(arch)

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -1020,7 +1020,7 @@ async def _poll_workspace(
     ws: Workspace,
     cache: VCSArchiveCache | None = None,
     meta: VCSMetadataCache | None = None,
-    paths_unions: PathsUnionMap | None = None,
+    paths_unions: "PathsUnionMap | None" = None,
 ) -> None:
     """Poll a single workspace: check branch for pushes and PRs for speculative plans.
 
@@ -1148,7 +1148,7 @@ async def _poll_workspace_owned(
     semaphore: asyncio.Semaphore,
     cache: VCSArchiveCache | None = None,
     meta: VCSMetadataCache | None = None,
-    paths_unions: PathsUnionMap | None = None,
+    paths_unions: "PathsUnionMap | None" = None,
 ) -> None:
     """Poll a single workspace in its own DB session, bounded by a semaphore.
 

--- a/services/terrapod/services/vcs_rate_limit.py
+++ b/services/terrapod/services/vcs_rate_limit.py
@@ -636,7 +636,7 @@ async def get_consumption(connection_id: object, snapshot: object | None) -> Con
         for v in values or []:
             try:
                 calls += int(v)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 continue
     except Exception:
         return None

--- a/services/tests/services/test_registry_collection_service.py
+++ b/services/tests/services/test_registry_collection_service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import io
 import json
+import pathlib
 import tarfile
 
 import pytest
@@ -155,7 +156,7 @@ class TestTheDigestDescribesWhatWasStored:
 
         path = _archive(tmp_path, manifest=_info())
         sha, size = collections._digest_and_size(path)
-        raw = open(path, "rb").read()
+        raw = pathlib.Path(path).read_bytes()
         assert sha == hashlib.sha256(raw).hexdigest()
         assert size == len(raw)
 


### PR DESCRIPTION
Nine code-scanning alerts were open. **None affected a released version** — seven were in tooling added this session, and two were false positives from syntax that exists only on `main`. So this is main-only, as agreed.

Also declines Dependabot #1497 with the reason recorded.

## `scripts/` excluded, like `e2e` and `ai_eval` before it

Six alerts were in the protocol-capture scripts — a throwaway stub's return style, and a subprocess call in a script whose entire job is to run a real client. **No Dockerfile COPYs `scripts/`**, so none of it ships or is reachable by anyone but whoever runs it.

The cost that matters isn't the alerts themselves, it's that they crowd out product findings: a security surface people learn to scroll past has stopped working.

**Semgrep still scans the directory** (`.semgrepignore` excludes only `ai_eval`), so this narrows one tool's noise rather than leaving the code unanalysed.

## One real fix

A test read a file without closing it → `read_bytes()`.

## ruff's `target-version` back to `py313`, for a *new* reason

The two remaining alerts were `py/uninitialized-local-variable` at **error** severity on `api/dependencies.py` — the authentication path. Both false: CodeQL cannot parse PEP 758's `except A, B:`, reads the Python 2 meaning where the second name is a binding target, and reports a local it believes was invented. #1461 introduced that syntax by moving ruff to `py314`.

The alternative was excluding the rule in `codeql-config.yml`. That's worse — it catches genuine use-before-assignment across all product code, and disabling it repo-wide to work around a parser gap trades a real safety net for a syntax preference.

**This is not the backport argument** that was made and rejected when the floor moved. That one didn't survive scrutiny: release branches carry their own config, and a cherry-pick is gated by their own CI. This is about the scanner, which is new information. **The interpreter floor stays at 3.14** — only what ruff is willing to *emit* moves.

Reverting needed both halves by hand, since ruff removes but never restores: **28 forward references re-quoted, 58 except clauses re-parenthesised.**

Four of the re-quotes were unions — `Mapped["X" | None]` is a `TypeError` at import, where the original quoted the whole annotation. Caught by building the app, not by the suite, which is why that check ran before the tests.

Verified: the tree parses under 3.13 again (0 files fail), mappers configure, `Settings` builds, all **388 routes** assemble, suite unchanged at **5314 passed**.

## python-hcl2 held below 8 (#1497 closed)

Its CI failure was real. python-hcl2 8.x changes the *shape* of what it parses, reproduced against 8.1.3:

```
v7:  {"variable": [{"name":     {"description": "a name"}}]}
v8:  {"variable": [{"\"name\"": {"description": "\"a name\"", "__is_block__": true}}]}
```

Module interface extraction reads that structure directly, so every `TestExtractModuleInterface` case fails — the parser tests doing their job.

Widening to `>=7,<9` doesn't *take* v8 today but permits it, and there's no Python lockfile to hold it back on the next fresh resolve. Held version-scoped beside the existing fastapi/starlette holds, so 7.x patches still arrive. Supporting v8 is work rather than a wall, if a reason appears.
