### PR TITLE
chore: quieten the remaining alerts in the capture scripts

### DIFF
--- a/scripts/goproxy-capture.py
+++ b/scripts/goproxy-capture.py
@@ -82,15 +82,20 @@ class Handler(BaseHTTPRequestHandler):
         path = self.path
 
         if path.endswith("/@v/list"):
-            return self._send(STATE["list"], "text/plain")
+            self._send(STATE["list"], "text/plain")
+            return
         if path.endswith("/@latest"):
-            return self._send(STATE["info"], "application/json")
+            self._send(STATE["info"], "application/json")
+            return
         if path.endswith(f"/@v/{VERSION}.info"):
-            return self._send(STATE["info"], "application/json")
+            self._send(STATE["info"], "application/json")
+            return
         if path.endswith(f"/@v/{VERSION}.mod"):
-            return self._send(STATE["mod"], "text/plain")
+            self._send(STATE["mod"], "text/plain")
+            return
         if path.endswith(f"/@v/{VERSION}.zip"):
-            return self._send(STATE["zip"], "application/zip")
+            self._send(STATE["zip"], "application/zip")
+            return
 
         self.send_response(404)
         self.send_header("Content-Length", "0")

--- a/scripts/nuget-capture.py
+++ b/scripts/nuget-capture.py
@@ -97,11 +97,14 @@ class Handler(BaseHTTPRequestHandler):
                     {"@id": f"{BASE}/flat/", "@type": "PackageBaseAddress/3.0.0"}
                 ],
             }
-            return send(json.dumps(index).encode(), "application/json")
+            send(json.dumps(index).encode(), "application/json")
+            return
         if path == f"{PREFIX}/flat/{lower}/index.json":
-            return send(json.dumps({"versions": [VER]}).encode(), "application/json")
+            send(json.dumps({"versions": [VER]}).encode(), "application/json")
+            return
         if path == f"{PREFIX}/flat/{lower}/{VER}/{lower}.{VER}.nupkg":
-            return send(NUPKG, "application/octet-stream")
+            send(NUPKG, "application/octet-stream")
+            return
 
         self.send_response(404)
         self.send_header("Content-Length", "0")

--- a/scripts/pulumi-capture.py
+++ b/scripts/pulumi-capture.py
@@ -112,6 +112,13 @@ def main() -> int:
         "PULUMI_SKIP_UPDATE_CHECK": "true",
     }
 
+    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
+    # The "taint" is the developer's own environment, and the argv[0] they chose
+    # when running this by hand. That is the whole point: this drives the real
+    # pulumi binary on the machine of whoever is capturing the protocol. It is
+    # not reachable by anyone else, ships in no image, and the alternative —
+    # excluding scripts/ from semgrep as well as CodeQL — would leave the
+    # directory with no static analysis at all.
     proc = subprocess.run(
         [pulumi, "plugin", "install", "resource", "random", "4.16.3"],
         env=env,
@@ -130,7 +137,9 @@ def main() -> int:
             print(f"  ! {line}")
     shutil.rmtree(work, ignore_errors=True)
 
-    print("\nCompare against docs/pulumi-cli-surface.md; update it if the client has moved.")
+    print(
+        "\nCompare against docs/pulumi-cli-surface.md; update it if the client has moved."
+    )
     return 0 if LOG else 1
 
 


### PR DESCRIPTION
chore: quieten the remaining alerts in the capture scripts

Six alerts survived #1503, all in scripts/. The CodeQL five close through the
paths-ignore that PR added; these are the two things that needed a code change
rather than a config one.

**The semgrep one is suppressed in place, not excluded.** It flags
`subprocess.run` with an env derived from os.environ in pulumi-capture.py. The
"taint" is the developer's own environment and the argv[0] they chose when
running it by hand — which is the entire point of a script whose job is to drive
the real pulumi binary. Adding scripts/ to .semgrepignore would have silenced it
too, and left the directory with no static analysis at all now that CodeQL skips
it. A targeted `# nosemgrep` naming the rule keeps everything else covered, and
matches how the repo already handles avoid-sqlalchemy-text and
unverified-jwt-decode.

**The style ones are just fixed.** `return send(...)` used a procedure's return
value and mixed bare returns with value returns in the same handler; the calls
now happen for effect with an explicit bare return. Both captures were re-run
and still reproduce: the Go walk is three requests under the prefix, NuGet's is
the service index, the versions document and the nupkg.