### PR TITLE
test(1485): prove the air-gap claim in CI, with real clients and no route out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2128,6 +2128,119 @@ jobs:
         if: always()
         run: docker compose -f e2e/docker-compose.e2e.yml down -v
 
+  # ── Air-gap gate (#1485, phase 0 of #1407) ──────────────
+  # #1407 §12 states the phase-0 acceptance in one sentence: *run each client with
+  # upstream network blocked*. Every surface met that by hand, once, when it was
+  # built. This makes it standing.
+  #
+  # A pull-through cache that has quietly started reaching upstream on a path
+  # nobody exercises looks identical to one that has not — right up until an
+  # air-gapped operator's runner hangs. That failure is invisible by construction,
+  # which is why it needs a machine watching rather than a memory of having checked.
+  airgap-gate:
+    name: Air-gap Gate
+    needs: [prepare, build-images-amd64]
+    if: |
+      always()
+      && needs.build-images-amd64.result == 'success'
+      && needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Log in to GHCR
+        if: needs.prepare.outputs.is_pr != 'true'
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+
+      - name: Pull images (branch/tag)
+        if: needs.prepare.outputs.is_pr != 'true'
+        run: |
+          sha_short="${{ needs.prepare.outputs.sha_short }}"
+          for image in terrapod-api terrapod-web terrapod-migrations; do
+            docker pull "$REGISTRY/$image:sha-${sha_short}-amd64"
+            docker tag "$REGISTRY/$image:sha-${sha_short}-amd64" "$image:local"
+          done
+
+      - name: Download image artifacts (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: image-*-amd64
+          path: /tmp/images
+          merge-multiple: true
+
+      - name: Load images (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        run: |
+          sha_short="${{ needs.prepare.outputs.sha_short }}"
+          for image in terrapod-api terrapod-web terrapod-migrations; do
+            gunzip -c "/tmp/images/$image-amd64.tar.gz" | docker load
+            docker tag "$REGISTRY/$image:sha-${sha_short}-amd64" "$image:local"
+          done
+
+      # Presigned filesystem URLs default to the api container's own address, so
+      # any other client following one gets connection refused. Pointed at the
+      # BFF here, which is also the hop the clients themselves use.
+      - name: Start stack
+        run: |
+          TERRAPOD_FS_BASE_URL=http://web:3000 \
+            docker compose -f e2e/docker-compose.e2e.yml up -d
+
+      - name: Wait for stack health
+        run: |
+          timeout=120
+          elapsed=0
+          while ! curl -sf http://localhost:3000/ > /dev/null 2>&1; do
+            if (( elapsed >= timeout )); then
+              echo "Stack not healthy after ${timeout}s"
+              docker compose -f e2e/docker-compose.e2e.yml logs
+              exit 1
+            fi
+            sleep 2
+            elapsed=$((elapsed + 2))
+          done
+          echo "Stack healthy (${elapsed}s)"
+
+      # Warm each client through Terrapod, then repeat every install on a network
+      # with no gateway. The script proves that network really is severed before
+      # asserting anything through it — without that self-check the whole job
+      # would pass while testing nothing.
+      - name: Real clients, with and without a route to the internet
+        run: scripts/airgap-gate.sh http://localhost:3000
+
+      # The other half of the engine gate (#1429): switched off, these surfaces
+      # are ABSENT rather than answering 404, while terraform's own provider
+      # mirror, module registry and binary cache still answer. Asserted per-PR in
+      # unit tests; asserting it against a running stack is what makes it true
+      # rather than believed.
+      - name: Restart with the ansible and pulumi engines disabled
+        run: |
+          TERRAPOD_FS_BASE_URL=http://web:3000 \
+          TERRAPOD_ENGINES_ANSIBLE=false TERRAPOD_ENGINES_PULUMI=false \
+            docker compose -f e2e/docker-compose.e2e.yml up -d
+          for _ in $(seq 1 30); do
+            curl -sf http://localhost:3000/ >/dev/null 2>&1 && break
+            sleep 4
+          done
+
+      - name: Gated-off surfaces are absent, terraform's still answer
+        run: scripts/airgap-gate.sh --gated-off http://localhost:3000
+
+      - name: Stack logs on failure
+        if: failure()
+        run: docker compose -f e2e/docker-compose.e2e.yml logs --tail=200
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f e2e/docker-compose.e2e.yml down -v
+
   # ── E2E Report (merge shard blob reports) ──────────────
   # Merges the per-shard Playwright blob reports into a single HTML report,
   # so a failure across 8 shards is triaged from one artifact. Runs even when
@@ -3277,6 +3390,7 @@ jobs:
       # waits for it. Re-adding this line reintroduces the stall silently, since
       # nothing about the verdict changes (#1468).
       - oci-conformance
+      - airgap-gate
       - create-manifests
       - release-create
       - release-images
@@ -3326,6 +3440,7 @@ jobs:
             "${{ needs.scan-images.result }}"
             "${{ needs.e2e-test.result }}"
             "${{ needs.oci-conformance.result }}"
+            "${{ needs.airgap-gate.result }}"
             "${{ needs.create-manifests.result }}"
             "${{ needs.release-create.result }}"
             "${{ needs.release-images.result }}"

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -49,6 +49,18 @@ services:
       TERRAPOD_REDIS_URL: redis://redis:6379
       TERRAPOD_STORAGE__BACKEND: filesystem
       TERRAPOD_STORAGE__FILESYSTEM__ROOT_DIR: /var/lib/terrapod/storage
+      # Presigned filesystem URLs are built from this and handed to whoever asked.
+      # The default (http://localhost:8000) is the api container's OWN address, so
+      # any other client following one gets connection refused — which is exactly
+      # what the air-gap gate hit on its first run. Overridable so that job can
+      # point it at the BFF; left unset, behaviour is identical to before.
+      TERRAPOD_STORAGE__FILESYSTEM__BASE_URL: ${TERRAPOD_FS_BASE_URL:-http://localhost:8000}
+      # Engine gate (#1429). Both default to true, matching the product default, so
+      # the normal e2e run is unchanged. The air-gap gate flips them off to assert
+      # the other half: that engine-specific surfaces go ABSENT rather than 404ing.
+      # Declared here because compose only forwards environment a service names.
+      TERRAPOD_ENGINES__ANSIBLE__ENABLED: ${TERRAPOD_ENGINES_ANSIBLE:-true}
+      TERRAPOD_ENGINES__PULUMI__ENABLED: ${TERRAPOD_ENGINES_PULUMI:-true}
       TERRAPOD_RATE_LIMIT__ENABLED: "false"
       # Service catalog (#535) is off by default; enable it so the catalog UI +
       # RBAC surfaces are exercised end-to-end.

--- a/scripts/airgap-gate.sh
+++ b/scripts/airgap-gate.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Prove the air-gap claim with real clients and no route to the internet (#1485).
+#
+# #1407 §12 states the phase-0 acceptance in one sentence: *run each client with
+# upstream network blocked*. Every surface has met that by hand, once, when it
+# was built. This makes it a standing guarantee.
+#
+# Two phases against one running stack:
+#
+#   warm     the client has internet; each install pulls through Terrapod once,
+#            which is what populates the cache.
+#   blocked  the client is moved onto a network with NO gateway and every install
+#            is repeated. Anything that reaches upstream fails here.
+#
+# The blocked client can still reach Terrapod — `--network none` would prove
+# nothing, since the claim is "no internet", not "no network". Both phases use
+# the SAME URL (http://web:3000), so nothing about the address varies between
+# them; only the route to the outside world does.
+#
+# **The self-check is what makes this a test rather than a tautology.** Before
+# any client runs blocked, the blocked network is proven to have no route out. A
+# harness that silently kept internet access would pass every row while asserting
+# nothing, and would look identical to a real pass.
+#
+# Client-side caches are defeated per client (`pip --no-cache-dir`, a throwaway
+# npm cache, `GOMODCACHE` in the container). Without that an install that never
+# touched the proxy reads as a passing test — a trap this repository has already
+# hit once.
+#
+# The api container is deliberately NOT recreated between phases. The e2e compose
+# stack mounts no volume on the storage dir, so replacing that container discards
+# every stored object while Postgres keeps the rows naming them — which presents
+# as "cached artifact 404s" and reads like a cache bug. Only the client moves.
+#
+#     scripts/airgap-gate.sh [base-url]
+#
+# Defaults to the e2e stack's BFF at http://localhost:3000. Point it at the BFF,
+# never the API directly: that hop is the only address a deployment exposes, and
+# it is where several of these surfaces' bugs have actually lived.
+
+set -euo pipefail
+
+# `--gated-off` asserts the other half of the engine gate (#1429): with the
+# ansible and pulumi engines switched off, these surfaces are *absent* rather
+# than answering 404, while terraform's own surfaces still answer. It needs no
+# clients, only a stack booted with the engines disabled.
+MODE="run"
+if [ "${1:-}" = "--gated-off" ]; then MODE="gated-off"; shift; fi
+
+BASE="${1:-http://localhost:3000}"
+NET="tp-airgap-$$"
+PREFIX="/api/terrapod/v1/package-cache"
+#: Reached by service alias from inside the blocked network.
+INNER="http://web:3000"
+
+PASS=0
+FAIL=0
+RESULTS=()
+LOGS="$(mktemp -d)"
+
+cleanup() {
+  docker network rm "$NET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+note() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+ok()   { PASS=$((PASS + 1)); RESULTS+=("PASS  $*"); printf '  \033[32mPASS\033[0m  %s\n' "$*"; }
+bad()  { FAIL=$((FAIL + 1)); RESULTS+=("FAIL  $*"); printf '  \033[31mFAIL\033[0m  %s\n' "$*"; }
+# A skip is recorded and printed, never silently dropped: a row that cannot run
+# here must be visible in the summary, or the gate quietly shrinks over time.
+skip() { RESULTS+=("SKIP  $*"); printf '  \033[33mSKIP\033[0m  %s\n' "$*"; }
+
+
+# ── gated-off mode ─────────────────────────────────────────────────────
+
+if [ "$MODE" = "gated-off" ]; then
+  note "Engine gate: ansible and pulumi disabled"
+  curl -sf "$BASE/" >/dev/null || { echo "no stack at $BASE"; exit 1; }
+
+  schema="$(curl -sf "$BASE/api/openapi.json")" || { echo "no schema"; exit 1; }
+  counts="$(printf '%s' "$schema" | python3 -c "
+import json, sys
+paths = list(json.load(sys.stdin).get('paths', {}))
+print(sum('/package-cache/' in p for p in paths),
+      sum(p.startswith('/v2/') for p in paths),
+      sum('/providers/' in p for p in paths),
+      sum('registry-modules' in p for p in paths),
+      sum('binary-cache' in p for p in paths))
+")"
+  read -r pkg oci prov mods bins <<<"$counts"
+
+  # Absent, not 404ing. A route that still exists and answers 404 would look
+  # identical from the outside; the schema is what distinguishes them.
+  [ "$pkg" -eq 0 ] && ok "package-cache routes absent from the schema ($pkg)" \
+                   || bad "package-cache routes still registered ($pkg)"
+  [ "$oci" -eq 0 ] && ok "OCI /v2/ routes absent from the schema ($oci)" \
+                   || bad "OCI /v2/ routes still registered ($oci)"
+
+  # ...while terraform's own surfaces are untouched. Without this half, deleting
+  # every route would pass.
+  [ "$prov" -gt 0 ] && ok "provider mirror still registered ($prov)" \
+                    || bad "provider mirror disappeared ($prov)"
+  [ "$mods" -gt 0 ] && ok "module registry still registered ($mods)" \
+                    || bad "module registry disappeared ($mods)"
+  [ "$bins" -gt 0 ] && ok "engine binary cache still registered ($bins)" \
+                    || bad "engine binary cache disappeared ($bins)"
+
+  # And the deployed path agrees with the schema.
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$BASE$PREFIX/pypi/simple/six/")"
+  [ "$code" = "404" ] && ok "a gated-off path 404s through the BFF ($code)" \
+                      || bad "a gated-off path answered $code, expected 404"
+
+  note "Result"
+  printf '  %s\n' "${RESULTS[@]}"
+  printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+  [ "$FAIL" -eq 0 ] || exit 1
+  exit 0
+fi
+
+# ── stack + credentials ────────────────────────────────────────────────
+
+note "Stack"
+curl -sf "$BASE/" >/dev/null || { echo "no stack at $BASE"; exit 1; }
+echo "  reachable at $BASE"
+
+TOKEN="$(python3 scripts/mint-token.py --url "$BASE" \
+         --email admin@terrapod.local --password 'TestPassword123!')"
+[ -n "$TOKEN" ] || { echo "could not mint a token"; exit 1; }
+echo "  minted an API token"
+
+# By compose service label rather than `--filter publish=`, which podman rejects
+# outright ("publish is an invalid filter") — and this harness has to run on both
+# engines, since CI is docker and local development is podman.
+WEB_CID="$(docker ps --filter 'label=com.docker.compose.service=web' --format '{{.ID}}' | head -1)"
+[ -n "$WEB_CID" ] || { echo "could not find the web container"; exit 1; }
+
+# The stack's own network. The warm phase runs there because `web` resolves AND
+# it has a route out, so warm and blocked can use the identical URL and differ in
+# exactly one thing: whether the internet is reachable.
+STACK_NET="$(docker inspect "$WEB_CID" \
+  --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}' | awk '{print $1}')"
+[ -n "$STACK_NET" ] || { echo "could not determine the stack network"; exit 1; }
+echo "  stack network: $STACK_NET"
+
+# ── the blocked network ────────────────────────────────────────────────
+#
+# `--internal` gives the network no gateway, so a container attached to it alone
+# has no route off the host. The BFF is attached too, under the alias `web`, so
+# Terrapod stays reachable — which is the whole point.
+
+note "Blocked network"
+docker network create --internal "$NET" >/dev/null
+docker network connect --alias web "$NET" "$WEB_CID"
+echo "  created $NET (internal) and attached the BFF as 'web'"
+
+# ── the self-check ─────────────────────────────────────────────────────
+
+note "Self-check: is the blocked network actually blocked?"
+if docker run --rm --network "$NET" curlimages/curl:8.11.1 \
+     -sS --max-time 8 https://pypi.org/simple/ >/dev/null 2>&1; then
+  bad "blocked network reached pypi.org — every result below would be meaningless"
+  echo
+  echo "The harness cannot assert anything while the blocked network has a route out."
+  exit 1
+else
+  ok "blocked network cannot reach pypi.org"
+fi
+
+if docker run --rm --network "$NET" curlimages/curl:8.11.1 \
+     -sS --max-time 8 "$INNER/" >/dev/null 2>&1; then
+  ok "blocked network can still reach Terrapod"
+else
+  bad "blocked network cannot reach Terrapod — nothing below can pass"
+  exit 1
+fi
+
+# ── surfaces ───────────────────────────────────────────────────────────
+#
+# Each surface runs warm then blocked. The blocked run is the assertion; the warm
+# run exists to populate the cache and to prove the row works at all.
+
+surface() {
+  local name="$1" image="$2" script="$3"
+  note "$name"
+
+  # Pull first and separately, so image-transfer chatter cannot bury the error
+  # the row actually produced.
+  docker pull -q "$image" >/dev/null 2>&1 || true
+
+  local warm="$LOGS/${name// /-}.warm.log" blocked="$LOGS/${name// /-}.blocked.log"
+
+  if docker run --rm --network "$STACK_NET" "$image" sh -ec "$script" >"$warm" 2>&1; then
+    ok "$name warm (through Terrapod, with internet)"
+  else
+    bad "$name warm — the row itself is broken, not the air gap"
+    tail -12 "$warm" | sed 's/^/        /'
+    return
+  fi
+
+  if docker run --rm --network "$NET" "$image" sh -ec "$script" >"$blocked" 2>&1; then
+    ok "$name blocked (no route to the internet)"
+  else
+    bad "$name blocked — it needs upstream"
+    tail -12 "$blocked" | sed 's/^/        /'
+  fi
+}
+
+surface "PyPI" python:3.12-slim "
+  pip install --no-cache-dir --quiet --disable-pip-version-check \
+    --index-url 'http://tp:$TOKEN@web:3000$PREFIX/pypi/simple/' \
+    --trusted-host web six
+  python -c 'import six; print(six.__version__)'
+"
+
+surface "npm" node:22-alpine "
+  mkdir -p /tmp/proj && cd /tmp/proj
+  # A dedicated cache dir, or an install that never touched the proxy passes.
+  printf '%s\n' \
+    'registry=http://web:3000$PREFIX/npm/' \
+    '//web:3000$PREFIX/npm/:_authToken=$TOKEN' \
+    'cache=/tmp/npmcache' > .npmrc
+  npm install --silent --no-audit --no-fund left-pad
+  node -e \"require('/tmp/proj/node_modules/left-pad')\"
+"
+
+# Two Go settings will silently defeat this row, and one of them passed the warm
+# phase while proving nothing:
+#   GOPRIVATE / GONOPROXY  — make the toolchain bypass the proxy and resolve the
+#                            module directly from its VCS host. With internet that
+#                            looks like a pass; blocked, it is the failure.
+#   GOPROXY=...,direct     — falls through to upstream on a proxy miss, which is
+#                            exactly the hole this gate exists to find.
+# So GOPROXY names the proxy and nothing else, and GOPRIVATE stays unset.
+if [ "${BASE#https://}" = "$BASE" ]; then
+  skip "Go modules — needs HTTPS: the toolchain refuses to send credentials to a
+        plain-HTTP URL ('refusing to pass credentials to insecure URL'), and
+        neither GOINSECURE nor .netrc lifts it. Confirmed by experiment here and
+        already recorded in docs/package-cache.md. Run this gate against an
+        HTTPS base URL to cover the row."
+else
+surface "Go modules" golang:1.23 "
+  export GOMODCACHE=/tmp/gomod GOFLAGS=-mod=mod GOSUMDB=off
+  export GOPROXY='http://tp:$TOKEN@web:3000$PREFIX/go'
+  mkdir -p /tmp/m && cd /tmp/m && go mod init probe >/dev/null
+  go mod edit -require=rsc.io/quote@v1.5.2
+  go mod download rsc.io/quote
+  test -d \"\$GOMODCACHE/rsc.io\"
+"
+fi
+
+# ── summary ────────────────────────────────────────────────────────────
+
+note "Result"
+printf '  %s\n' "${RESULTS[@]}"
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
#1407 §12 states the phase-0 acceptance in one sentence: *run each client with upstream network blocked*. Every surface has met that by hand, once, when it was built. This makes it standing.

## Two phases, one variable

| phase | client has internet | asserts |
|---|---|---|
| **warm** | yes | the row works at all, and populates Terrapod's cache |
| **blocked** | **no** — network with no gateway | nothing reaches upstream |

Both phases use the **identical URL**, so the only thing differing between them is whether the internet is reachable. The blocked client can still reach Terrapod — `--network none` would prove nothing, since the claim is "no internet", not "no network".

**The self-check is what makes this a test rather than a tautology.** Before any row runs blocked, the harness proves that network cannot reach `pypi.org` *and* can still reach Terrapod. A harness that quietly kept internet access would pass every row while asserting nothing, and would look exactly like a real pass.

The api container is deliberately never recreated: the e2e stack mounts no volume on its storage dir, so replacing it discards every stored object while Postgres keeps the rows naming them — which presents as cache 404s and reads like a product bug. Only the client moves.

## Two things this found on its first runs

**Presigned filesystem URLs pointed at the api container's own address.** `storage.filesystem.base_url` defaults to `http://localhost:8000`, so the PyPI index redirected clients to a host only the api itself can reach — meaning **no external client could ever have downloaded through these surfaces on the e2e stack**. Helm auto-detects this from the ingress hostname, so real deployments are unaffected. Now overridable, defaulting to exactly the previous value, and pointed at the BFF here so downloads traverse the hop clients actually use.

**`GOPRIVATE='*'` made the Go row pass warm while never touching Terrapod.** The toolchain bypasses the proxy and resolves from the module's VCS host; with internet that reads as a pass, and only the blocked phase exposed it. That and `GOPROXY=…,direct` are both called out in the script, since either silently hollows out the row.

## The gated-off half

Same job, second phase — with the `ansible` and `pulumi` engines off:

```
PASS  package-cache routes absent from the schema (0)
PASS  OCI /v2/ routes absent from the schema (0)
PASS  provider mirror still registered (4)
PASS  module registry still registered (10)
PASS  engine binary cache still registered (8)
PASS  a gated-off path 404s through the BFF (404)
```

**Absent**, not answering 404 — which is why it checks the schema and not just a status code. Both directions are asserted, because without the second half, deleting every route would pass.

## Coverage, and one honest skip

PyPI and npm pass both phases, verified locally against a real stack. Go is **skipped, not faked** — the toolchain refuses to send credentials to a plain-HTTP URL and neither `GOINSECURE` nor `.netrc` lifts it. I confirmed that by experiment; it is already recorded in `docs/package-cache.md`, so this reproduces a known constraint rather than finding a new one. The row runs when the gate is pointed at an HTTPS base URL. Skips are printed and kept in the summary so the gate cannot quietly shrink.

Galaxy, NuGet, Pulumi and OCI rows are the next increments — the shape the issue asks for, where the job grows into the gate's closing argument rather than waiting for everything.

## Registration

`airgap-gate` is a test job, so it is registered at both sites `ci-pass` requires — `needs` and the `results` array — matching how `oci-conformance` is wired. Verified by parsing the workflow rather than by eye.

Part of #1407 (phase 0)
