### PR TITLE
refactor(1488): retire build_job_spec's 34-parameter signature behind the strategy

### DIFF
--- a/services/terrapod/engines/terraform.py
+++ b/services/terrapod/engines/terraform.py
@@ -1,45 +1,190 @@
 """The Terraform/OpenTofu strategy — today's behaviour, byte for byte.
 
-#1407 phase 1. Every method here delegates to the code that already runs, so
-routing a call site through the strategy changes nothing about what executes.
-Phases 2 and 3 move the bodies in; this file is where they land.
+#1407 phases 1 and 2. `TerraformRunOptions` collects the twenty run options that
+used to be twenty positional parameters on a general-purpose Job builder, and the
+env translation that reads them now lives here rather than inside that builder.
+
+The block below was **moved verbatim** rather than rewritten. The only changes are
+the name of the accumulator and the indent — the options are rebound as locals at
+the top precisely so the transplanted lines could stay identical. For a refactor
+whose failure mode is a Job that launches with a subtly different spec, a
+transformation you can read as "unchanged" beats one you have to re-derive.
+
+Everything here is Terraform's, including the parts that look generic:
+`TP_VERIFY_BINARIES` and `TP_SIGNING_KEY_*` verify the terraform/tofu/terragrunt
+binaries specifically, and `TP_COST_*` prices a terraform plan. A second engine
+gets its own translation beside this one, not another branch inside it.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from terrapod.config import settings
+
+if TYPE_CHECKING:  # the listener image ships no DB layer — see tests/meta
+    from terrapod.config import RunnerConfig
+
+
+@dataclass(frozen=True)
+class TerraformRunOptions:
+    """How one Terraform run differs from the default.
+
+    Frozen because a Job spec is built once from it; a builder that could mutate
+    its own inputs halfway through is a bug waiting for a second caller.
+    """
+
+    terraform_version: str = ""
+    execution_backend: str = ""
+    terragrunt_enabled: bool = False
+    terragrunt_version: str = ""
+    plan_only: bool = False
+    var_files: list[str] | None = None
+    target_addrs: list[str] | None = None
+    replace_addrs: list[str] | None = None
+    refresh_only: bool = False
+    refresh: bool = True
+    allow_empty_apply: bool = False
+    is_destroy: bool = False
+    parallelism: int = 10
+    cost_estimation: bool = True
+    cost_default_region: str = "us-east-1"
+    working_directory: str = ""
+    onboard_session_id: str = ""
+    onboard_provider: str = ""
+    onboard_provider_version: str = ""
+    onboard_types: list[str] | None = None
 
 
 class TerraformStrategy:
     """Terraform and OpenTofu, which share one engine and differ only in binary.
 
-    `execution_backend` picks between them per workspace — that is a choice
-    *within* this engine, not a different engine, which is why both are served
-    here rather than by two strategies.
+    `execution_backend` picks between them per workspace — a choice *within* this
+    engine, not a different engine, which is why both are served here rather than
+    by two strategies.
     """
 
     name = "terraform"
 
-    #: `terraform plan` then `terraform apply`. The reconciler and the UI already
-    #: speak these words; naming them here is what lets a later engine say
-    #: `preview`/`update` without the platform hard-coding Terraform's vocabulary.
+    #: `terraform plan` then `terraform apply`. Naming the vocabulary here is what
+    #: lets a later engine say `preview`/`update` without the platform hard-coding
+    #: Terraform's words.
     phases = ("plan", "apply")
 
     #: OpenTofu, matching the column default on workspaces.
     default_execution_backend = "tofu"
 
-    def build_job_spec(self, **kwargs: Any) -> dict:
-        """Delegate to the existing builder, unchanged.
+    def container_env(
+        self, options: TerraformRunOptions, runner_config: RunnerConfig
+    ) -> list[dict[str, Any]]:
+        """The TP_* instructions this engine gives its entrypoint.
 
-        Imported here rather than at module scope so this package stays free of
-        `runner` at import time — the API imports the strategy and has no use for
-        the Job template, and keeping the edge lazy means neither image pays for
-        the other's code.
+        Returned as a list and spliced into the container env at exactly the
+        position these lines occupied before, so the rendered order is unchanged —
+        which the golden spec matrix pins.
+        """
+        env: list[dict[str, Any]] = []
+        terraform_version = options.terraform_version
+        execution_backend = options.execution_backend
+        terragrunt_enabled = options.terragrunt_enabled
+        terragrunt_version = options.terragrunt_version
+        plan_only = options.plan_only
+        var_files = options.var_files
+        target_addrs = options.target_addrs
+        replace_addrs = options.replace_addrs
+        refresh_only = options.refresh_only
+        refresh = options.refresh
+        allow_empty_apply = options.allow_empty_apply
+        is_destroy = options.is_destroy
+        parallelism = options.parallelism
+        cost_estimation = options.cost_estimation
+        cost_default_region = options.cost_default_region
+        working_directory = options.working_directory
+        onboard_session_id = options.onboard_session_id
+        onboard_provider = options.onboard_provider
+        onboard_provider_version = options.onboard_provider_version
+        onboard_types = options.onboard_types
 
-        #1488 replaces this `**kwargs` pass-through with a structured argument;
-        the 34-parameter signature is exactly what that issue exists to retire.
-        Until then this is a pure forward so nothing about the spec can change.
+        # Terraform version + backend
+        version = terraform_version or runner_config.default_terraform_version
+        backend = execution_backend or runner_config.default_execution_backend
+        env.append({"name": "TP_VERSION", "value": version})
+        env.append({"name": "TP_BACKEND", "value": backend})
+        # Runner-side executable verification level (#607): the runner re-verifies
+        # the terraform/tofu/terragrunt binary against the publisher's signed
+        # SHA256SUMS with its own pinned key before executing it. Mirrors the
+        # server's binary_cache.verify so operators control it in one place.
+        env.append({"name": "TP_VERIFY_BINARIES", "value": settings.registry.binary_cache.verify})
+        # Operator-overridden publisher keys (#607): propagate the configured trust
+        # set to the Job so runner-side verification uses the same keys as the API
+        # (set at Job-creation from config, not fetched at request time → not an
+        # attacker-controllable trust anchor). Empty (default) → runner uses bundled.
+        for _tool, _armor in settings.registry.binary_cache.signing_keys.items():
+            if _armor:
+                env.append({"name": f"TP_SIGNING_KEY_{_tool.upper()}", "value": _armor})
+        # Terragrunt (#534): the runner wraps tofu/terraform with terragrunt when
+        # enabled. Version is partial (e.g. "1.0") — the binary cache resolves it.
+        if terragrunt_enabled:
+            env.append({"name": "TP_TERRAGRUNT_ENABLED", "value": "true"})
+            env.append({"name": "TP_TERRAGRUNT_VERSION", "value": terragrunt_version or "1.0"})
+        if plan_only:
+            env.append({"name": "TP_PLAN_ONLY", "value": "true"})
+        if var_files:
+            env.append({"name": "TP_VAR_FILES", "value": json.dumps(var_files)})
+        if target_addrs:
+            env.append({"name": "TP_TARGET_ADDRS", "value": json.dumps(target_addrs)})
+        if replace_addrs:
+            env.append({"name": "TP_REPLACE_ADDRS", "value": json.dumps(replace_addrs)})
+        if refresh_only:
+            env.append({"name": "TP_REFRESH_ONLY", "value": "true"})
+        if not refresh:
+            env.append({"name": "TP_REFRESH", "value": "false"})
+        if allow_empty_apply:
+            env.append({"name": "TP_ALLOW_EMPTY_APPLY", "value": "true"})
+        if is_destroy:
+            env.append({"name": "TP_DESTROY", "value": "true"})
+        # Always emitted, never only-when-non-default: the runner has no way to know
+        # the workspace's setting otherwise, and a default that drifts between API
+        # and runner across a version skew would be invisible (#1431).
+        env.append({"name": "TP_PARALLELISM", "value": str(parallelism)})
+        # Cost estimation (#871). The runner defaults to enabled, so only emit the
+        # env when the API instructs OFF; always ship the fallback region so a
+        # resource whose region can't be resolved is priced consistently.
+        if not cost_estimation:
+            env.append({"name": "TP_COST_ESTIMATION", "value": "false"})
+        elif cost_default_region:
+            env.append({"name": "TP_COST_DEFAULT_REGION", "value": cost_default_region})
+        if working_directory:
+            env.append({"name": "TP_WORKING_DIR", "value": working_directory})
+
+        # Onboarding discovery (#824 P2): a non-empty session id makes the entrypoint
+        # run D2/D3 (terrapod-query) instead of a workspace plan. The run stays
+        # plan-phase for all infra (Job name / Redis keys / reconciler).
+        if onboard_session_id:
+            env.append({"name": "TP_ONBOARD_SESSION_ID", "value": onboard_session_id})
+            env.append({"name": "TP_ONBOARD_PROVIDER", "value": onboard_provider})
+            env.append({"name": "TP_ONBOARD_PROVIDER_VERSION", "value": onboard_provider_version})
+            env.append({"name": "TP_ONBOARD_TYPES", "value": json.dumps(onboard_types or [])})
+
+        return env
+
+    def build_job_spec(
+        self,
+        *,
+        options: TerraformRunOptions | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Build the Job spec: engine env from `options`, the rest from the
+        neutral builder.
+
+        The strategy composes rather than being called by the builder — the
+        builder knows nothing about Terraform, and this is the only place that
+        knows both.
         """
         from terrapod.runner.job_template import build_job_spec
 
-        return build_job_spec(**kwargs)
+        opts = options or TerraformRunOptions()
+        runner_config = kwargs["runner_config"]
+        return build_job_spec(engine_env=self.container_env(opts, runner_config), **kwargs)

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -1,9 +1,8 @@
 """Build K8s Job specs for terraform/tofu plan and apply phases."""
 
-import json
 import re
 
-from terrapod.config import RunnerConfig, settings
+from terrapod.config import RunnerConfig
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -73,29 +72,13 @@ def build_job_spec(
     vars_secret_name: str = "",
     resource_cpu: str = "1",
     resource_memory: str = "2Gi",
-    parallelism: int = 10,
     timeout_minutes: int = 60,
-    terraform_version: str = "",
-    execution_backend: str = "",
-    terragrunt_enabled: bool = False,
-    terragrunt_version: str = "",
     namespace: str = "",
-    plan_only: bool = False,
-    var_files: list[str] | None = None,
-    target_addrs: list[str] | None = None,
-    replace_addrs: list[str] | None = None,
-    refresh_only: bool = False,
-    refresh: bool = True,
-    allow_empty_apply: bool = False,
-    is_destroy: bool = False,
-    cost_estimation: bool = True,
-    cost_default_region: str = "us-east-1",
-    working_directory: str = "",
     ca_secret_name: str = "",
-    onboard_session_id: str = "",
-    onboard_provider: str = "",
-    onboard_provider_version: str = "",
-    onboard_types: list[str] | None = None,
+    #: The engine's TP_* instructions, built by its strategy (#1407 phase 2).
+    #: Defaults to empty so a caller that supplies none renders a spec with no
+    #: engine env rather than failing — the neutral half stands on its own.
+    engine_env: list[dict] | None = None,
 ) -> dict:
     """Build a K8s Job spec for a run phase.
 
@@ -170,72 +153,13 @@ def build_job_spec(
     if public_api_url and public_api_url.rstrip("/") != api_url.rstrip("/"):
         container_env.append({"name": "TP_PUBLIC_API_URL", "value": public_api_url})
 
-    # Terraform version + backend
-    version = terraform_version or runner_config.default_terraform_version
-    backend = execution_backend or runner_config.default_execution_backend
-    container_env.append({"name": "TP_VERSION", "value": version})
-    container_env.append({"name": "TP_BACKEND", "value": backend})
-    # Runner-side executable verification level (#607): the runner re-verifies
-    # the terraform/tofu/terragrunt binary against the publisher's signed
-    # SHA256SUMS with its own pinned key before executing it. Mirrors the
-    # server's binary_cache.verify so operators control it in one place.
-    container_env.append(
-        {"name": "TP_VERIFY_BINARIES", "value": settings.registry.binary_cache.verify}
-    )
-    # Operator-overridden publisher keys (#607): propagate the configured trust
-    # set to the Job so runner-side verification uses the same keys as the API
-    # (set at Job-creation from config, not fetched at request time → not an
-    # attacker-controllable trust anchor). Empty (default) → runner uses bundled.
-    for _tool, _armor in settings.registry.binary_cache.signing_keys.items():
-        if _armor:
-            container_env.append({"name": f"TP_SIGNING_KEY_{_tool.upper()}", "value": _armor})
-    # Terragrunt (#534): the runner wraps tofu/terraform with terragrunt when
-    # enabled. Version is partial (e.g. "1.0") — the binary cache resolves it.
-    if terragrunt_enabled:
-        container_env.append({"name": "TP_TERRAGRUNT_ENABLED", "value": "true"})
-        container_env.append(
-            {"name": "TP_TERRAGRUNT_VERSION", "value": terragrunt_version or "1.0"}
-        )
-    if plan_only:
-        container_env.append({"name": "TP_PLAN_ONLY", "value": "true"})
-    if var_files:
-        container_env.append({"name": "TP_VAR_FILES", "value": json.dumps(var_files)})
-    if target_addrs:
-        container_env.append({"name": "TP_TARGET_ADDRS", "value": json.dumps(target_addrs)})
-    if replace_addrs:
-        container_env.append({"name": "TP_REPLACE_ADDRS", "value": json.dumps(replace_addrs)})
-    if refresh_only:
-        container_env.append({"name": "TP_REFRESH_ONLY", "value": "true"})
-    if not refresh:
-        container_env.append({"name": "TP_REFRESH", "value": "false"})
-    if allow_empty_apply:
-        container_env.append({"name": "TP_ALLOW_EMPTY_APPLY", "value": "true"})
-    if is_destroy:
-        container_env.append({"name": "TP_DESTROY", "value": "true"})
-    # Always emitted, never only-when-non-default: the runner has no way to know
-    # the workspace's setting otherwise, and a default that drifts between API
-    # and runner across a version skew would be invisible (#1431).
-    container_env.append({"name": "TP_PARALLELISM", "value": str(parallelism)})
-    # Cost estimation (#871). The runner defaults to enabled, so only emit the
-    # env when the API instructs OFF; always ship the fallback region so a
-    # resource whose region can't be resolved is priced consistently.
-    if not cost_estimation:
-        container_env.append({"name": "TP_COST_ESTIMATION", "value": "false"})
-    elif cost_default_region:
-        container_env.append({"name": "TP_COST_DEFAULT_REGION", "value": cost_default_region})
-    if working_directory:
-        container_env.append({"name": "TP_WORKING_DIR", "value": working_directory})
-
-    # Onboarding discovery (#824 P2): a non-empty session id makes the entrypoint
-    # run D2/D3 (terrapod-query) instead of a workspace plan. The run stays
-    # plan-phase for all infra (Job name / Redis keys / reconciler).
-    if onboard_session_id:
-        container_env.append({"name": "TP_ONBOARD_SESSION_ID", "value": onboard_session_id})
-        container_env.append({"name": "TP_ONBOARD_PROVIDER", "value": onboard_provider})
-        container_env.append(
-            {"name": "TP_ONBOARD_PROVIDER_VERSION", "value": onboard_provider_version}
-        )
-        container_env.append({"name": "TP_ONBOARD_TYPES", "value": json.dumps(onboard_types or [])})
+    # The engine's own instructions to its entrypoint (#1407 phase 2). Spliced in
+    # at exactly the position these lines occupied when they lived here, so the
+    # rendered env order is unchanged — the golden spec matrix pins that.
+    #
+    # This builder knows nothing about which engine it is serving; the strategy
+    # composed this list and passes it in.
+    container_env.extend(engine_env or [])
 
     # Termination grace period — passed to entrypoint for time-budgeted shutdown
     container_env.append(

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -681,6 +681,7 @@ class RunnerListener:
         immediate signal at the API instead of a generic timeout 5 min later.
         """
         from terrapod.engines import strategy_for
+        from terrapod.engines.terraform import TerraformRunOptions
         from terrapod.runner.job_manager import create_job, get_job_uid
 
         phase = attrs.get("phase", "plan")
@@ -764,19 +765,10 @@ class RunnerListener:
         ca_pem = self._read_ca_bundle_pem()
         ca_secret_name = f"tprun-{run_short}-{phase}-ca" if ca_pem else ""
 
-        spec = engine.build_job_spec(
-            run_id=run_id,
-            phase=phase,
-            runner_config=self.runner_config,
-            auth_secret_name=auth_secret_name,
-            vars_secret_name=vars_secret_name,
-            env_vars=env_vars,
-            terraform_vars=terraform_vars,
-            execution_hooks=execution_hooks,
-            git_auth=git_auth,
-            resource_cpu=attrs.get("resource-cpu", "1"),
-            parallelism=attrs.get("parallelism", 10),
-            resource_memory=attrs.get("resource-memory", "2Gi"),
+        # The engine's run options as one typed object (#1407 phase 2), instead of
+        # twenty keyword arguments threaded through a general-purpose builder. The
+        # wire keys are unchanged — this is how they are carried, not what is sent.
+        options = TerraformRunOptions(
             terraform_version=attrs.get("terraform-version", ""),
             execution_backend=attrs.get("execution-backend", "tofu"),
             terragrunt_enabled=attrs.get("terragrunt-enabled", False),
@@ -789,17 +781,33 @@ class RunnerListener:
             refresh=attrs.get("refresh", True),
             allow_empty_apply=attrs.get("allow-empty-apply", False),
             is_destroy=attrs.get("is-destroy", False),
+            parallelism=attrs.get("parallelism", 10),
             # Cost estimation (#871): the API instructs per-run (fallback yes);
             # the listener only relays it, never self-configures.
             cost_estimation=attrs.get("cost-estimation", True),
             cost_default_region=attrs.get("cost-default-region", "us-east-1"),
             working_directory=attrs.get("working-directory", ""),
-            ca_secret_name=ca_secret_name,
             # Onboarding discovery (#824 P2): present only for discovery runs.
             onboard_session_id=attrs.get("onboard-session-id", ""),
             onboard_provider=attrs.get("onboard-provider", ""),
             onboard_provider_version=attrs.get("onboard-provider-version", ""),
             onboard_types=attrs.get("onboard-types", []),
+        )
+
+        spec = engine.build_job_spec(
+            options=options,
+            run_id=run_id,
+            phase=phase,
+            runner_config=self.runner_config,
+            auth_secret_name=auth_secret_name,
+            vars_secret_name=vars_secret_name,
+            env_vars=env_vars,
+            terraform_vars=terraform_vars,
+            execution_hooks=execution_hooks,
+            git_auth=git_auth,
+            resource_cpu=attrs.get("resource-cpu", "1"),
+            resource_memory=attrs.get("resource-memory", "2Gi"),
+            ca_secret_name=ca_secret_name,
         )
 
         namespace = self.runner_config.runner_namespace

--- a/services/tests/runner/job_spec_golden.json
+++ b/services/tests/runner/job_spec_golden.json
@@ -1,0 +1,3163 @@
+{
+  "allow-empty-apply": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "apply",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-apply",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "apply",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "apply"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_ALLOW_EMPTY_APPLY",
+                  "value": "true"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "apply-minimal": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "apply",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-apply",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "apply",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "apply"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "ca-bundle": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "cost-off": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_ESTIMATION",
+                  "value": "false"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "cost-region": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "eu-west-2"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "destroy": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_DESTROY",
+                  "value": "true"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "hooks-and-git-auth": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  },
+                  {
+                    "key": "execution-hooks.json",
+                    "path": "execution-hooks.json"
+                  },
+                  {
+                    "key": "git-auth.json",
+                    "path": "git-auth.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "onboarding": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_ONBOARD_SESSION_ID",
+                  "value": "onb-123"
+                },
+                {
+                  "name": "TP_ONBOARD_PROVIDER",
+                  "value": "aws"
+                },
+                {
+                  "name": "TP_ONBOARD_PROVIDER_VERSION",
+                  "value": "5.60.0"
+                },
+                {
+                  "name": "TP_ONBOARD_TYPES",
+                  "value": "[\"aws_s3_bucket\", \"aws_iam_role\"]"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "plan-minimal": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "plan-only": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PLAN_ONLY",
+                  "value": "true"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "refresh-options": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_REFRESH_ONLY",
+                  "value": "true"
+                },
+                {
+                  "name": "TP_REFRESH",
+                  "value": "false"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "resources-and-parallelism": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "apply",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-apply",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 10800,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "apply",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "apply"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "32"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "8",
+                  "memory": "16Gi"
+                },
+                "requests": {
+                  "cpu": "4",
+                  "memory": "8Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "targeted": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_TARGET_ADDRS",
+                  "value": "[\"aws_s3_bucket.a\", \"aws_s3_bucket.b\"]"
+                },
+                {
+                  "name": "TP_REPLACE_ADDRS",
+                  "value": "[\"aws_instance.c\"]"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "terraform-backend": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.9.8"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "terraform"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "terragrunt": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_TERRAGRUNT_ENABLED",
+                  "value": "true"
+                },
+                {
+                  "name": "TP_TERRAGRUNT_VERSION",
+                  "value": "0.67"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_WORKING_DIR",
+                  "value": "envs/prod"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  },
+  "var-files": {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "runner",
+        "app.kubernetes.io/name": "terrapod-runner",
+        "terrapod.io/phase": "plan",
+        "terrapod.io/run-id": "run-0123456789abcdef"
+      },
+      "name": "tprun-run-0123456789ab-plan",
+      "namespace": "terrapod-runners"
+    },
+    "spec": {
+      "activeDeadlineSeconds": 3600,
+      "backoffLimit": 3,
+      "podFailurePolicy": {
+        "rules": [
+          {
+            "action": "Ignore",
+            "onPodConditions": [
+              {
+                "status": "True",
+                "type": "DisruptionTarget"
+              }
+            ]
+          },
+          {
+            "action": "FailJob",
+            "onExitCodes": {
+              "containerName": "runner",
+              "operator": "NotIn",
+              "values": [
+                0
+              ]
+            }
+          }
+        ]
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app.kubernetes.io/name": "terrapod-runner",
+            "terrapod.io/phase": "plan",
+            "terrapod.io/run-id": "run-0123456789abcdef"
+          }
+        },
+        "spec": {
+          "automountServiceAccountToken": true,
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "HOME",
+                  "value": "/home/runner"
+                },
+                {
+                  "name": "TP_RUN_ID",
+                  "value": "run-0123456789abcdef"
+                },
+                {
+                  "name": "TP_PHASE",
+                  "value": "plan"
+                },
+                {
+                  "name": "TP_API_URL",
+                  "value": "http://terrapod-api:8000"
+                },
+                {
+                  "name": "TP_AUTH_TOKEN",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "token",
+                      "name": "tprun-0123-plan-auth"
+                    }
+                  }
+                },
+                {
+                  "name": "TP_VERSION",
+                  "value": "1.11"
+                },
+                {
+                  "name": "TP_BACKEND",
+                  "value": "tofu"
+                },
+                {
+                  "name": "TP_VERIFY_BINARIES",
+                  "value": "signature"
+                },
+                {
+                  "name": "TP_VAR_FILES",
+                  "value": "[\"common.tfvars\", \"prod.tfvars\"]"
+                },
+                {
+                  "name": "TP_PARALLELISM",
+                  "value": "10"
+                },
+                {
+                  "name": "TP_COST_DEFAULT_REGION",
+                  "value": "us-east-1"
+                },
+                {
+                  "name": "TP_TERMINATION_GRACE",
+                  "value": "120"
+                },
+                {
+                  "name": "TF_LOG",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "key": "TF_LOG",
+                      "name": "tprun-0123-plan-vars"
+                    }
+                  }
+                }
+              ],
+              "image": "ghcr.io/test/runner:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "runner",
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "4Gi"
+                },
+                "requests": {
+                  "cpu": "1",
+                  "memory": "2Gi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "readOnlyRootFilesystem": true,
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace",
+                  "name": "workspace"
+                },
+                {
+                  "mountPath": "/tmp",
+                  "name": "tmp"
+                },
+                {
+                  "mountPath": "/home/runner",
+                  "name": "home"
+                },
+                {
+                  "mountPath": "/var/run/terrapod/vars",
+                  "name": "tfvars",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "imagePullSecrets": [],
+          "restartPolicy": "Never",
+          "serviceAccountName": "terrapod-runner",
+          "terminationGracePeriodSeconds": 120,
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "workspace"
+            },
+            {
+              "emptyDir": {},
+              "name": "tmp"
+            },
+            {
+              "emptyDir": {},
+              "name": "home"
+            },
+            {
+              "name": "tfvars",
+              "secret": {
+                "items": [
+                  {
+                    "key": "terraform.tfvars.json",
+                    "path": "terraform.tfvars.json"
+                  }
+                ],
+                "secretName": "tprun-0123-plan-vars"
+              }
+            }
+          ]
+        }
+      },
+      "ttlSecondsAfterFinished": 300
+    }
+  }
+}

--- a/services/tests/runner/test_job_spec_golden.py
+++ b/services/tests/runner/test_job_spec_golden.py
@@ -1,0 +1,198 @@
+"""The rendered Job spec must not change across the #1488 refactor.
+
+Phase 2 of #1407 rewrites how the Job spec is built — it touches the code path
+behind every plan and every apply. Its failure mode is not a red test: it is a
+Job that launches with a subtly different spec, is accepted by Kubernetes, and
+then runs differently. Unit tests that assert individual fields cannot see that;
+only comparing the whole rendered object can.
+
+So this captures the spec across an option matrix and pins it byte for byte. The
+golden was generated from the code *before* the refactor, which is the only order
+in which such a snapshot means anything — one captured afterwards would enshrine
+whatever the refactor happened to produce, including its bugs.
+
+    UPDATE_JOB_SPEC_GOLDEN=1 pytest tests/runner/test_job_spec_golden.py
+
+Regenerate only when a spec change is *intended*, and say in the commit what
+changed and why. A diff here during a pure refactor is a defect, not a snapshot
+to refresh.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import pathlib
+
+import pytest
+
+from tests.runner.test_job_template import _runner_config
+
+GOLDEN = pathlib.Path(__file__).parent / "job_spec_golden.json"
+
+#: The option combinations worth pinning. Each exercises a branch that produces
+#: different container args, env, volumes or metadata — chosen from the parameter
+#: list rather than by guessing at what matters.
+SCENARIOS: dict[str, dict] = {
+    "plan-minimal": {"phase": "plan"},
+    "apply-minimal": {"phase": "apply"},
+    "plan-only": {"phase": "plan", "plan_only": True},
+    "destroy": {"phase": "plan", "is_destroy": True},
+    "targeted": {
+        "phase": "plan",
+        "target_addrs": ["aws_s3_bucket.a", "aws_s3_bucket.b"],
+        "replace_addrs": ["aws_instance.c"],
+    },
+    "refresh-options": {"phase": "plan", "refresh_only": True, "refresh": False},
+    "allow-empty-apply": {"phase": "apply", "allow_empty_apply": True},
+    "terragrunt": {
+        "phase": "plan",
+        "terragrunt_enabled": True,
+        "terragrunt_version": "0.67",
+        "working_directory": "envs/prod",
+    },
+    "terraform-backend": {
+        "phase": "plan",
+        "execution_backend": "terraform",
+        "terraform_version": "1.9.8",
+    },
+    "var-files": {"phase": "plan", "var_files": ["common.tfvars", "prod.tfvars"]},
+    "resources-and-parallelism": {
+        "phase": "apply",
+        "resource_cpu": "4",
+        "resource_memory": "8Gi",
+        "parallelism": 32,
+        "timeout_minutes": 180,
+    },
+    "cost-off": {"phase": "plan", "cost_estimation": False},
+    "cost-region": {"phase": "plan", "cost_default_region": "eu-west-2"},
+    "hooks-and-git-auth": {
+        "phase": "plan",
+        "execution_hooks": [{"hook_point": "pre_init", "name": "h", "script": "echo hi"}],
+        "git_auth": [
+            {"kind": "git_http_auth", "url_pattern": "github.com", "username": "x", "token": "t"}
+        ],
+    },
+    "ca-bundle": {"phase": "plan", "ca_secret_name": "tp-ca"},
+    # The onboarding path, which #1488 folds in — it is currently four extra
+    # parameters riding along on a general-purpose builder, and its spec must be
+    # identical after they move behind the strategy.
+    "onboarding": {
+        "phase": "plan",
+        "onboard_session_id": "onb-123",
+        "onboard_provider": "aws",
+        "onboard_provider_version": "5.60.0",
+        "onboard_types": ["aws_s3_bucket", "aws_iam_role"],
+    },
+}
+
+#: Values held fixed so a diff can only come from the scenario or the code.
+BASE: dict = {
+    "run_id": "run-0123456789abcdef",
+    "auth_secret_name": "tprun-0123-plan-auth",
+    "vars_secret_name": "tprun-0123-plan-vars",
+    "env_vars": [{"key": "TF_LOG", "value": "INFO"}],
+    "terraform_vars": [{"key": "region", "value": "eu-west-1", "hcl": False}],
+    "namespace": "terrapod-runners",
+}
+
+
+def _cfg():
+    """The shared mock, with the last few attributes pinned to real values.
+
+    `_runner_config()` leaves these three unset, so they render as MagicMock
+    reprs — which embed a memory address and therefore differ on every run. A
+    golden built from that would fail immediately and for the wrong reason.
+    Pinned here rather than in the shared helper, so no existing test changes
+    behaviour because of this file.
+    """
+    cfg = _runner_config()
+    cfg.service_account_name = "terrapod-runner"
+    cfg.termination_grace_period_seconds = 120
+    cfg.extra_env_from = []
+    return cfg
+
+
+def _render(name: str) -> dict:
+    """Render one scenario through the path production uses.
+
+    After #1488 that is the strategy: it owns the run options and composes the
+    neutral builder. The *inputs* are expressed differently from before the
+    refactor; the rendered spec must be byte-identical, which is the whole point
+    of the golden.
+    """
+    from terrapod.engines.terraform import TerraformRunOptions, TerraformStrategy
+
+    scenario = dict(SCENARIOS[name])
+    option_fields = {f.name for f in dataclasses.fields(TerraformRunOptions)}
+    options = TerraformRunOptions(**{k: v for k, v in scenario.items() if k in option_fields})
+    neutral = dict(BASE)
+    neutral.update({k: v for k, v in scenario.items() if k not in option_fields})
+    return TerraformStrategy().build_job_spec(options=options, runner_config=_cfg(), **neutral)
+
+
+def _render_all() -> dict[str, dict]:
+    return {name: _render(name) for name in sorted(SCENARIOS)}
+
+
+def test_rendered_job_specs_are_unchanged():
+    current = _render_all()
+
+    if os.environ.get("UPDATE_JOB_SPEC_GOLDEN"):
+        GOLDEN.write_text(json.dumps(current, indent=2, sort_keys=True, default=str) + "\n")
+        pytest.skip("golden regenerated")
+
+    assert GOLDEN.exists(), (
+        "no golden spec recorded — generate it from the PRE-refactor code with "
+        "UPDATE_JOB_SPEC_GOLDEN=1, or it pins nothing"
+    )
+    expected = json.loads(GOLDEN.read_text())
+
+    # Compare per scenario: a single whole-dict assertion prints an unreadable
+    # diff across sixteen Job specs, and the first difference is the one worth
+    # seeing.
+    for name in sorted(SCENARIOS):
+        got = json.loads(json.dumps(current[name], sort_keys=True, default=str))
+        assert got == expected.get(name), (
+            f"the rendered Job spec for {name!r} changed.\n"
+            "During a pure refactor this is a defect, not a snapshot to refresh — "
+            "the spec is what Kubernetes runs, and a difference here is a "
+            "difference in what executes against real infrastructure."
+        )
+
+
+def test_the_matrix_covers_every_option():
+    """A scenario set that misses an option pins nothing about it.
+
+    Checked against the real definitions rather than trusted to be complete: the
+    value of the golden is that the refactor cannot quietly change a branch
+    nobody exercised, and after #1488 the options live on the dataclass while the
+    neutral parameters stay on the builder — so both are checked.
+    """
+    import ast
+
+    from terrapod.engines.terraform import TerraformRunOptions
+
+    src = pathlib.Path(__file__).resolve().parents[2] / "terrapod/runner/job_template.py"
+    tree = ast.parse(src.read_text())
+    fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "build_job_spec")
+    builder_optional = {
+        a.arg
+        for a, d in zip(
+            fn.args.args,
+            [None] * (len(fn.args.args) - len(fn.args.defaults)) + list(fn.args.defaults),
+            strict=True,
+        )
+        if d is not None
+    }
+    # `engine_env` is what the strategy passes in, not a knob a scenario sets.
+    builder_optional.discard("engine_env")
+    option_fields = {f.name for f in dataclasses.fields(TerraformRunOptions)}
+
+    exercised = {k for s in SCENARIOS.values() for k in s} | set(BASE)
+    missing = sorted((builder_optional | option_fields) - exercised)
+    assert not missing, (
+        "these options are never varied by the matrix, so the golden says nothing "
+        f"about them: {missing}"
+    )

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -48,16 +48,18 @@ def _runner_config():
 class TestVarFilesInjection:
     def test_var_files_env_var_set(self):
         """TP_VAR_FILES should be set when var_files is provided."""
-        from terrapod.runner.job_template import build_job_spec
+        from terrapod.engines.terraform import TerraformRunOptions, TerraformStrategy
 
-        spec = build_job_spec(
+        spec = TerraformStrategy().build_job_spec(
+            options=TerraformRunOptions(
+                var_files=["envs/dev.tfvars", "secrets.tfvars"],
+            ),
             run_id="abc123",
             phase="plan",
             runner_config=_runner_config(),
             auth_secret_name="tprun-abc12345-auth",
             env_vars=[],
             terraform_vars=[],
-            var_files=["envs/dev.tfvars", "secrets.tfvars"],
         )
 
         container = spec["spec"]["template"]["spec"]["containers"][0]
@@ -68,16 +70,18 @@ class TestVarFilesInjection:
 
     def test_no_var_files_env_var_when_empty(self):
         """TP_VAR_FILES should NOT be set when var_files is empty."""
-        from terrapod.runner.job_template import build_job_spec
+        from terrapod.engines.terraform import TerraformRunOptions, TerraformStrategy
 
-        spec = build_job_spec(
+        spec = TerraformStrategy().build_job_spec(
+            options=TerraformRunOptions(
+                var_files=[],
+            ),
             run_id="abc123",
             phase="plan",
             runner_config=_runner_config(),
             auth_secret_name="tprun-abc12345-auth",
             env_vars=[],
             terraform_vars=[],
-            var_files=[],
         )
 
         container = spec["spec"]["template"]["spec"]["containers"][0]
@@ -86,16 +90,18 @@ class TestVarFilesInjection:
 
     def test_no_var_files_env_var_when_none(self):
         """TP_VAR_FILES should NOT be set when var_files is None."""
-        from terrapod.runner.job_template import build_job_spec
+        from terrapod.engines.terraform import TerraformRunOptions, TerraformStrategy
 
-        spec = build_job_spec(
+        spec = TerraformStrategy().build_job_spec(
+            options=TerraformRunOptions(
+                var_files=None,
+            ),
             run_id="abc123",
             phase="plan",
             runner_config=_runner_config(),
             auth_secret_name="tprun-abc12345-auth",
             env_vars=[],
             terraform_vars=[],
-            var_files=None,
         )
 
         container = spec["spec"]["template"]["spec"]["containers"][0]
@@ -570,16 +576,27 @@ class TestCostEstimationEnv:
     """#871 — the API's per-run cost instruction reaches the Job env."""
 
     def _spec_env(self, **kw):
-        from terrapod.runner.job_template import build_job_spec
+        """Render through the strategy, splitting run options from neutral args.
 
-        spec = build_job_spec(
+        Cost estimation is an engine option after #1488, so it reaches the spec
+        via `TerraformRunOptions` rather than as a builder parameter. The split is
+        done from the dataclass's own fields so this helper cannot drift from it.
+        """
+        import dataclasses
+
+        from terrapod.engines.terraform import TerraformRunOptions, TerraformStrategy
+
+        fields = {f.name for f in dataclasses.fields(TerraformRunOptions)}
+        options = TerraformRunOptions(**{k: v for k, v in kw.items() if k in fields})
+        spec = TerraformStrategy().build_job_spec(
+            options=options,
             run_id="abc123",
             phase="plan",
             runner_config=_runner_config(),
             auth_secret_name="tprun-abc12345-auth",
             env_vars=[],
             terraform_vars=[],
-            **kw,
+            **{k: v for k, v in kw.items() if k not in fields},
         )
         container = spec["spec"]["template"]["spec"]["containers"][0]
         return {e["name"]: e.get("value") for e in container["env"] if "value" in e}


### PR DESCRIPTION
#1407 phase 2, on top of #1487. No behaviour change. `make test`: **5330 passed**.

`build_job_spec` goes from **34 parameters to 15**. The twenty run options — the Terraform CLI flags, terragrunt, cost estimation, parallelism, and the four `onboard_*` that were riding along on a general-purpose builder — now live on a frozen `TerraformRunOptions` behind `TerraformStrategy`. What remains is genuinely engine-neutral: identity, config, secrets, resources, timeout, namespace.

Everything moved is Terraform's, **including the parts that look generic**: `TP_VERIFY_BINARIES` and `TP_SIGNING_KEY_*` verify the terraform/tofu/terragrunt binaries specifically, and `TP_COST_*` prices a terraform plan. A second engine now gets its own translation beside this one rather than another branch inside a shared signature.

## Moved verbatim, spliced back in place

The env-building block was **transplanted, not rewritten**: only the accumulator name and the indent changed, with the options rebound as locals at the top precisely so the moved lines could stay identical. For a refactor whose failure mode is a Job that launches with a subtly different spec, a change you can read as "unchanged" beats one you have to re-derive.

It is spliced back at exactly the position it occupied, so the rendered env **order** is unchanged — not merely the values.

## How "no behaviour change" is actually proved

A golden matrix of **16 rendered Job specs, captured from the code *before* the refactor**. That ordering is the whole point — a golden captured afterwards enshrines whatever the refactor produced, bugs included. All 16 are byte-identical after.

A companion test parses the real signature *and* the dataclass fields, failing if any option is never varied, so the matrix cannot quietly stop covering a branch.

Building it turned up two things that would have made it worthless: the render was **non-deterministic** (three `RunnerConfig` attributes are left unset by the shared mock and render as MagicMock reprs embedding a memory address), and the matrix needed checking against the signature rather than being trusted.

The **wire contract is byte-identical** — verified by diffing before against after, not by regenerating it.

## Live verification

A real plan and a real apply on the Tilt stack — the check CI cannot substitute for, since a spec can be well-formed enough for the API server to accept and still make the kubelet run something different.

```
random_string.smoke: Creation complete after 0s [id=ErrLpY1MeGLM]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Run reached `applied`, state serial 1. And the live Job object confirmed the splice:

```
TP_RUN_ID, TP_PHASE, TP_API_URL, TP_AUTH_TOKEN, TP_PUBLIC_API_URL,      ← neutral
TP_VERSION, TP_BACKEND, TP_VERIFY_BINARIES, TP_PARALLELISM, TP_COST_…,  ← engine block
TP_TERMINATION_GRACE                                                     ← neutral
```

— exactly the order it had before the refactor.

## Incidental

`json` and `settings` became unused imports in `job_template.py`, which is a useful confirmation that the engine-specific code fully left the builder rather than partially.

The five tests that broke were asserting on options that moved; they now exercise the strategy, where that logic lives.

Closes #1488
