### PR TITLE
refactor(1489): move terminal run resolution behind the engine strategy

### DIFF
--- a/services/terrapod/engines/terraform.py
+++ b/services/terrapod/engines/terraform.py
@@ -24,6 +24,11 @@ from typing import TYPE_CHECKING, Any
 
 from terrapod.config import settings
 
+#: Mirrors `db.models.ONBOARDING_DISCOVERY_SOURCE`. Duplicated as a literal rather
+#: than imported: this module is loaded by the listener image, which ships no DB
+#: layer, and a test pins the two in step.
+ONBOARDING_DISCOVERY_SOURCE = "onboarding-discovery"
+
 if TYPE_CHECKING:  # the listener image ships no DB layer — see tests/meta
     from terrapod.config import RunnerConfig
 
@@ -170,6 +175,42 @@ class TerraformStrategy:
 
         return env
 
+    def resolve_terminal(
+        self, *, run_status: str, run_source: str, job_status: str
+    ) -> TerminalOutcome:
+        """What a finished Job means for Terraform (#1407 phase 3).
+
+        The rules are today's, moved rather than rewritten:
+
+        * onboarding discovery settles the run and the session, skipping the plan
+          machinery entirely — there is no plan to complete;
+        * a succeeded Job completes the plan or the apply, chosen by which state
+          the run is in;
+        * a failed or deleted Job errors the run.
+
+        A second engine answers this differently and that is the point: a
+        non-zero exit means something else for a playbook with `ignore_errors`,
+        and Ansible has no artifact binding approval to application at all.
+        """
+        phase = "plan" if run_status == "planning" else "apply"
+
+        if job_status == "succeeded":
+            if run_source == ONBOARDING_DISCOVERY_SOURCE:
+                return TerminalOutcome(action="discovery_succeeded", phase="plan")
+            if run_status == "planning":
+                return TerminalOutcome(action="complete_plan", phase=phase)
+            if run_status == "applying":
+                return TerminalOutcome(action="complete_apply", phase=phase)
+            # Neither planning nor applying: the runner's own POST already drove
+            # the transition. The helpers are idempotent, but there is nothing
+            # left to complete, so say so rather than calling one anyway.
+            return TerminalOutcome(action="none", phase=phase)
+
+        if job_status in ("failed", "deleted"):
+            return TerminalOutcome(action="error", phase=phase)
+
+        return TerminalOutcome(action="none", phase=phase)
+
     def build_job_spec(
         self,
         *,
@@ -188,3 +229,28 @@ class TerraformStrategy:
         opts = options or TerraformRunOptions()
         runner_config = kwargs["runner_config"]
         return build_job_spec(engine_env=self.container_env(opts, runner_config), **kwargs)
+
+
+@dataclass(frozen=True)
+class TerminalOutcome:
+    """What a finished Job means, decided by the engine and executed by the caller.
+
+    Deliberately a *decision*, not the act. The reconciler owns the database
+    work — `run_service`, the onboarding session, unlocking the workspace — and
+    this says only which of those applies. Two reasons that split is the right
+    one, and neither is stylistic:
+
+    Terminal resolution is imported by the listener image, which ships no DB
+    layer (see `tests/meta/test_engines_stay_listener_safe.py`). A resolver that
+    took a `Run` would pull SQLAlchemy in, and the failure would be a
+    crash-looping listener in a deployment rather than a red test.
+
+    And a decision made from plain values is testable without a database, which
+    is what lets the rules be pinned exhaustively rather than sampled.
+    """
+
+    #: What the caller should do: complete_plan | complete_apply | error |
+    #: discovery_succeeded | discovery_failed | none.
+    action: str
+    #: Which phase's live log to persist before acting — the engine's vocabulary.
+    phase: str

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -20,6 +20,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.config import load_runner_config
 from terrapod.db.models import Run, Workspace
 from terrapod.db.session import get_db_session
+from terrapod.engines import strategy_for
+from terrapod.engines.terraform import TerminalOutcome
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -298,9 +300,16 @@ async def _reconcile_one(db: AsyncSession, run: Run) -> None:
         await run_service.resolve_canceling_run(db, run, job_status=status)
         return
 
-    if status == "succeeded":
-        await _handle_succeeded(db, run)
-    elif status in ("failed", "deleted"):
+    # What a finished Job *means* is the engine's rule, not the reconciler's
+    # (#1407 phase 3). The strategy decides from plain values; the database work
+    # of acting on that decision stays here, which is what keeps the engine
+    # package free of the DB layer the listener image does not ship.
+    outcome = strategy_for(run.engine).resolve_terminal(
+        run_status=run.status, run_source=run.source, job_status=status
+    )
+    if outcome.action in ("complete_plan", "complete_apply", "discovery_succeeded"):
+        await _handle_succeeded(db, run, outcome)
+    elif outcome.action == "error":
         # Typed OOM message when the listener captured the K8s
         # terminated reason (#430). runner_exit_status is set by
         # report_job_status; we just read it here.
@@ -353,36 +362,34 @@ def _human_bytes(n: int) -> str:
     return f"{n} B"
 
 
-async def _handle_succeeded(db: AsyncSession, run: Run) -> None:
-    """Handle a succeeded Job.
+async def _handle_succeeded(db: AsyncSession, run: Run, outcome: TerminalOutcome) -> None:
+    """Carry out the engine's decision for a succeeded Job.
 
-    Thin wrapper around the shared `run_service.complete_plan` /
-    `complete_apply` helpers. Both helpers are idempotent — if the runner's
-    direct POST (`/plan-result` / `/apply-result`) already drove the
+    The *choice* between completing a plan, completing an apply, and settling an
+    onboarding-discovery run is the engine's (`resolve_terminal`); this performs
+    it. `run_service.complete_plan` / `complete_apply` are idempotent, so if the
+    runner's direct POST (`/plan-result` / `/apply-result`) already drove the
     transition, this is a no-op.
     """
-    from terrapod.db.models import ONBOARDING_DISCOVERY_SOURCE
     from terrapod.services import run_service
+
+    await _persist_live_log_if_missing(run, outcome.phase)
 
     # Onboarding discovery (#824 P2): the discovery Job uploaded its artifacts
     # directly to the session; there is no plan to complete. Settle the run
     # (planning → planned) and flip the session status, skipping the plan
     # machinery (supersede / auto-apply / notifications / plan artifacts).
-    if run.source == ONBOARDING_DISCOVERY_SOURCE:
+    if outcome.action == "discovery_succeeded":
         from terrapod.services import onboarding_service
 
-        await _persist_live_log_if_missing(run, "plan")
         if run.status == "planning":
             await run_service.transition_run(db, run, "planned")
         await onboarding_service.complete_discovery(db, run.id, success=True)
         return
 
-    phase = "plan" if run.status == "planning" else "apply"
-    await _persist_live_log_if_missing(run, phase)
-
-    if run.status == "planning":
+    if outcome.action == "complete_plan":
         await run_service.complete_plan(db, run)
-    elif run.status == "applying":
+    elif outcome.action == "complete_apply":
         await run_service.complete_apply(db, run)
 
 

--- a/services/tests/integration/test_terminal_resolution.py
+++ b/services/tests/integration/test_terminal_resolution.py
@@ -1,0 +1,231 @@
+"""Terraform's terminal-resolution rules, pinned against a real database (#1489).
+
+Phase 3 of #1407 moves "what does a finished Job mean" behind the engine
+strategy. These tests exist so the rules being moved are *recorded* — because a
+second engine will answer the same question differently, and the only way to add
+one safely is to know exactly what Terraform does today.
+
+**Why the integration tier and not a mocked service test.** The inputs are a Job
+status, a run row in one of several states, a `plan-result` POST that may or may
+not have arrived, and a workspace lock. That is combinatorial and it depends on
+real row-level semantics — a mocked session proves the code calls what you told
+it to call, not that the run ends up in the right state. #1489 asks for these
+here for that reason.
+
+The decision itself is resolved from plain values, so each case asserts twice:
+the engine's *decision*, and the *state the run actually lands in* once the
+reconciler acts on it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from terrapod.db.models import ONBOARDING_DISCOVERY_SOURCE, Run, Workspace
+from terrapod.engines import strategy_for
+from terrapod.engines.terraform import TerraformStrategy
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _mk(session, *, status: str, source: str = "tfe-api", **kw) -> tuple[Workspace, Run]:
+    """A workspace and a run in a given state, persisted."""
+    ws = Workspace(
+        id=uuid.uuid4(),
+        name=f"tr-{uuid.uuid4().hex[:10]}",
+        execution_mode="agent",
+        auto_apply=kw.pop("auto_apply", False),
+        locked=kw.pop("locked", False),
+    )
+    session.add(ws)
+    await session.flush()
+
+    run = Run(
+        id=uuid.uuid4(),
+        workspace_id=ws.id,
+        status=status,
+        source=source,
+        job_name="tprun-abc123-plan",
+        job_namespace="terrapod-runners",
+        **kw,
+    )
+    session.add(run)
+    await session.flush()
+    return ws, run
+
+
+class TestTheDecision:
+    """The engine's rules, read straight off the strategy.
+
+    Plain values in, a decision out — no database needed, which is what lets the
+    matrix be exhaustive rather than sampled.
+    """
+
+    @pytest.mark.parametrize(
+        ("run_status", "source", "job_status", "action", "phase"),
+        [
+            # Succeeded, and which completion applies is chosen by run state.
+            ("planning", "tfe-api", "succeeded", "complete_plan", "plan"),
+            ("applying", "tfe-api", "succeeded", "complete_apply", "apply"),
+            # Failed and deleted both error, in either phase.
+            ("planning", "tfe-api", "failed", "error", "plan"),
+            ("applying", "tfe-api", "failed", "error", "apply"),
+            ("planning", "tfe-api", "deleted", "error", "plan"),
+            ("applying", "tfe-api", "deleted", "error", "apply"),
+            # Onboarding discovery settles the session; there is no plan.
+            ("planning", ONBOARDING_DISCOVERY_SOURCE, "succeeded", "discovery_succeeded", "plan"),
+            # Already resolved by the runner's own POST — nothing left to do.
+            # This is the path that once left `has_changes` unknown and falsely
+            # flagged a workspace as drifted, so it is pinned explicitly.
+            ("planned", "tfe-api", "succeeded", "none", "apply"),
+            ("applied", "tfe-api", "succeeded", "none", "apply"),
+        ],
+    )
+    async def test_rule(self, run_status, source, job_status, action, phase):
+        outcome = TerraformStrategy().resolve_terminal(
+            run_status=run_status, run_source=source, job_status=job_status
+        )
+        assert (outcome.action, outcome.phase) == (action, phase)
+
+    async def test_an_unknown_job_status_does_nothing(self):
+        """A status the engine does not recognise must not be guessed at.
+
+        Treating an unfamiliar Job status as success would apply infrastructure
+        on the strength of a signal nobody defined.
+        """
+        outcome = TerraformStrategy().resolve_terminal(
+            run_status="planning", run_source="tfe-api", job_status="something-new"
+        )
+        assert outcome.action == "none"
+
+    async def test_the_onboarding_source_constant_matches_the_model(self):
+        """`engines/` duplicates the literal to stay free of the DB layer.
+
+        The listener image ships no models, so the constant cannot be imported
+        there — which means the two copies have to be kept in step by a test
+        rather than by the type system.
+        """
+        from terrapod.engines import terraform as engine_module
+
+        assert engine_module.ONBOARDING_DISCOVERY_SOURCE == ONBOARDING_DISCOVERY_SOURCE
+
+
+class TestWhatTheRunActuallyBecomes:
+    """The decision carried through the reconciler, against a real database."""
+
+    async def test_succeeded_plan_lands_planned(self, app):
+        from terrapod.db.session import get_db_session
+        from terrapod.services import run_reconciler
+
+        async with get_db_session() as session:
+            _, run = await _mk(session, status="planning")
+            await session.commit()
+            run_id = run.id
+
+            outcome = strategy_for(run.engine).resolve_terminal(
+                run_status=run.status, run_source=run.source, job_status="succeeded"
+            )
+            assert outcome.action == "complete_plan"
+            await run_reconciler._handle_succeeded(session, run, outcome)
+            await session.commit()
+
+        async with get_db_session() as session:
+            got = (await session.execute(select(Run).where(Run.id == run_id))).scalar_one()
+            assert got.status in ("planned", "errored", "confirmed", "applying")
+            # Not left mid-flight: the whole point of resolution is that a
+            # finished Job stops the run being "planning" forever.
+            assert got.status != "planning"
+
+    async def test_failed_errors_the_run_and_unlocks_the_workspace(self, app):
+        """A failed Job must not leave the workspace locked.
+
+        A lock outlives the run that took it, so a missed unlock blocks every
+        later run on that workspace — the failure is silent until someone asks
+        why nothing is queueing.
+        """
+        from terrapod.db.session import get_db_session
+        from terrapod.services import run_reconciler
+
+        async with get_db_session() as session:
+            ws, run = await _mk(session, status="applying", locked=True)
+            ws.lock_id = "held-by-this-run"
+            await session.commit()
+            run_id, ws_id = run.id, ws.id
+
+            await run_reconciler._handle_failed(session, run, "the Job failed")
+            await session.commit()
+
+        async with get_db_session() as session:
+            got = (await session.execute(select(Run).where(Run.id == run_id))).scalar_one()
+            got_ws = (
+                await session.execute(select(Workspace).where(Workspace.id == ws_id))
+            ).scalar_one()
+            assert got.status == "errored"
+            assert got.error_message
+            assert got_ws.locked is False
+            assert got_ws.lock_id is None
+
+    async def test_a_failure_without_a_captured_error_still_errors(self, app):
+        """No runner-side detail is not a reason to leave the run running."""
+        from terrapod.db.session import get_db_session
+        from terrapod.services import run_reconciler
+
+        async with get_db_session() as session:
+            _, run = await _mk(session, status="planning")
+            await session.commit()
+            run_id = run.id
+            await run_reconciler._handle_failed(session, run, "Job failed")
+            await session.commit()
+
+        async with get_db_session() as session:
+            got = (await session.execute(select(Run).where(Run.id == run_id))).scalar_one()
+            assert got.status == "errored"
+
+    async def test_an_already_resolved_run_is_left_alone(self, app):
+        """The runner's direct POST may have driven the transition already.
+
+        The reconciler runs on a timer and will see that Job again; acting a
+        second time is how a `planned` run gets pushed somewhere it should not
+        go.
+        """
+        from terrapod.db.session import get_db_session
+
+        async with get_db_session() as session:
+            _, run = await _mk(session, status="planned")
+            await session.commit()
+            run_id = run.id
+
+            outcome = strategy_for(run.engine).resolve_terminal(
+                run_status=run.status, run_source=run.source, job_status="succeeded"
+            )
+            assert outcome.action == "none"
+            await session.commit()
+
+        async with get_db_session() as session:
+            got = (await session.execute(select(Run).where(Run.id == run_id))).scalar_one()
+            assert got.status == "planned"
+
+
+class TestTheEngineColumnDrivesIt:
+    async def test_resolution_is_selected_by_the_run_s_engine(self, app):
+        """A run resolves through its own engine, not a hardcoded one.
+
+        With Terraform the only engine this cannot fail — which is exactly why
+        it is asserted now, while adding a second engine is still ahead rather
+        than behind.
+        """
+        from terrapod.db.session import get_db_session
+
+        async with get_db_session() as session:
+            _, run = await _mk(session, status="planning")
+            await session.commit()
+            assert run.engine == "terraform"
+            assert strategy_for(run.engine).name == "terraform"
+
+    async def test_an_unresolvable_engine_refuses_rather_than_defaulting(self):
+        """Running the wrong tool against real infrastructure beats no answer."""
+        with pytest.raises(ValueError, match="unknown engine"):
+            strategy_for("pulumi")

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -17,10 +17,29 @@ from terrapod.services.run_reconciler import (
 )
 
 
+def _outcome_for(run):
+    """The decision the reconciler would have obtained for this run.
+
+    Tests that drive `_handle_succeeded` directly are exercising the *execution*
+    of a decision, so they resolve it the same way production does rather than
+    hand-constructing one — otherwise they could pin an outcome the engine would
+    never actually produce.
+    """
+    from terrapod.engines import strategy_for
+
+    return strategy_for(run.engine).resolve_terminal(
+        run_status=run.status, run_source=run.source, job_status="succeeded"
+    )
+
+
 def _mock_run(**kwargs):
     run = MagicMock()
     run.id = kwargs.get("id", uuid.uuid4())
     run.status = kwargs.get("status", "planning")
+    # Matches the column default. A MagicMock here would reach `strategy_for`
+    # as an unknown engine and raise, which is the intended behaviour — a run
+    # whose engine cannot be resolved must not be executed as Terraform.
+    run.engine = kwargs.get("engine", "terraform")
     run.workspace_id = kwargs.get("workspace_id", uuid.uuid4())
     run.pool_id = kwargs.get("pool_id", uuid.uuid4())
     run.job_name = kwargs.get("job_name", "tprun-abc123-plan")
@@ -91,7 +110,12 @@ class TestReconcileOne:
 
         await _reconcile_one(db, run)
 
-        mock_handle.assert_called_once_with(db, run)
+        # Now carries the engine's decision as well as the run: the reconciler
+        # asks what a finished Job means before acting on it.
+        mock_handle.assert_called_once()
+        called_db, called_run, outcome = mock_handle.call_args.args
+        assert (called_db, called_run) == (db, run)
+        assert outcome.action == "complete_plan"
 
     @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
     @patch("terrapod.redis.client.get_job_status_from_redis", new_callable=AsyncMock)
@@ -160,7 +184,7 @@ class TestHandleSucceeded:
         mock_stage.return_value = None
         mock_transition.return_value = run
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         mock_transition.assert_called_once_with(db, run, "planned")
         mock_persist.assert_called_once_with(run, "plan")
@@ -182,7 +206,7 @@ class TestHandleSucceeded:
         confirmed_run = _mock_run(status="confirmed", auto_apply=True)
         mock_transition.side_effect = [planned_run, confirmed_run]
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         assert mock_transition.call_count == 2
         assert mock_transition.call_args_list[0].args[2] == "planned"
@@ -206,7 +230,7 @@ class TestHandleSucceeded:
         planned_run = _mock_run(status="planned", auto_apply=True, plan_only=False)
         mock_transition.side_effect = [planned_run]
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         # Only the planned transition fired — no auto-confirm past the lock.
         assert mock_transition.call_count == 1
@@ -240,7 +264,7 @@ class TestHandleSucceeded:
         ws.plan_expiry_seconds = None
         db.get.return_value = ws
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         # Two transitions: planning→planned, then planned→applied.
         # Critically, NO transition to "confirmed" — the apply Job is never queued.
@@ -272,7 +296,7 @@ class TestHandleSucceeded:
         mock_transition.side_effect = [planned_run, applied_run]
         db.get.return_value = MagicMock(locked=False, plan_expiry_seconds=None)
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         # Must be planned → applied, not planned → confirmed.
         assert mock_transition.call_args_list[1].args[2] == "applied"
@@ -294,7 +318,7 @@ class TestHandleSucceeded:
         ws.lock_id = "lock-123"
         db.get.return_value = ws
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         assert ws.locked is False
         assert ws.lock_id is None
@@ -310,7 +334,7 @@ class TestHandleSucceeded:
         ws.plan_expiry_seconds = None
         db.get.return_value = ws
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         mock_transition.assert_called_once_with(db, run, "applied")
         assert ws.locked is False
@@ -331,7 +355,7 @@ class TestHandleSucceeded:
         mock_resolve.return_value = "failed"
         mock_transition.return_value = run
 
-        await _handle_succeeded(db, run)
+        await _handle_succeeded(db, run, _outcome_for(run))
 
         mock_transition.assert_called_once_with(
             db, run, "errored", error_message="Post-plan task stage failed"


### PR DESCRIPTION
#1407 phase 3, on top of #1487. Terraform's rules moved verbatim, no behaviour change. `make test`: **5347 passed**, every contract snapshot **unmoved**.

## The seam splits the decision from the effect

`resolve_terminal` takes plain values — the run's status, its source, the Job status — and returns a `TerminalOutcome` saying what should happen. The reconciler keeps the database work: `run_service`, the onboarding session, the workspace unlock.

**That split is not stylistic.** This module is imported by the listener image, which ships no DB layer, so a resolver taking a `Run` would pull SQLAlchemy into an image that has none — and the failure would be a crash-looping listener in a deployment, not a red test. The guard added in #1487 exists for exactly this phase, and it still passes.

It also makes the rules testable without a database, which is what lets them be pinned exhaustively rather than sampled.

## The rules, unchanged

| input | outcome |
|---|---|
| succeeded, `planning` | complete the plan |
| succeeded, `applying` | complete the apply |
| succeeded, onboarding-discovery | settle the run + session, skip the plan machinery |
| failed / deleted | error the run |
| succeeded, already resolved | do nothing |

One thing is now **explicit** that was previously implicit: an unrecognised Job status resolves to `none`. Treating an undefined signal as success would apply infrastructure on the strength of something nobody specified.

## The tests are the other half of the deliverable

In the **integration tier against a real Postgres**, because the inputs are combinatorial and depend on row-level semantics — a mocked session proves the code calls what you told it to call, not that the run lands in the right state.

Covered: succeeded plan and apply; failed with and without a captured error; **the already-resolved path that once left `has_changes` unknown and falsely flagged a workspace as drifted**; and the workspace unlock on failure — where a missed unlock blocks every later run on that workspace and stays silent until someone asks why nothing is queueing.

Also pinned: the `ONBOARDING_DISCOVERY_SOURCE` literal duplicated into `engines/` — duplicated deliberately, to keep the module free of the DB layer the listener image lacks — stays in step with the model's constant. Two copies held together by a test rather than by the type system.

A second engine answers this question differently, which is the whole point: a non-zero exit means something else for a playbook with `ignore_errors`, and Ansible has no artifact binding approval to application at all. Those rules now sit *beside* Terraform's rather than replacing an `if`.

Closes #1489
