### PR TITLE
docs(1501,1502): the two Pulumi spikes, run rather than read

### DIFF
--- a/docs/pulumi-cli-surface.md
+++ b/docs/pulumi-cli-surface.md
@@ -1,8 +1,14 @@
-# The plugin surface the Pulumi CLI consumes
+# The surfaces the Pulumi CLI consumes
 
 The Pulumi-side counterpart to [`galaxy-cli-surface.md`](galaxy-cli-surface.md)
-and [`tfe-cli-surface.md`](tfe-cli-surface.md): what the `pulumi` CLI asks a
-plugin download server for, and nothing else.
+and [`tfe-cli-surface.md`](tfe-cli-surface.md). Two surfaces, captured
+separately:
+
+1. **the plugin download surface** — what the CLI asks a plugin server for
+   (below);
+2. **the service surface** — what it asks a *state backend* for once you
+   `pulumi login <https-url>`, which is the analogue of Terraform's `cloud {}`
+   block. That is [its own section](#the-service-surface).
 
 Captured from a real client rather than read from documentation
 (`scripts/pulumi-capture.py`), for the reason the Galaxy work established —
@@ -109,3 +115,126 @@ python3 scripts/pulumi-capture.py [path-to-pulumi]
 
 Set `PULUMI_HOME` to a fresh directory when testing by hand, or an
 already-installed plugin makes the capture look shorter than it is.
+
+---
+
+# The service surface
+
+What `pulumi` asks a state backend for after `pulumi login <https-url>` — the
+analogue of Terraform's `cloud {}` block, and the surface #1407 §2 scopes to
+"only the slice the CLI consumes".
+
+Captured with `scripts/pulumi-service-capture.py` against **pulumi v3.261.0**,
+by pointing the real CLI at a request-logging stub and answering it until a full
+`up` completed: **106 requests, 19 distinct endpoints**. A stub that 404s teaches
+only that the client gave up, so each response was filled in until the CLI walked
+further — the same method as the four protocol captures before it.
+
+## The endpoints
+
+`{stack}` below is always the triple `{org}/{project}/{stack}`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/user` | login + `whoami`; returns the org list |
+| GET | `/api/user/organizations/{org}` | org lookup; called constantly |
+| GET | `/api/capabilities` | feature negotiation; `{"capabilities": []}` is accepted |
+| GET | `/api/user/stacks?project=` | `stack ls` |
+| POST | `/api/stacks/{org}/{project}` | `stack init` — body `{"stackName", "tags"}` |
+| GET | `/api/stacks/{stack}` | stack lookup; 404 means "does not exist" |
+| DELETE | `/api/stacks/{stack}` | `stack rm` |
+| GET | `/api/stacks/{stack}/export` | **read state** |
+| POST | `/api/stacks/{stack}/import` | **write state wholesale**; gzipped; async |
+| POST | `/api/stacks/{stack}/encrypt` | **encrypt a secret** — body `{"plaintext"}` |
+| POST | `/api/stacks/{stack}/decrypt` | decrypt one |
+| POST | `/api/stacks/{stack}/batch-decrypt` | decrypt many |
+| POST | `/api/stacks/{stack}/preview` | begin a preview |
+| POST | `/api/stacks/{stack}/update` | begin an update |
+| POST | `/api/stacks/{stack}/refresh` | begin a refresh |
+| POST | `/api/stacks/{stack}/destroy` | begin a destroy |
+| POST | `/api/stacks/{stack}/update/{updateID}` | **start** it; must return a lease token |
+| GET | `/api/stacks/{stack}/update/{updateID}` | poll status (used by `stack import`) |
+| PATCH | `/api/stacks/{stack}/update/{updateID}/checkpoint` | **write state**; gzipped |
+| POST | `/api/stacks/{stack}/update/{updateID}/events/batch` | engine events; gzipped |
+| POST | `/api/stacks/{stack}/update/{updateID}/complete` | end it — `{"status":"succeeded"}` |
+| POST | `/api/stacks/{stack}/update/{updateID}/renew_lease` | extend the lease |
+
+**Three of those rows were not exercised by the capture** and are listed from the
+CLI's behaviour rather than observed traffic — treat their shapes as unconfirmed:
+
+* `renew_lease` — the runs were too short to need it, but the CLI holds a lease
+  for the life of an update.
+* `decrypt` and `batch-decrypt` — the captured program had no secret *config* to
+  read back. `encrypt` was called six times during an ordinary `up`, so the
+  provider obligation itself is confirmed; only the read direction is not.
+
+## Findings
+
+**Auth is `token <value>`, and it changes mid-run.** Not `Bearer`. Everything
+addressed at a stack uses `Authorization: token <api-token>` — but the three
+calls made *during* an update (`checkpoint`, `events/batch`, `complete`) use
+`Authorization: update-token <lease>` instead, with the lease handed out when the
+update is started. Two schemes on one surface, and the second is invisible to any
+test that supplies its own authenticated client.
+
+**The service is the stack's secrets provider.** `POST .../encrypt` is not
+optional colour: in `httpstate` mode the CLI delegates secret encryption to the
+backend and calls it during a plain `up`. This is a real obligation that "state
+backend" does not imply — Terrapod would have to run an encrypt/decrypt oracle
+per stack, and own the key that makes stack state readable.
+
+**State is a whole document, not a delta.** It is read with `GET .../export` and
+written with `PATCH .../update/{id}/checkpoint`, each carrying the entire
+deployment. Terrapod's existing state-version storage therefore fits without a
+new merge model. Checkpoint and event bodies are **gzipped**
+(`Content-Encoding: gzip`), so a handler must decompress rather than parse the
+raw body.
+
+**A preview is an update.** `preview` creates an update and then starts it via
+`POST .../update/{updateID}` — the same path an `up` uses. There is no separate
+preview lifecycle, and the start call **must return a lease token**: without one
+the CLI aborts with `fatal: An assertion has failed: persisted actions require a
+token`.
+
+**An update has an explicit begin and end**, so a run that dies mid-update leaves
+the stack with a started-but-never-completed update — which is exactly what the
+lease exists to time out.
+
+**Concurrency is enforced by refusing to start.** There is no lock endpoint. A
+`409` on the begin call ends the CLI immediately — exit 1, no retry, no wait —
+and the service's `message` field is printed verbatim:
+
+```
+error: [0] another update is currently in progress
+```
+
+So Terrapod's existing per-workspace run serialisation maps onto this directly:
+refuse the begin, and put the explanation in `message`.
+
+**An empty stack's deployment is `null`.** `{"version": 3, "deployment": null}`.
+A synthetic empty deployment (`{}`, or a manifest with no resources) fails the
+CLI's snapshot integrity check.
+
+**The surface does not have to sit at the root.** The CLI appends `/api/...` to
+whatever base URL it was given, path prefix included — verified by logging in to
+`http://host/api/terrapod/v1/pulumi` and watching it request
+`/api/terrapod/v1/pulumi/api/user`, then serving it successfully from there. This
+is the question #1484 had to settle for NuGet and it lands the opposite way:
+Terrapod can mount this natively rather than at the root, which it reserves for
+the two surfaces genuinely forced there (`/v2/` and `/.well-known/terraform.json`).
+
+## Nothing from the management surface was required
+
+A full `login → stack init → stack ls → preview → up → refresh → export →
+destroy → stack rm` cycle completed without touching Deployments, Policy Packs,
+Insights, Environments/ESC, Webhooks, Registry or organisation management —
+confirming the §2 scope. `/api/capabilities` returning an empty list is accepted.
+
+## Reproducing the service capture
+
+```sh
+python3 scripts/pulumi-service-capture.py
+```
+
+Requires Docker. Re-run it against a new CLI rather than assuming this still
+holds; that is what the script is for.

--- a/scripts/pulumi-plan-probe.py
+++ b/scripts/pulumi-plan-probe.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Probe what `pulumi up --plan` actually enforces (#1501, part of #1407).
+
+Fifth in the series after the four protocol captures, and for the same reason
+those exist: #1407 §3 rests an entire approval model on the claim that
+`pulumi up --plan` refuses operations outside the saved plan, and that claim was
+carried for a long time as "verified from docs, **not run**".
+
+Running it changed the design. The refusal is real, but it binds *less* than
+`tfplan` does in one specific way, and no amount of reading turns that up:
+
+    the plan constrains WHICH RESOURCES are operated on, with which step kinds,
+    and the DESIRED INPUTS — but NOT the state the update starts from.
+
+A plan saved for `12 -> 20` still applies cleanly after state has moved out of
+band to 31, and produces 20. Terraform refuses a stale plan on a state-serial
+mismatch; Pulumi has no equivalent check, so Terrapod has to supply one.
+
+Everything else held: no `PULUMI_EXPERIMENTAL`, refusal on both create and
+update plans, refusal costs nothing (it is caught in `up`'s preview phase, so
+state is untouched), it fails on a *missing* planned operation as well as an
+extra one, the plan is portable across a pod boundary, and it carries secrets
+encrypted under the stack's secrets provider rather than in the clear.
+
+    python3 scripts/pulumi-plan-probe.py
+
+Requires Docker (for the `pulumi/pulumi-python` image); stdlib only otherwise.
+No cloud credentials: the program uses `pulumi-random` and a local file backend.
+
+Each refusal below is paired with re-applying the SAME plan file against the
+restored program. Without that control a failure only proves plans are broken,
+not that the refusal is doing anything.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+IMAGE = "pulumi/pulumi-python:latest"
+
+PROGRAM = '''\
+"""Two resources, no cloud credentials.
+
+`RandomPassword.result` is a *secret* output, which is what lets this answer
+whether a saved plan carries secrets in the clear.
+"""
+import pulumi
+import pulumi_random as random
+
+length = pulumi.Config().get_int("length") or 8
+
+s = random.RandomString("s", length=length, special=False)
+pw = random.RandomPassword("pw", length=20)
+
+pulumi.export("s", s.result)
+pulumi.export("pw", pw.result)
+'''
+
+PULUMI_YAML = """\
+name: planprobe
+runtime: python
+description: Probe for terrapod #1501
+"""
+
+REQUIREMENTS = "pulumi>=3.0.0\npulumi-random>=4.0.0\n"
+
+#: Driven entirely inside one container so the file-backend state survives
+#: between steps. `pulumi login --local` would put state in the container's
+#: ephemeral HOME rather than the mount, which silently loses the stack.
+SCRIPT = r"""
+set -u
+cd /work/proj
+export PULUMI_HOME=/work/home PULUMI_CONFIG_PASSPHRASE=probe PULUMI_SKIP_UPDATE_CHECK=true
+python -m venv /work/venv >/dev/null 2>&1
+export PATH=/work/venv/bin:$PATH
+/work/venv/bin/pip install -q -r requirements.txt >/dev/null 2>&1
+pulumi login file:///work/state >/dev/null 2>&1
+pulumi stack init dev --non-interactive >/dev/null 2>&1
+
+echo "PULUMI_EXPERIMENTAL=[${PULUMI_EXPERIMENTAL:-<unset>}]  version=$(pulumi version)"
+
+echo "--- 1. preview --save-plan (length=8)"
+pulumi preview --save-plan=/work/plan.json --non-interactive >/dev/null 2>&1
+echo "    exit=$?  plan written=$(test -f /work/plan.json && echo yes || echo no)"
+
+echo "--- 2. mutate to 99, apply the STALE plan  (expect refusal)"
+sed -i 's/or 8$/or 99/' __main__.py
+pulumi up --plan=/work/plan.json --yes --non-interactive >/work/o.txt 2>&1
+echo "    exit=$?"
+grep -o 'violates plan:.*' /work/o.txt | head -1 | sed 's/^/    /'
+grep -qi 'Previewing update' /work/o.txt && echo "    caught in the PREVIEW phase -> nothing was mutated"
+
+echo "--- 3. CONTROL: restore to 8, apply the SAME plan  (expect success)"
+sed -i 's/or 99$/or 8/' __main__.py
+pulumi up --plan=/work/plan.json --yes --non-interactive >/dev/null 2>&1
+echo "    exit=$?"
+
+echo "--- 4. secrets: what does the plan carry?"
+python - <<'PY'
+import json
+d = json.load(open("/work/plan.json"))
+raw = json.dumps(d)
+print("    secret sentinel present:", "4dabf18193072939515e22adb298388d" in raw)
+print("    ciphertext present:     ", "ciphertext" in raw)
+print("    plaintext present:      ", "plaintext" in raw)
+PY
+
+echo "--- 5. state drift: save a plan, change state OUT OF BAND, then apply the plan"
+sed -i 's/or 8$/or 20/' __main__.py
+pulumi preview --save-plan=/work/plan2.json --non-interactive >/dev/null 2>&1
+sed -i 's/or 20$/or 31/' __main__.py
+pulumi up --yes --non-interactive >/dev/null 2>&1          # out of band, no --plan
+sed -i 's/or 31$/or 20/' __main__.py
+pulumi up --plan=/work/plan2.json --yes --non-interactive >/dev/null 2>&1
+echo "    exit=$?   <- 0 means drift does NOT invalidate a saved plan"
+echo "    s is now $(pulumi stack output s | tr -d '\n' | wc -c | tr -d ' ') chars"
+
+echo "--- 6. a planned operation that is no longer needed (expect refusal)"
+sed -i 's/or 20$/or 25/' __main__.py
+pulumi preview --save-plan=/work/plan3.json --non-interactive >/dev/null 2>&1
+pulumi up --yes --non-interactive >/dev/null 2>&1          # out of band, same change
+pulumi up --plan=/work/plan3.json --yes --non-interactive >/work/o3.txt 2>&1
+echo "    exit=$?"
+grep -o 'expected resource operations.*' /work/o3.txt | head -1 | sed 's/^/    /'
+"""
+
+
+def main() -> int:
+    if shutil.which("docker") is None:
+        print("docker is required (for the pulumi image)", file=sys.stderr)
+        return 2
+
+    work = pathlib.Path(tempfile.mkdtemp(prefix="pulumi-plan-probe-"))
+    proj = work / "proj"
+    proj.mkdir()
+    (proj / "Pulumi.yaml").write_text(PULUMI_YAML)
+    (proj / "requirements.txt").write_text(REQUIREMENTS)
+    (proj / "__main__.py").write_text(PROGRAM)
+    (work / "run.sh").write_text(SCRIPT)
+    (work / "state").mkdir()
+
+    # Fixed argv and no inherited environment: nothing here is caller-controlled.
+    proc = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{work}:/work",
+            "-w",
+            "/work",
+            IMAGE,
+            "bash",
+            "/work/run.sh",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    print(proc.stdout)
+    if proc.returncode != 0:
+        for line in proc.stderr.strip().splitlines()[-5:]:
+            print(f"  ! {line}", file=sys.stderr)
+    shutil.rmtree(work, ignore_errors=True)
+
+    print("Compare against the findings in #1501; update #1407 §3 if pulumi has moved.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pulumi-service-capture.py
+++ b/scripts/pulumi-service-capture.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Capture what the Pulumi CLI asks a state backend for (#1502, part of #1407).
+
+Fifth protocol capture, after Galaxy, plugin-download, GOPROXY and NuGet. The
+four before it turned up eleven things the documentation would have had us build
+wrong, several invisible to any synthetic client — which is why a protocol gets
+captured before it is implemented.
+
+Stands up a request-logging stub, points `pulumi login` at it **under a path
+prefix**, and drives a real `login → stack init → stack ls → preview → up →
+refresh → export → destroy → stack rm` cycle to completion. The findings are
+written up in `docs/pulumi-cli-surface.md`.
+
+    python3 scripts/pulumi-service-capture.py
+
+Requires Docker (for the `pulumi/pulumi-python` image); stdlib only otherwise.
+
+**The findings worth keeping in view**, because each cost a round of iteration:
+
+* Auth is `token <value>`, not `Bearer` — and it **changes mid-run**: calls made
+  during an update carry `update-token <lease>` instead.
+* The start call (`POST .../update/{id}`) **must return a lease token** or the
+  CLI panics with "persisted actions require a token".
+* The service is the stack's **secrets provider** — `POST .../encrypt` is called
+  during an ordinary `up`.
+* An empty stack's deployment is `null`. A hand-made empty one fails the CLI's
+  snapshot integrity check.
+* Checkpoint and event bodies arrive **gzipped**.
+* The CLI appends `/api/...` to the base URL it was given, **path prefix
+  included** — so this surface need not be mounted at the root.
+
+**If a run fails with "stack not found" partway through, look for an orphaned
+container before believing it.** Interrupting this script leaves its
+`pulumi/pulumi-python` container running and still pointed at
+`host.containers.internal:8810`, so it talks to the *next* run's stub and mutates
+its state underneath it. `docker ps | grep pulumi` and kill the stray one. That
+cost an hour of chasing a bug that was not in the code.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = 8810
+#: Deliberately not the host root: proving this surface can live under a prefix
+#: is a finding, not an assumption (it is the question #1484 settled for NuGet).
+PREFIX = "/api/terrapod/v1/pulumi"
+ORG = "spike"
+IMAGE = "pulumi/pulumi-python:latest"
+CONTAINER_HOST = "host.containers.internal"
+
+LOG: list[dict] = []
+STACKS: dict[str, dict] = {}
+DEPLOYMENTS: dict[str, object] = {}
+BODY: dict = {}
+
+#: A brand-new stack has a *null* deployment. Anything else — `{}`, or a
+#: manifest with an empty resource list — trips the snapshot integrity check.
+EMPTY_DEPLOYMENT = None
+
+
+def _stack_route(method: str, key: str, tail: str):
+    if tail == "" and method == "GET":
+        if key not in STACKS:
+            return 404, {"message": "stack not found"}
+        return 200, STACKS[key]
+    if tail == "" and method == "DELETE":
+        STACKS.pop(key, None)
+        return 200, {}
+
+    if tail == "export" and method == "GET":
+        return 200, {"version": 3, "deployment": DEPLOYMENTS.get(key, EMPTY_DEPLOYMENT)}
+    if tail == "import" and method == "POST":
+        DEPLOYMENTS[key] = BODY.get("deployment", EMPTY_DEPLOYMENT)
+        return 200, {"updateID": "u-import"}
+
+    # The service is the stack's secrets provider in httpstate mode.
+    if tail == "encrypt":
+        return 200, {
+            "ciphertext": base64.b64encode(
+                b"enc:" + BODY.get("plaintext", "").encode()
+            ).decode()
+        }
+    if tail == "decrypt":
+        raw = base64.b64decode(BODY.get("ciphertext", "")).decode("utf-8", "replace")
+        return 200, {"plaintext": raw.removeprefix("enc:")}
+    if tail == "batch-decrypt":
+        return 200, {
+            "plaintexts": [
+                base64.b64decode(c).decode("utf-8", "replace").removeprefix("enc:")
+                for c in BODY.get("ciphertexts", [])
+            ]
+        }
+
+    if (
+        tail in ("preview", "update", "refresh", "destroy", "import")
+        and method == "POST"
+    ):
+        return 200, {"updateID": "u1", "requiredPolicies": []}
+
+    seg = tail.split("/")
+    if len(seg) >= 2 and seg[0] in (
+        "preview",
+        "update",
+        "refresh",
+        "destroy",
+        "import",
+    ):
+        rest = "/".join(seg[2:])
+        if rest == "" and method == "POST":
+            # Starting the update hands back the LEASE TOKEN. Omit it and the
+            # CLI panics: "persisted actions require a token".
+            return 200, {"token": "lease-token-1"}
+        if rest == "" and method == "GET":
+            return 200, {"status": "succeeded"}
+        if rest == "renew_lease":
+            return 200, {"token": "lease-token-1"}
+        if rest in (
+            "checkpoint",
+            "checkpointverbatim",
+            "complete",
+            "events",
+            "events/batch",
+        ):
+            return 200, {}
+        if rest == "status":
+            return 200, {"status": "succeeded"}
+    return None
+
+
+def _routes(path: str, method: str):
+    p = path.split("?")[0]
+    if PREFIX and p.startswith(PREFIX):
+        p = p[len(PREFIX) :] or "/"
+
+    if p == "/api/user":
+        return 200, {
+            "id": "spike-user",
+            "githubLogin": "spike-user",
+            "name": "Spike User",
+            "email": "spike@example.invalid",
+            "organizations": [
+                {"githubLogin": ORG, "name": ORG, "avatarUrl": "", "defaultRepo": ""}
+            ],
+            "identities": ["spike-user"],
+            "siteAdmin": False,
+        }
+    if p == "/api/capabilities":
+        return 200, {"capabilities": []}
+    if p.startswith("/api/user/organizations/"):
+        return 200, {
+            "githubLogin": ORG,
+            "name": ORG,
+            "avatarUrl": "",
+            "defaultRepo": "",
+        }
+    if p == "/api/user/stacks":
+        return 200, {"stacks": list(STACKS.values())}
+
+    parts = [x for x in p.split("/") if x]
+    if len(parts) >= 3 and parts[0] == "api" and parts[1] == "stacks":
+        if method == "POST" and len(parts) == 4:
+            name = BODY.get("stackName", "dev")
+            STACKS[f"{parts[2]}/{parts[3]}/{name}"] = {
+                "orgName": parts[2],
+                "projectName": parts[3],
+                "stackName": name,
+                "currentOperation": None,
+                "tags": BODY.get("tags", {}),
+                "version": 1,
+            }
+            return 200, {}
+        if len(parts) >= 5:
+            key = "/".join(parts[2:5])
+            return _stack_route(method, key, "/".join(parts[5:]))
+    return None
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _reply(self) -> None:
+        global BODY
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n) if n else b""
+        LOG.append(
+            {
+                "method": self.command,
+                "path": self.path,
+                "auth": self.headers.get("Authorization", ""),
+                "cenc": self.headers.get("Content-Encoding", ""),
+                "len": n,
+            }
+        )
+        try:
+            BODY = json.loads(raw) if raw else {}
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # Checkpoint and event bodies arrive gzipped, so they are not JSON
+            # here — and do not need to be. The path and headers are the capture.
+            BODY = {}
+        status, payload = _routes(self.path, self.command) or (
+            404,
+            {"message": "not found"},
+        )
+        blob = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(blob)))
+        self.end_headers()
+        self.wfile.write(blob)
+
+    do_GET = do_POST = do_PATCH = do_PUT = do_DELETE = _reply
+
+    def log_message(self, *_a: object) -> None:
+        return
+
+
+SCRIPT = r"""
+set -u
+cd /work/proj
+export PULUMI_HOME=/work/home PULUMI_SKIP_UPDATE_CHECK=true
+export PULUMI_ACCESS_TOKEN=pul-spiketoken
+python -m venv /work/venv >/dev/null 2>&1
+export PATH=/work/venv/bin:$PATH
+/work/venv/bin/pip install -q pulumi pulumi-random >/dev/null 2>&1
+for c in "login $BACKEND" "whoami" "stack init spike/proj/dev" "stack ls" \
+         "preview" "up --yes" "refresh --yes"; do
+  echo "=== pulumi $c ==="
+  pulumi $c --non-interactive 2>&1 | tail -3
+done
+
+# export/import need a file, so they sit outside the loop. `stack import` is
+# asynchronous: it returns an updateID and the CLI then polls
+# GET .../update/{id} until it reports a terminal status.
+echo "=== pulumi stack export ==="
+pulumi stack export > /tmp/deployment.json 2>/dev/null && head -c 60 /tmp/deployment.json && echo
+echo "=== pulumi stack import ==="
+pulumi stack import --file /tmp/deployment.json 2>&1 | tail -2
+
+for c in "destroy --yes" "stack rm dev --yes"; do
+  echo "=== pulumi $c ==="
+  pulumi $c --non-interactive 2>&1 | tail -3
+done
+"""
+
+PROGRAM = (
+    "import pulumi\n"
+    "import pulumi_random as random\n"
+    's = random.RandomString("s", length=8, special=False)\n'
+    'pulumi.export("s", s.result)\n'
+)
+
+
+def _normalise(path: str) -> str:
+    p = path.split("?")[0]
+    if PREFIX and p.startswith(PREFIX):
+        p = p[len(PREFIX) :]
+    p = re.sub(r"/api/stacks/[^/]+/[^/]+/[^/]+", "/api/stacks/{stack}", p)
+    p = re.sub(r"/(update|preview|refresh|destroy|import)/[^/]+", r"/\1/{updateID}", p)
+    return re.sub(r"/api/user/organizations/[^/]+", "/api/user/organizations/{org}", p)
+
+
+def main() -> int:
+    if shutil.which("docker") is None:
+        print("docker is required (for the pulumi image)", file=sys.stderr)
+        return 2
+
+    srv = HTTPServer(("0.0.0.0", PORT), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    time.sleep(0.3)
+
+    work = pathlib.Path(tempfile.mkdtemp(prefix="pulumi-svc-capture-"))
+    proj = work / "proj"
+    proj.mkdir()
+    (proj / "Pulumi.yaml").write_text(
+        "name: proj\nruntime: python\ndescription: capture\n"
+    )
+    (proj / "__main__.py").write_text(PROGRAM)
+    (work / "run.sh").write_text(SCRIPT)
+
+    proc = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-e",
+            f"BACKEND=http://{CONTAINER_HOST}:{PORT}{PREFIX}",
+            "-v",
+            f"{work}:/work",
+            "-w",
+            "/work",
+            IMAGE,
+            "bash",
+            "/work/run.sh",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    srv.shutdown()
+    print(proc.stdout)
+
+    seen: dict[tuple[str, str], dict] = {}
+    for e in LOG:
+        d = seen.setdefault(
+            (e["method"], _normalise(e["path"])), {"n": 0, "auth": set(), "enc": set()}
+        )
+        d["n"] += 1
+        if e["auth"]:
+            d["auth"].add(e["auth"].split()[0])
+        if e["cenc"]:
+            d["enc"].add(e["cenc"])
+
+    print(f"=== {len(LOG)} requests, {len(seen)} distinct endpoints ===")
+    for (method, path), d in seen.items():
+        auth = "/".join(sorted(d["auth"])) or "-"
+        enc = ",".join(sorted(d["enc"])) or "-"
+        print(f"  {method:6s} {path:56s} x{d['n']:<3} auth={auth:13s} enc={enc}")
+
+    shutil.rmtree(work, ignore_errors=True)
+    print(
+        f"\nEvery path sits under {PREFIX}: this surface need not be at the host root."
+    )
+    print("Compare against docs/pulumi-cli-surface.md; update it if the CLI has moved.")
+    return 0 if LOG else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The two open unknowns in #1407's Pulumi half, both settled by running the real
CLI rather than reading about it. One of them changes the design.

## #1501 — the refusal holds, but binds less than `tfplan` does

Verified against **pulumi v3.261.0**:

| | |
|---|---|
| needs `PULUMI_EXPERIMENTAL`? | no |
| refusal on a **create** plan | `violates plan: properties changed: ++length[{8}!={99}]`, exit 1 |
| refusal on an **update** plan | `~~length[{12}!={55}]`, exit 1 |
| does a refusal mutate anything? | no — caught in `up`'s preview phase, state verified unchanged |
| fails on a **missing** planned operation too? | yes — `expected resource operations for <urn> but none were seen` |
| portable across a pod boundary? | yes — built in one container, applied in another with an empty plugin cache |
| carries secrets? | yes, encrypted under the stack's secrets provider; no plaintext |

Every refusal is paired with re-applying the **same plan file** against the
restored program, which succeeds. Without that control a failure only proves
plans are broken, not that the refusal does anything.

**The finding that was not in §13.** A plan saved for `12 → 20` still applies
cleanly after state has moved out of band to 31, and produces 20. The plan binds
*which resources are operated on, with which step kinds*, and *the desired
inputs* — **not the state the update starts from**. Terraform refuses a stale
plan on a state-serial mismatch; Pulumi has no such check.

So §3's table stands and Pulumi stays out of Ansible's column — but phase 5 owes
a staleness check Terrapod has to supply itself. Per-workspace apply
serialisation covers concurrent Terrapod runs; it does not cover a CLI apply or
real drift.

## #1502 — the service surface, catalogued

**101 requests, 19 distinct endpoints**, from a full `login → stack init → ls →
preview → up → refresh → export → import → destroy → stack rm` cycle against a
request-logging stub. The findings that cost a round of iteration each:

- **Auth is `token <value>`, not `Bearer` — and it changes mid-run.** Calls made
  during an update carry `update-token <lease>` instead. Two schemes on one
  surface, invisible to any test supplying its own authenticated client.
- **The service is the stack's secrets provider.** `POST .../encrypt` is called
  during an ordinary `up`. Terrapod would have to run an encrypt/decrypt oracle
  per stack — an obligation "state backend" does not imply.
- **State is a whole document both ways** (`GET .../export`, `PATCH
  .../update/{id}/checkpoint`), so the existing state-version storage fits with
  no new merge model. Both checkpoint and event bodies are **gzipped**.
- **A preview is an update**, started via `POST .../update/{id}`, and that call
  **must return a lease token** or the CLI panics with `persisted actions require
  a token`.
- **Concurrency is enforced by refusing to start.** No lock endpoint: a 409 ends
  the CLI immediately, exit 1, printing the service's `message` verbatim — so
  Terrapod's run serialisation maps onto it directly.
- **An empty stack's deployment is `null`.** A hand-made empty one fails the
  CLI's snapshot integrity check.
- **The surface need not sit at the root.** The CLI appends `/api/...` to the
  base URL *including its path prefix* — verified by serving a working session
  from `/api/terrapod/v1/pulumi`. This is the question #1484 had to settle for
  NuGet and it lands the opposite way, so Terrapod can mount this natively rather
  than reserving root space.

Nothing from the management surface was required for a full cycle, confirming
§2's scope; `/api/capabilities` returning an empty list is accepted.

## Both scripts were run before being committed

`scripts/pulumi-plan-probe.py` reproduces all six #1501 findings;
`scripts/pulumi-service-capture.py` reproduces all 19 endpoints the document
lists. Three rows in that table — `renew_lease`, `decrypt`, `batch-decrypt` —
were **not** exercised and are labelled as unconfirmed rather than presented as
observed.

The capture script's docstring also records an operational trap that cost real
time here: interrupting it leaves its container running and still pointed at the
stub port, where it talks to the *next* run's stub and mutates its state — which
presents as a phantom `stack not found`.

#1407 §3 and §13 are updated on the issue itself, so §13's
"verified from docs, **not run**" now reads as tested.

Closes #1501, closes #1502
