### PR TITLE
fix(1510): scope the Redis IAM mint locks to what each SDK requires

### DIFF
--- a/services/terrapod/redis/iam_auth.py
+++ b/services/terrapod/redis/iam_auth.py
@@ -33,11 +33,16 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import structlog
 
 from redis.credentials import CredentialProvider
+
+if TYPE_CHECKING:  # imported lazily at runtime — the cloud SDKs are optional
+    from botocore.session import Session
+    from botocore.signers import RequestSigner
 
 logger = structlog.get_logger(__name__)
 
@@ -45,16 +50,36 @@ _TOKEN_TTL_SECONDS = 900  # ElastiCache presigned-token validity (15 min)
 _GCP_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 _AZURE_REDIS_SCOPE = "https://redis.azure.com/.default"
 
-# One lock serialises every token mint/refresh so concurrent (re)connects can't
-# race a shared credential object (google-auth Credentials.refresh mutates in
-# place and is not thread-safe).
-_lock = threading.Lock()
+# One lock per cloud, and each covers only what its SDK actually requires
+# (#1510). This was a single global lock held across the whole mint, which meant
+# every concurrent (re)connect serialised behind whichever call happened to be
+# refreshing credentials — a refresh that, for a workload identity, is a
+# blocking STS or IMDS round trip under botocore's retry policy. Since each mint
+# runs on an `asyncio.to_thread` worker, a reconnect storm could tie up the
+# loop's shared executor waiting on one refresh.
+#
+# What each SDK needs was checked rather than assumed:
+#   AWS   — botocore's RefreshableCredentials takes its own `_refresh_lock` in
+#           `get_frozen_credentials`, so signing is already thread-safe and
+#           needs no lock from us. Ours now covers the cache only.
+#   GCP   — google-auth has no internal lock and `refresh()` mutates the
+#           credentials in place, so the refresh must stay inside the lock.
+#   Azure — azure-identity's GetTokenMixin has no internal lock either, so
+#           `get_token` stays inside the lock too.
+#
+# Only one auth_mode is ever active in a deployment, so splitting them is not
+# about cross-cloud contention; it is so each cloud's locking says what that
+# cloud requires, instead of all three inheriting a rule that describes GCP.
+_aws_lock = threading.Lock()
+_gcp_lock = threading.Lock()
+_azure_lock = threading.Lock()
+
 #: Per-region ``(session, signer)``. Both halves are required: see
 #: ``_aws_signer`` for why the session must outlive the call that built it. They
 #: are stored as one entry so the coupling is structural — holding the session
 #: in a second dict would leave a mapping nothing ever reads, which is an
 #: invitation to delete it and silently reintroduce #1509.
-_aws_signers: dict[str, tuple[object, object]] = {}
+_aws_signers: dict[str, tuple[Session, RequestSigner]] = {}
 _gcp_state: dict[str, object] = {}
 _azure_state: dict[str, object] = {}
 
@@ -78,7 +103,7 @@ def strip_url_credentials(redis_url: str) -> str:
 # ── AWS ElastiCache IAM ───────────────────────────────────────────────
 
 
-def _aws_signer(region: str):
+def _aws_signer(region: str) -> RequestSigner:
     # The RequestSigner holds the session's *refreshable* credentials object
     # (botocore freezes them at sign time via get_frozen_credentials), so the
     # cached per-region signer auto-renews across credential rotation — do NOT
@@ -96,39 +121,58 @@ def _aws_signer(region: str):
     # first connection signs fine, and auth only dies once a collection happens
     # to run.
     key = region or "default"
-    cached = _aws_signers.get(key)
-    if cached is None:
-        import botocore.session
-        from botocore.model import ServiceId
-        from botocore.signers import RequestSigner
+    # The lock covers the cache, not the signing (#1510). Building the session
+    # resolves the credential chain, which can itself do I/O, so it is
+    # serialised — once per region — rather than raced by every connection.
+    with _aws_lock:
+        cached = _aws_signers.get(key)
+        if cached is None:
+            import botocore.session
+            from botocore.exceptions import NoCredentialsError
+            from botocore.model import ServiceId
+            from botocore.signers import RequestSigner
 
-        session = botocore.session.get_session()
-        signer = RequestSigner(
-            ServiceId("elasticache"),
-            region or session.get_config_variable("region"),
-            "elasticache",
-            "v4",
-            session.get_credentials(),
-            session.get_component("event_emitter"),
-        )
-        cached = (session, signer)
-        _aws_signers[key] = cached
-    return cached[1]
+            session = botocore.session.get_session()
+            credentials = session.get_credentials()
+            if credentials is None:
+                # The chain yielded nothing. botocore returns None here rather
+                # than raising, so caching this entry would poison the cache for
+                # the life of the process: every later mint would fail with
+                # NoCredentialsError even once credentials became available.
+                # Fail now instead, and leave the cache empty so a later attempt
+                # can succeed. (A provider that *raises* never reached the store
+                # anyway; only the silent-empty-chain case could poison it.)
+                raise NoCredentialsError()
+
+            signer = RequestSigner(
+                ServiceId("elasticache"),
+                region or session.get_config_variable("region"),
+                "elasticache",
+                "v4",
+                credentials,
+                session.get_component("event_emitter"),
+            )
+            cached = (session, signer)
+            _aws_signers[key] = cached
+        return cached[1]
 
 
 def mint_aws_elasticache_token(*, cache_name: str, user: str, region: str) -> str:
     """SigV4-presigned ElastiCache ``connect`` token (local signing, no I/O)."""
-    with _lock:
-        signer = _aws_signer(region)
-        url = f"https://{cache_name}/?{urlencode({'Action': 'connect', 'User': user})}"
-        signed = signer.generate_presigned_url(  # type: ignore[attr-defined]
-            {"method": "GET", "url": url, "body": {}, "headers": {}, "context": {}},
-            operation_name="connect",
-            expires_in=_TOKEN_TTL_SECONDS,
-            region_name=region or None,
-        )
-        # The IAM auth token is the presigned URL without the scheme.
-        return signed.removeprefix("https://")
+    # Deliberately outside any lock of ours (#1510): botocore's
+    # RefreshableCredentials guards its own refresh, so concurrent mints do not
+    # need to queue behind one another — and if a refresh is needed, botocore
+    # coordinates it without stalling every other connection.
+    signer = _aws_signer(region)
+    url = f"https://{cache_name}/?{urlencode({'Action': 'connect', 'User': user})}"
+    signed = signer.generate_presigned_url(
+        {"method": "GET", "url": url, "body": {}, "headers": {}, "context": {}},
+        operation_name="connect",
+        expires_in=_TOKEN_TTL_SECONDS,
+        region_name=region or None,
+    )
+    # The IAM auth token is the presigned URL without the scheme.
+    return signed.removeprefix("https://")
 
 
 # ── GCP Memorystore IAM ───────────────────────────────────────────────
@@ -139,7 +183,10 @@ def mint_gcp_access_token() -> str:
     import google.auth
     import google.auth.transport.requests
 
-    with _lock:
+    # The refresh stays inside the lock: google-auth has no internal locking and
+    # `refresh()` mutates the credentials in place, so concurrent refreshes of
+    # one shared object would race (#1510).
+    with _gcp_lock:
         creds = _gcp_state.get("creds")
         if creds is None:
             creds, _ = google.auth.default(scopes=[_GCP_SCOPE])
@@ -155,7 +202,10 @@ def mint_gcp_access_token() -> str:
 
 def mint_azure_redis_token() -> str:
     """Microsoft Entra access token for Azure Cache for Redis."""
-    with _lock:
+    # `get_token` stays inside the lock: azure-identity's GetTokenMixin carries
+    # no internal locking, so its cached-token refresh is not guaranteed safe
+    # under concurrent callers (#1510).
+    with _azure_lock:
         cred = _azure_state.get("cred")
         if cred is None:
             from azure.identity import DefaultAzureCredential

--- a/services/tests/test_redis_iam_auth.py
+++ b/services/tests/test_redis_iam_auth.py
@@ -179,6 +179,115 @@ def test_aws_token_still_mints_after_the_session_could_be_collected(monkeypatch)
     assert "X-Amz-Signature=" in second
 
 
+class TestMintLocking:
+    """Each cloud's lock covers exactly what its SDK requires (#1510).
+
+    These assert on `Lock.locked()` observed from inside the call being made,
+    which is the only way to distinguish "the lock is held across this" from
+    "the lock is held somewhere in this function" — and that distinction is the
+    whole point of the change.
+    """
+
+    def test_aws_signing_does_not_hold_a_lock(self, monkeypatch):
+        """The reported hazard: signing can trigger a blocking STS/IMDS refresh.
+
+        Held under a lock, one such refresh stalls every other concurrent mint —
+        each of which occupies an `asyncio.to_thread` worker. botocore's
+        RefreshableCredentials guards its own refresh, so ours is not needed
+        here and its absence is what stops a reconnect storm queueing up.
+        """
+        observed = {}
+
+        class _Probe:
+            def generate_presigned_url(self, *_a, **_kw):
+                observed["aws_locked"] = iam_auth._aws_lock.locked()
+                return "https://my-cache/?X-Amz-Signature=abc"
+
+        monkeypatch.setattr(iam_auth, "_aws_signer", lambda _region: _Probe())
+
+        iam_auth.mint_aws_elasticache_token(cache_name="my-cache", user="u", region="r")
+
+        assert observed["aws_locked"] is False
+
+    def test_aws_cache_construction_does_hold_the_lock(self, monkeypatch):
+        """Building the session resolves the credential chain, which can do I/O.
+
+        That part must still be serialised, or every connection in a storm
+        builds its own session.
+        """
+        _fake_aws_env(monkeypatch)
+        observed = {}
+        real = __import__("botocore.session", fromlist=["get_session"]).get_session
+
+        def _watched():
+            observed["locked_while_building"] = iam_auth._aws_lock.locked()
+            return real()
+
+        monkeypatch.setattr("botocore.session.get_session", _watched)
+        iam_auth._aws_signer("us-east-1")
+
+        assert observed["locked_while_building"] is True
+
+    def test_gcp_refresh_holds_its_own_lock(self, monkeypatch):
+        """google-auth has no internal lock and refresh() mutates in place."""
+        observed = {}
+
+        class _Creds:
+            valid = False
+            token = "GCP"
+
+            def refresh(self, _request):
+                observed["gcp_locked"] = iam_auth._gcp_lock.locked()
+                observed["aws_lock_free"] = not iam_auth._aws_lock.locked()
+
+        monkeypatch.setattr(iam_auth, "_gcp_state", {"creds": _Creds(), "request": object()})
+
+        assert iam_auth.mint_gcp_access_token() == "GCP"
+        assert observed["gcp_locked"] is True
+        # And it does not take a lock another cloud's mints depend on.
+        assert observed["aws_lock_free"] is True
+
+    def test_the_three_locks_are_distinct(self):
+        locks = {id(iam_auth._aws_lock), id(iam_auth._gcp_lock), id(iam_auth._azure_lock)}
+        assert len(locks) == 3
+
+
+def test_a_session_without_credentials_is_not_cached(monkeypatch):
+    """botocore returns None rather than raising when the chain yields nothing.
+
+    Cached, that entry would fail every future mint for the life of the process
+    — including after credentials became available — and report
+    `NoCredentialsError`, which names the symptom rather than the cause.
+    """
+    from botocore.exceptions import NoCredentialsError
+
+    _fake_aws_env(monkeypatch)
+
+    class _Empty:
+        def get_credentials(self):
+            return None
+
+        def get_config_variable(self, _name):
+            return "us-east-1"
+
+        def get_component(self, _name):
+            raise AssertionError("must fail before building the signer")
+
+    monkeypatch.setattr("botocore.session.get_session", _Empty)
+
+    with pytest.raises(NoCredentialsError):
+        iam_auth._aws_signer("us-east-1")
+
+    # The cache is left clean, so a later attempt can still succeed.
+    assert iam_auth._aws_signers == {}
+
+    monkeypatch.undo()
+    _fake_aws_env(monkeypatch)
+    assert "X-Amz-Signature=" in iam_auth.mint_aws_elasticache_token(
+        cache_name="my-cache", user="terrapod", region="us-east-1"
+    )
+
+
 # ── credential provider dispatch ──────────────────────────────────────
 
 


### PR DESCRIPTION
The two findings the #1509 release review turned up, held back from the
v1.6.2/v1.5.7 patches because both change behaviour and a patch on a line people
are running should not.

## The mint lock no longer spans a blocking credential refresh

One global lock covered every mint, across all three clouds, for the whole call.
Signing can trigger a blocking STS or IMDS refresh for a workload identity, so a
single refresh stalled every other concurrent mint — each of which occupies an
`asyncio.to_thread` worker. A Redis reconnect storm could tie up the loop's
shared executor behind one refresh.

**What each SDK needs was read from its source, not assumed — and they differ.**
This is the part that mattered: a uniform "release the lock" change would have
introduced a real race in two of the three paths.

| | requirement | so |
|---|---|---|
| **AWS** | `RefreshableCredentials.get_frozen_credentials` takes botocore's own `_refresh_lock` | signing needs no lock from us; ours now covers the cache only |
| **GCP** | google-auth has no internal lock, `refresh()` mutates in place | the refresh stays **inside** the lock |
| **Azure** | azure-identity's `GetTokenMixin` has no internal lock | `get_token` stays **inside** the lock |

Building the AWS session still holds the lock — it resolves the credential
chain, which can do I/O, and that should happen once per region rather than be
raced by every connection.

The lock is now one per cloud. Only one `auth_mode` is ever active, so this is
not about cross-cloud contention; it is so each cloud's locking states what that
cloud requires, rather than all three inheriting a rule whose stated
justification ("google-auth mutates in place") describes exactly one of them.

## A credential-less session is no longer cached

`session.get_credentials()` returns `None` rather than raising when the chain
yields nothing. Cached, that entry poisoned the signer cache for the life of the
process — every later mint failed with `NoCredentialsError` even after
credentials became available, naming the symptom rather than the cause. It now
raises before the entry is stored, so the cache stays clean and a later attempt
can succeed.

Also types `_aws_signers` and `_aws_signer`'s return, via a `TYPE_CHECKING`
import since the cloud SDKs are imported lazily.

## Tests

Four new, each pinned by mutation:

| mutation | fails |
|---|---|
| signing moved back inside the AWS lock | `test_aws_signing_does_not_hold_a_lock` |
| credential-less guard removed | `test_a_session_without_credentials_is_not_cached` |
| locks collapsed back to one shared lock | GCP lock test + distinctness test |

They assert on `Lock.locked()` observed from *inside* the call being made —
the only way to distinguish "held across this" from "held somewhere in this
function", which is the entire change.

`make test`: 5322 passed.

Closes #1510
