### PR TITLE
docs(1502): note that Pulumi's remote execution exists, off this surface

### DIFF
--- a/docs/pulumi-cli-surface.md
+++ b/docs/pulumi-cli-surface.md
@@ -223,6 +223,25 @@ is the question #1484 had to settle for NuGet and it lands the opposite way:
 Terrapod can mount this natively rather than at the root, which it reserves for
 the two surfaces genuinely forced there (`/v2/` and `/.well-known/terraform.json`).
 
+## Remote execution is not on this surface — but it does exist
+
+Nothing above executes anything. The service is a state store, a secrets oracle and an
+event sink; the CLI runs the language host, the engine and the providers locally, and
+`events/batch` is the CLI *pushing* what it did rather than a remote run streamed back.
+The `preview` and `update` bodies carry the project's name, runtime, options and config —
+**never the program source** — so the service could not execute it even in principle.
+
+Do not read that as "Pulumi has no remote execution". It does:
+`pulumi deployment run <operation>` queues a job on Pulumi Cloud, takes
+`--agent-pool-id`, and can stream its logs back (`--suppress-stream-logs`, default true).
+That lives on the **Deployments** API, a separate surface from this one, which is why a
+capture of `login` / `preview` / `up` never touches it.
+
+It is also not the same shape as `terraform apply` against an agent. Terraform uploads
+the local working directory, so uncommitted edits execute remotely; `deployment run` is
+git-sourced (`--git-branch` / `--git-commit` / `--git-repo-dir` / `--git-auth-*`), so it
+deploys committed code and local edits do not participate.
+
 ## Nothing from the management surface was required
 
 A full `login → stack init → stack ls → preview → up → refresh → export →


### PR DESCRIPTION
Follow-up to #1514, correcting something my capture makes easy to over-read.

The service surface catalogued in that PR executes nothing, and the capture shows why — the `preview`/`update` bodies carry project name, runtime, options and config, and **never the program source**, so the service could not run it even in principle.

That is a short step from concluding "Pulumi has no remote execution", which is wrong. `pulumi deployment run <operation>` is CLI-driven, takes `--agent-pool-id`, and can stream the job's logs back (`--suppress-stream-logs`, default true). It lives on the **Deployments** API — a separate surface — which is precisely why a capture of `login`/`preview`/`up` never reaches it.

It is not the same shape as `terraform apply` against an agent, and that difference is the part worth designing around:

| | approve + apply local edits remotely | trigger a git-sourced remote run |
|---|---|---|
| Terraform | yes — `apply` with agent execution | yes — VCS-driven runs |
| **Pulumi** | **no** — `up` always executes locally | yes — `pulumi deployment run` |

Terraform uploads the local working directory, so uncommitted edits execute remotely. `deployment run` is git-sourced, so committed code is what runs.

Doc-only. #1407 §3 now carries the comparison, and #1487 carries the constraint that keeps the option open — `engine` must not imply execution locus, since a strategy that hardcodes "Pulumi is client-executed" is the one change that would close the door.