### PR TITLE
fix: bind the pulumi-capture semgrep suppression to the line it matches

### DIFF
--- a/scripts/pulumi-capture.py
+++ b/scripts/pulumi-capture.py
@@ -112,15 +112,26 @@ def main() -> int:
         "PULUMI_SKIP_UPDATE_CHECK": "true",
     }
 
-    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
     # The "taint" is the developer's own environment, and the argv[0] they chose
     # when running this by hand. That is the whole point: this drives the real
     # pulumi binary on the machine of whoever is capturing the protocol. It is
     # not reachable by anyone else, ships in no image, and the alternative —
     # excluding scripts/ from semgrep as well as CodeQL — would leave the
     # directory with no static analysis at all.
+    #
+    # The rule suppressed here is
+    # python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.
+    #
+    # Placement is fiddly and was got wrong twice, so: the rule matches the
+    # tainted *argument list*, not the statement, and semgrep binds `nosemgrep`
+    # only to the matched line. A comment above the statement, or on the
+    # `subprocess.run(` line, therefore suppresses nothing — both were tried and
+    # both silently left the alert open. It must sit on the argument line, and
+    # it is the bare form because spelling the rule id out there makes the line
+    # long enough that the formatter explodes the list, which moves the match
+    # off the comment and breaks the binding again.
     proc = subprocess.run(
-        [pulumi, "plugin", "install", "resource", "random", "4.16.3"],
+        [pulumi, "plugin", "install", "resource", "random", "4.16.3"],  # nosemgrep
         env=env,
         capture_output=True,
         text=True,


### PR DESCRIPTION
[Code-scanning alert 425](https://github.com/mattrobinsonsre/terrapod/security/code-scanning/425)
has stayed open since #1507, which added a `nosemgrep` for this exact rule and
did not work. The comment was present on `main` the whole time; it simply
suppressed nothing, and the alert's most recent instance was current `main`.

**Why it didn't bind.** Semgrep binds `nosemgrep` to the **matched** line, and
this rule matches the tainted *argument list*, not the statement. Two placements
were tried against the real scanner before this one, and both silently left the
alert open:

| placement | result |
|---|---|
| above the statement, with the explanation in between | still fires |
| trailing comment on the `subprocess.run(` line | still fires |
| trailing comment on the **argument** line | suppressed |

The behaviour was established empirically with a set of minimal variants rather
than inferred, because guessing had already cost two rounds.

**Why the bare form.** Spelling the rule id out on the argument line makes it
long enough that `ruff format` explodes the list across several lines — which
moves the match away from the comment and breaks the binding again. The specific
form is self-defeating in exactly this position, so the rule is named in the
comment above instead.

**Verification** — by running the scanner, not by inspection: one
`dangerous-subprocess-use-tainted-env-args` finding before, zero after, and
`ruff format` leaves the result unchanged so the binding is stable against a
future format pass.

The suppression is unchanged in substance: a developer-only capture script whose
"taint" is the operator's own environment and the pulumi path they passed by
hand, reachable by nobody else and shipped in no image. Excluding `scripts/` from
semgrep as well as CodeQL would leave the directory with no static analysis at
all, which is why this is a targeted suppression rather than a path exclusion.
