### PR TITLE
fix(1509): keep the botocore session alive alongside the ElastiCache signer

### DIFF
--- a/services/terrapod/redis/iam_auth.py
+++ b/services/terrapod/redis/iam_auth.py
@@ -49,7 +49,12 @@ _AZURE_REDIS_SCOPE = "https://redis.azure.com/.default"
 # race a shared credential object (google-auth Credentials.refresh mutates in
 # place and is not thread-safe).
 _lock = threading.Lock()
-_aws_signers: dict[str, object] = {}
+#: Per-region ``(session, signer)``. Both halves are required: see
+#: ``_aws_signer`` for why the session must outlive the call that built it. They
+#: are stored as one entry so the coupling is structural — holding the session
+#: in a second dict would leave a mapping nothing ever reads, which is an
+#: invitation to delete it and silently reintroduce #1509.
+_aws_signers: dict[str, tuple[object, object]] = {}
 _gcp_state: dict[str, object] = {}
 _azure_state: dict[str, object] = {}
 
@@ -76,11 +81,23 @@ def strip_url_credentials(redis_url: str) -> str:
 def _aws_signer(region: str):
     # The RequestSigner holds the session's *refreshable* credentials object
     # (botocore freezes them at sign time via get_frozen_credentials), so the
-    # cached per-region signer auto-renews across IRSA credential rotation — do
-    # NOT "fix" this by rebuilding the signer each call.
+    # cached per-region signer auto-renews across credential rotation — do NOT
+    # "fix" this by rebuilding the signer each call.
+    #
+    # The session must be cached alongside it (#1509). RequestSigner keeps the
+    # event emitter as a `weakref.proxy`, and the session is what holds the
+    # emitter strongly — so a session left to go out of scope here is freed, and
+    # every subsequent signing raises
+    # `ReferenceError: weakly-referenced object no longer exists`.
+    #
+    # It is freed by the *cyclic* collector rather than by refcounting, because
+    # a botocore Session contains reference cycles. That is precisely why the
+    # symptom read as intermittent: the session outlives this function, the
+    # first connection signs fine, and auth only dies once a collection happens
+    # to run.
     key = region or "default"
-    signer = _aws_signers.get(key)
-    if signer is None:
+    cached = _aws_signers.get(key)
+    if cached is None:
         import botocore.session
         from botocore.model import ServiceId
         from botocore.signers import RequestSigner
@@ -94,8 +111,9 @@ def _aws_signer(region: str):
             session.get_credentials(),
             session.get_component("event_emitter"),
         )
-        _aws_signers[key] = signer
-    return signer
+        cached = (session, signer)
+        _aws_signers[key] = cached
+    return cached[1]
 
 
 def mint_aws_elasticache_token(*, cache_name: str, user: str, region: str) -> str:

--- a/services/tests/test_redis_iam_auth.py
+++ b/services/tests/test_redis_iam_auth.py
@@ -11,6 +11,7 @@ static auth string.
 from __future__ import annotations
 
 import asyncio
+import gc
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -76,6 +77,106 @@ def test_mint_aws_elasticache_token_signs_and_strips_scheme(monkeypatch):
     assert args.kwargs["operation_name"] == "connect"
     assert "Action=connect" in args.args[0]["url"]
     assert "User=terrapod" in args.args[0]["url"]
+
+
+def _fake_aws_env(monkeypatch):
+    """Isolate the two AWS tests below that build a **real** botocore signer.
+
+    Signing is local arithmetic — nothing here reaches AWS, and the credentials
+    are never validated — but botocore still needs *some* credentials to sign
+    with. Every ambient source is cleared so the result does not depend on
+    whether the machine running the tests happens to have AWS config: with a key
+    and secret in the environment botocore's ``EnvProvider`` wins its resolution
+    chain outright, so it never consults the filesystem, ECS or IMDS.
+    """
+    for var in (
+        "AWS_PROFILE",
+        "AWS_DEFAULT_PROFILE",
+        "AWS_SESSION_TOKEN",
+        "AWS_SECURITY_TOKEN",
+        # Left set, botocore's EnvProvider hands back RefreshableCredentials
+        # whose refresher re-reads this same stale value, and signing dies with
+        # "credentials are still expired". `aws configure export-credentials`
+        # emits it, so a developer can easily have one exported.
+        "AWS_CREDENTIAL_EXPIRATION",
+        "AWS_CONFIG_FILE",
+        "AWS_SHARED_CREDENTIALS_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setattr(iam_auth, "_aws_signers", {})  # isolate the module cache
+
+
+def test_the_signer_is_cached_per_region(monkeypatch):
+    """The cache itself is load-bearing, and was otherwise unguarded (#1509).
+
+    `_aws_signer` states twice that the signer must not be rebuilt per call, but
+    nothing tested it: removing the cache outright left every other test in this
+    file green, because a signer used inside the call that built it never
+    outlives its session. That the session is *retained* is proved by
+    ``test_aws_token_still_mints_after_the_session_could_be_collected`` — an
+    assertion here that the cached session is still reachable would be vacuous,
+    since the cache holds it strongly for the whole test either way.
+    """
+    _fake_aws_env(monkeypatch)
+
+    # Cached, not rebuilt per connection: a Redis reconnect must not pay for a
+    # fresh botocore session, and the retained signer is what carries
+    # refreshable credentials across rotation.
+    assert iam_auth._aws_signer("us-east-1") is iam_auth._aws_signer("us-east-1")
+    # Keyed by region, so two regions do not share one signer.
+    assert iam_auth._aws_signer("us-east-1") is not iam_auth._aws_signer("eu-west-1")
+
+
+def test_aws_token_mints_when_the_region_is_left_unset(monkeypatch):
+    """`redis.aws_iam_region: ""` is a supported (and reported) configuration.
+
+    It takes the other branch of `_aws_signer` — the region comes from the
+    session's own config and the cache key becomes "default" — so it is the
+    branch a deployment that omits the setting actually runs.
+    """
+    _fake_aws_env(monkeypatch)
+
+    token = iam_auth.mint_aws_elasticache_token(cache_name="my-cache", user="terrapod", region="")
+
+    assert token.startswith("my-cache/?")
+    assert "X-Amz-Signature=" in token
+    assert set(iam_auth._aws_signers) == {"default"}
+
+
+def test_aws_token_still_mints_after_the_session_could_be_collected(monkeypatch):
+    """The signer must outlive the botocore session that built it (#1509).
+
+    This is the one AWS test that builds a **real** ``RequestSigner`` rather
+    than mocking ``_aws_signer``. That mocking is why the bug shipped: every
+    other test replaces the very construction that was wrong.
+
+    ``RequestSigner`` keeps the event emitter as a ``weakref.proxy`` and the
+    session is what holds it strongly, so a session dropped on return is
+    collected and later signing raises ``ReferenceError``. In production the
+    first connection succeeded (it beat the collector) and everything after it
+    failed, which read as an intermittent auth fault.
+
+    The explicit ``gc.collect()`` is load-bearing: without it this passes
+    against the broken code too, because the session simply hadn't been
+    collected yet.
+    """
+    _fake_aws_env(monkeypatch)
+
+    first = iam_auth.mint_aws_elasticache_token(
+        cache_name="my-cache", user="terrapod", region="us-east-1"
+    )
+    assert "X-Amz-Signature=" in first
+
+    gc.collect()
+
+    second = iam_auth.mint_aws_elasticache_token(
+        cache_name="my-cache", user="terrapod", region="us-east-1"
+    )
+    assert second.startswith("my-cache/?")
+    assert "X-Amz-Signature=" in second
 
 
 # ── credential provider dispatch ──────────────────────────────────────


### PR DESCRIPTION
Forward-port of the fix released as **v1.6.2** and **v1.5.7**, cherry-picked
with `-x` from `release/v1.6` (`feaf0b23`) where it originated.

With `redis.auth_mode: aws_iam` the API authenticated on its first connection
and failed on every one after it, leaving the pod permanently unready. The
cached botocore `RequestSigner` outlived the session that produced it:
`RequestSigner` keeps the event emitter as a `weakref.proxy`, and the session is
what holds that emitter strongly. Once the session was freed — by the *cyclic*
collector, since a botocore `Session` contains reference cycles — every
subsequent mint raised `ReferenceError`. The first connection beat the
collector, which is why a deterministic lifetime bug presented as an
intermittent auth fault.

`Authentication required.` in the health check was downstream noise: minting
raised, the credential provider yielded nothing, and redis-py opened a
connection with no AUTH at all.

The session is now cached *with* the signer as a tuple. A parallel dict nothing
reads is an invitation to delete it and silently reintroduce this.

## Tests

Three, all building **real** botocore signers — mocking `_aws_signer` is what
let this through, since it replaces the one thing that was wrong. Each mutation
is caught by exactly one:

| mutation | fails |
|---|---|
| session dropped from the cache entry | the collection test |
| cache removed entirely | the caching test |

The `gc.collect()` is load-bearing — without it the collection test passes
against the broken code. The caching invariant was previously unguarded:
removing the cache outright left the whole file green.

The third covers `aws_iam_region: ""`, the other branch of `_aws_signer` and the
configuration this was reported from.

All three clear every ambient AWS variable, `AWS_CREDENTIAL_EXPIRATION`
included — left set, botocore hands back refreshable credentials that refresh to
the same stale value, which is green in CI and red on a developer machine with
an exported SSO session.

## Scope

Only the AWS path. `mint_gcp_access_token` and `mint_azure_redis_token` cache
credential objects the same way but hold them strongly; neither `google-auth`
nor `azure-identity` uses `weakref` at all. `db/iam_auth.py` caches a botocore
*client*, which owns its emitter strongly and survives collection. This is the
only bare `RequestSigner` in the tree.

Two adjacent findings from the release review were deliberately left out of the
patches and are tracked in #1510: the global mint lock is held across a call
that can perform a blocking credential refresh, and a credential-less session is
cached permanently.

Closes #1509
