### PR TITLE
fix: unblock the npm Dependabot updater

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -50,7 +50,6 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "postcss": "^8.5.23",
     "@babel/core": "^7.29.6",
     "brace-expansion": "^2.1.4",
     "sharp": "^0.35.3",


### PR DESCRIPTION
Dependabot has been failing on **every** npm run:

```
postcss | dependency_file_not_resolvable
        | Override for postcss@8.5.26 conflicts with direct dependency
```

`postcss` was listed twice in `web/package.json` — once as a direct devDependency and once in `overrides`, at the same range. npm rejects that combination, so the entire npm update job errored and **no npm updates were proposed at all**.

## Why this is worth fixing now rather than filing

The updater is how a Next.js advisory reaches us. Today's critical unauthenticated RCE (GHSA-2xp9-vwfh-vxw4, CVSS 9.5) arrived through exactly that channel — which means it arrived *despite* this, and the next one might not. An updater that cannot run is a security notification that does not arrive.

## The override was doing nothing

`postcss` resolves **once** in the lockfile, and the direct dependency already pins it. Removing the override leaves the lockfile **byte-identical** — still 8.5.23, still zero advisories — and the web image builds.

It was dead weight that happened to be load-bearing for the failure. The diff is one deleted line.

The other six overrides are untouched: each forces a transitive resolution where there is no direct dependency to do it, which is what an override is for.
