### PR TITLE
feat(1523): register PulumiStrategy and wire the Pulumi runner Job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1137,6 +1137,11 @@ jobs:
           off=$(helm template ./helm/terrapod --set api.config.engines.pulumi.enabled=false)
           echo "$off" | grep -qE "pulumi:\s*$" || { echo "FAIL: engines.pulumi block missing when disabled (#1522)"; exit 1; }
           echo "$off" | grep -q "enabled: false" || { echo "FAIL: engines.pulumi.enabled=false did not render (#1522)"; exit 1; }
+          # The Pulumi CLI is a platform tool, not a baked-in binary (#1523): a
+          # Terraform-only deployment should not carry another engine's binary, and
+          # a missing render line leaves the version inert with the code default
+          # silently winning.
+          echo "$out" | grep -q "pulumi_version:" || { echo "FAIL: platform_tools.pulumi_version not rendered (#1523)"; exit 1; }
           # Platform tools (#1208): opa/trivy/checkov are no longer baked into the
           # images, so these versions are the ONLY thing telling a runner what to
           # fetch. A missing render line leaves the value inert and the code default

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -344,6 +344,12 @@ data:
         {{- end }}
         {{- if .Values.api.config.registry.platform_tools.checkov_version }}
         checkov_version: {{ .Values.api.config.registry.platform_tools.checkov_version | quote }}
+        {{- if .Values.api.config.registry.platform_tools.pulumi_version }}
+        pulumi_version: {{ .Values.api.config.registry.platform_tools.pulumi_version | quote }}
+        {{- end }}
+        {{- if .Values.api.config.registry.platform_tools.pulumi_mirror_url }}
+        pulumi_mirror_url: {{ .Values.api.config.registry.platform_tools.pulumi_mirror_url | quote }}
+        {{- end }}
         {{- end }}
         {{- if .Values.api.config.registry.platform_tools.opa_mirror_url }}
         opa_mirror_url: {{ .Values.api.config.registry.platform_tools.opa_mirror_url | quote }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -1710,12 +1710,20 @@
             "ansible": {
               "type": "object",
               "additionalProperties": false,
-              "properties": { "enabled": { "type": "boolean" } }
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
             },
             "pulumi": {
               "type": "object",
               "additionalProperties": false,
-              "properties": { "enabled": { "type": "boolean" } }
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         },
@@ -1854,6 +1862,12 @@
                     "off",
                     "checksum"
                   ]
+                },
+                "pulumi_version": {
+                  "type": "string"
+                },
+                "pulumi_mirror_url": {
+                  "type": "string"
                 }
               }
             },
@@ -1870,53 +1884,85 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "enabled": { "type": "boolean" },
+                "enabled": {
+                  "type": "boolean"
+                },
                 "pypi": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "enabled": { "type": "boolean" },
-                    "upstream": { "type": "string", "format": "uri" }
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "upstream": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 },
                 "npm": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "enabled": { "type": "boolean" },
-                    "upstream": { "type": "string", "format": "uri" }
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "upstream": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 },
                 "pulumi": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "enabled": { "type": "boolean" },
-                    "upstream": { "type": "string", "format": "uri" }
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "upstream": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 },
                 "go": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "enabled": { "type": "boolean" },
-                    "upstream": { "type": "string", "format": "uri" }
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "upstream": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 },
                 "nuget": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "enabled": { "type": "boolean" },
-                    "upstream": { "type": "string", "format": "uri" }
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "upstream": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 },
                 "galaxy": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "enabled": { "type": "boolean" },
-                    "upstream": { "type": "string", "format": "uri" }
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "upstream": {
+                      "type": "string",
+                      "format": "uri"
+                    }
                   }
                 }
               }
@@ -1936,8 +1982,13 @@
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "enabled": { "type": "boolean" },
-                    "grace_hours": { "type": "integer", "minimum": 1 }
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "grace_hours": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
                   }
                 },
                 "mirror_tag_ttl_hours": {

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -505,9 +505,14 @@ api:
         opa_version: "1.20.1"
         trivy_version: "0.74.0"
         checkov_version: "3.3.16"
+        # Pulumi CLI for engine=pulumi runs (#1523). Fetched on demand like the
+        # tools above rather than baked in, so a Terraform-only deployment does
+        # not carry another engine's binary.
+        pulumi_version: "3.208.0"
         opa_mirror_url: "https://github.com/open-policy-agent/opa/releases/download"
         trivy_mirror_url: "https://github.com/aquasecurity/trivy/releases/download"
         checkov_mirror_url: "https://github.com/bridgecrewio/checkov/releases/download"
+        pulumi_mirror_url: "https://github.com/pulumi/pulumi/releases/download"
         # Checkov publishes NO checksum file next to its release assets, so the
         # only verification material available is the digest the GitHub release
         # API reports — registry-computed, not a publisher attestation, and

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -594,7 +594,9 @@ class WarmBinaryEntry(BaseModel):
     just {tool, version}.
     """
 
-    tool: Literal["terraform", "tofu", "terragrunt", "opa", "trivy", "checkov"] = "terraform"
+    tool: Literal["terraform", "tofu", "terragrunt", "opa", "trivy", "checkov", "pulumi"] = (
+        "terraform"
+    )
     version: str
     platforms: list[WarmPlatform] = Field(default_factory=list)
 
@@ -790,6 +792,17 @@ class PlatformToolsConfig(BaseModel):
         default="https://github.com/bridgecrewio/checkov/releases/download",
         description="Upstream download base for Checkov. Assets are per-platform "
         "zips containing a single self-contained dist/checkov executable.",
+    )
+    pulumi_version: str = Field(
+        default="3.208.0",
+        description="Pulumi CLI version fetched for engine=pulumi runs (#1523). Not "
+        "baked into the runner image: a Terraform-only deployment should not carry "
+        "another engine's binary, and an upstream fix reaches an operator through a "
+        "values change rather than a Terrapod release.",
+    )
+    pulumi_mirror_url: str = Field(
+        default="https://github.com/pulumi/pulumi/releases/download",
+        description="Where Pulumi CLI archives are fetched from before caching.",
     )
     checkov_checksum_api_url: str = Field(
         default="https://api.github.com/repos/bridgecrewio/checkov/releases/tags",

--- a/services/terrapod/engines/__init__.py
+++ b/services/terrapod/engines/__init__.py
@@ -68,6 +68,28 @@ class EngineStrategy(Protocol):
         ...
 
 
+def engine_enabled(engine: str) -> bool:
+    """Whether an engine is offered by this deployment (#1429).
+
+    Defined here rather than in `services/engine_gating.py` because the listener
+    image ships `engines/` and no `services/` — so a gate living there could not
+    be consulted by the strategy registry, and the registry is where gating a
+    *strategy* has to happen. `engine_gating` imports this rather than declaring
+    a second copy, so there is one answer to "is this engine on".
+
+    Terraform is always enabled: it is not an optional engine, it is what
+    Terrapod is.
+    """
+    if engine == DEFAULT_ENGINE:
+        return True
+    from terrapod.config import settings
+
+    config = getattr(settings.engines, engine, None)
+    if config is None:
+        raise ValueError(f"unknown engine: {engine}")
+    return bool(config.enabled)
+
+
 def strategy_for(engine: str | None) -> EngineStrategy:
     """Resolve the strategy for an engine value.
 
@@ -77,6 +99,14 @@ def strategy_for(engine: str | None) -> EngineStrategy:
     """
     key = (engine or DEFAULT_ENGINE).strip().lower()
     strategy = _REGISTRY.get(key)
+    if strategy is not None and not engine_enabled(key):
+        # Distinguished from "unknown" deliberately. An operator who turned the
+        # engine off wants to be told that, not that Terrapod has never heard of
+        # it — the two have completely different fixes.
+        raise ValueError(
+            f"engine {key!r} is not enabled on this deployment "
+            f"(set engines.{key}.enabled to turn it on)"
+        )
     if strategy is None:
         # Deliberately not a silent fallback. An unknown engine means a row was
         # written by a newer replica mid-rollout, or by hand; running it as
@@ -88,15 +118,26 @@ def strategy_for(engine: str | None) -> EngineStrategy:
 
 
 def known_engines() -> tuple[str, ...]:
-    """Every engine this build can run, for validation and error messages."""
-    return tuple(sorted(_REGISTRY))
+    """Every engine this deployment can run, for validation and error messages.
+
+    Filtered by the gate, so a gated-off engine is absent rather than listed and
+    then refused — the same rule the surfaces follow.
+    """
+    return tuple(sorted(name for name in _REGISTRY if engine_enabled(name)))
 
 
 def _build_registry() -> dict[str, EngineStrategy]:
+    """Every strategy this build CONTAINS, before gating.
+
+    Built once at import and filtered at resolve time. Reading config here
+    instead would freeze the answer for the life of the process, which no test
+    could vary and no operator could change without a restart.
+    """
+    from terrapod.engines.pulumi import PulumiStrategy
     from terrapod.engines.terraform import TerraformStrategy
 
-    terraform = TerraformStrategy()
-    return {terraform.name: terraform}
+    strategies: list[EngineStrategy] = [TerraformStrategy(), PulumiStrategy()]
+    return {s.name: s for s in strategies}
 
 
 _REGISTRY: dict[str, EngineStrategy] = _build_registry()

--- a/services/terrapod/engines/pulumi.py
+++ b/services/terrapod/engines/pulumi.py
@@ -1,0 +1,186 @@
+"""Pulumi as an execution engine (#1523, #1407 phase 5).
+
+The second implementation of the seam #1487–#1489 built, and the first time
+engine gating applies to a *strategy* rather than a surface.
+
+**What differs from Terraform, and why it is not an `if` somewhere.** Terraform
+writes a plan file and applies it; Pulumi does the same shape with different
+words — `preview --save-plan` then `up --plan` — which #1501 verified end to end.
+Both are a single container, so the Job is a sibling of Terraform's rather than a
+new Pod shape. Where they genuinely diverge is what a finished Job *means*, and
+that is what `resolve_terminal` below answers for Pulumi rather than Terraform
+answering for both.
+
+**Listener-safe.** This module is imported by the listener, whose image ships no
+DB layer (`tests/meta/test_engines_stay_listener_safe.py` pins that). Nothing
+here imports a model or opens a session; the strategy takes plain values and
+returns plain values. A violation is not a red test in CI — it is a
+crash-looping listener in somebody's cluster.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from terrapod.engines.terraform import TerminalOutcome
+
+#: Pulumi writes its plan here inside the Job, and reads it back on the update.
+#: One constant because the two phases must agree, and a typo would surface as
+#: "no plan file" on the update rather than anywhere near the preview.
+PLAN_FILE = "/workspace/plan.json"
+
+
+@dataclass(frozen=True)
+class PulumiRunOptions:
+    """How one Pulumi run differs from the default.
+
+    Frozen for the same reason Terraform's is: a Job spec is built once from it,
+    and a builder that can mutate its own inputs halfway through is a bug waiting
+    for a second caller.
+    """
+
+    phase: str = "preview"
+    #: The stack this run targets, as `{project}/{stack}`.
+    stack: str = ""
+    #: Pinned CLI version; empty means the image's own.
+    pulumi_version: str = ""
+    #: Working directory within the fetched configuration.
+    working_directory: str = ""
+    #: A destroy rather than an update.
+    is_destroy: bool = False
+    #: A refresh before the operation, matching Terraform's `-refresh`.
+    refresh: bool = True
+    #: `--target` equivalents; Pulumi spells them URNs.
+    target_urns: list[str] | None = None
+    resource_cpu: str = ""
+    resource_memory: str = ""
+    parallelism: int = 0
+    timeout_minutes: int = 0
+    env_vars: list[dict[str, Any]] = field(default_factory=list)
+
+
+class PulumiStrategy:
+    """Pulumi.
+
+    `execution_backend` has no meaning here — there is one binary, unlike the
+    tofu/terraform split *within* the Terraform engine — so it names the CLI
+    itself rather than a choice.
+    """
+
+    name = "pulumi"
+
+    #: `pulumi preview` then `pulumi up`. Terraform's plan/apply in Pulumi's own
+    #: words, which is exactly why the vocabulary is per-engine rather than a
+    #: platform-wide label (#1521).
+    phases = ("preview", "update")
+
+    #: One binary; no equivalent of the tofu/terraform choice.
+    default_execution_backend = "pulumi"
+
+    #: Resolves to `phases.pulumi.*` in the message catalogues.
+    vocabulary = "pulumi"
+
+    #: Which phase each internal run status belongs to. The platform's status
+    #: names never change — a run is `planning` whatever engine it belongs to —
+    #: and this is what stops a Pulumi run being described as "planning" to a
+    #: user who has only ever seen the word "preview".
+    status_phases = {
+        "planning": "preview",
+        "planned": "preview",
+        "applying": "update",
+        "applied": "update",
+    }
+
+    def container_env(self, options: PulumiRunOptions, runner_config: Any) -> list[dict[str, Any]]:
+        """The TP_* instructions this engine gives its entrypoint.
+
+        Returned as a list and spliced into the container env at the same
+        position Terraform's occupies, so the two Job specs stay siblings.
+        """
+        env: list[dict[str, Any]] = [
+            {"name": "TP_ENGINE", "value": "pulumi"},
+            {"name": "TP_PULUMI_PHASE", "value": options.phase},
+            {"name": "TP_PULUMI_PLAN_FILE", "value": PLAN_FILE},
+        ]
+        if options.stack:
+            env.append({"name": "TP_PULUMI_STACK", "value": options.stack})
+        if options.pulumi_version:
+            env.append({"name": "TP_PULUMI_VERSION", "value": options.pulumi_version})
+        if options.working_directory:
+            env.append({"name": "TP_WORKING_DIR", "value": options.working_directory})
+        if options.is_destroy:
+            env.append({"name": "TP_DESTROY", "value": "true"})
+        if not options.refresh:
+            env.append({"name": "TP_REFRESH", "value": "false"})
+        if options.target_urns:
+            import json
+
+            env.append({"name": "TP_TARGET_URNS", "value": json.dumps(options.target_urns)})
+        if options.parallelism:
+            env.append({"name": "TP_PARALLELISM", "value": str(options.parallelism)})
+        return env
+
+    def build_job_spec(self, **kwargs: Any) -> dict:
+        """Compose the neutral builder with this engine's env.
+
+        The builder is engine-agnostic by #1488; everything Pulumi-specific
+        arrives through `engine_env`. That is what keeps adding an engine from
+        touching the Job-construction code every other engine shares — and why
+        Terraform's golden spec matrix does not move when this lands.
+        """
+        from terrapod.runner.job_template import build_job_spec as _build
+
+        options: PulumiRunOptions = kwargs.pop("options")
+        runner_config = kwargs.get("runner_config")
+        return _build(
+            phase=options.phase,
+            engine_env=self.container_env(options, runner_config),
+            resource_cpu=options.resource_cpu or "",
+            resource_memory=options.resource_memory or "",
+            timeout_minutes=options.timeout_minutes or 0,
+            env_vars=options.env_vars,
+            **kwargs,
+        )
+
+    def resolve_terminal(
+        self, *, run_status: str, run_source: str, job_status: str
+    ) -> TerminalOutcome:
+        """What a finished Job means for Pulumi.
+
+        **Pulumi asks about the checkpoint** (#1407 §11), and that is the real
+        divergence from Terraform rather than a rewording of it. Terraform's plan
+        is an artifact the apply consumes, so a succeeded plan Job means "a plan
+        exists to approve". Pulumi's `preview --save-plan` writes a plan file
+        too, but the authoritative record of what happened is the checkpoint the
+        CLI pushes to the service — which arrives over the #1522 surface *during*
+        the run, not at the end of it.
+
+        The consequence: a succeeded Job is the same signal in both engines, but
+        for Pulumi the state is already durable by the time the Job exits,
+        because the checkpoint was written mid-run. There is nothing to collect
+        afterwards, so completion is a state transition and nothing more.
+
+        A failed or deleted Job errors the run, as for Terraform. Pulumi has no
+        equivalent of Ansible's `ignore_errors`, so a non-zero exit means the
+        same thing here as there.
+        """
+        phase = "preview" if run_status == "planning" else "update"
+
+        if job_status == "succeeded":
+            if run_status == "planning":
+                return TerminalOutcome(action="complete_plan", phase=phase)
+            if run_status == "applying":
+                return TerminalOutcome(action="complete_apply", phase=phase)
+            # Neither planning nor applying: the checkpoint already drove the
+            # transition. The completion helpers are idempotent, but there is
+            # nothing left to complete, so say so rather than calling one anyway.
+            return TerminalOutcome(action="none", phase=phase)
+
+        if job_status in ("failed", "deleted"):
+            return TerminalOutcome(action="error", phase=phase)
+
+        # A status this engine does not recognise is not guessed at. Treating an
+        # unfamiliar Job status as success would apply infrastructure on the
+        # strength of a signal nobody defined.
+        return TerminalOutcome(action="none", phase=phase)

--- a/services/terrapod/runner/job_entrypoint.py
+++ b/services/terrapod/runner/job_entrypoint.py
@@ -758,6 +758,15 @@ def _run_body(cfg: RunnerConfig, work_dir: Path) -> int:
         return 1
 
     # 11. Phase-specific execution.
+    #
+    # Pulumi branches before Terraform's phases rather than inside them (#1523):
+    # its two phases are `preview`/`update`, and the steps above — backend
+    # neutralisation, var-files, the lock file — are Terraform's own and do not
+    # apply. Terraform's path below is byte-for-byte what it was, which is what
+    # the golden Job-spec matrix asserts.
+    if os.environ.get("TP_ENGINE", "") == "pulumi":
+        return _run_pulumi_phase(cfg, child_grace=child_grace)
+
     if cfg.phase == "plan":
         return _run_plan_phase(
             cfg,
@@ -776,6 +785,50 @@ def _run_body(cfg: RunnerConfig, work_dir: Path) -> int:
         )
     log.error("unknown phase", phase=cfg.phase)
     return 1
+
+
+def _run_pulumi_phase(cfg, *, child_grace: int) -> int:  # type: ignore[no-untyped-def]
+    """Run one Pulumi phase.
+
+    `preview --save-plan` then `up --plan` — the saved plan is what makes an
+    approved preview and its update the same decision, exactly as Terraform gets
+    from `plan -out` / `apply <file>`.
+
+    Writes to the same per-phase log files the Terraform path uses, so the
+    upload/rollup at the end of the run needs no engine-specific handling.
+    """
+    import structlog
+
+    from terrapod.runner import exec_subprocess
+    from terrapod.runner.phases import pulumi_exec
+
+    log = structlog.get_logger("runner.job_entrypoint")
+    plan_file = os.environ.get("TP_PULUMI_PLAN_FILE", "/workspace/plan.json")
+    phase = os.environ.get("TP_PULUMI_PHASE", cfg.phase)
+
+    # The CLI reads its plugin-download override from the environment, and
+    # `exec_subprocess.run` inherits this process's, so it is set here rather
+    # than passed.
+    os.environ.update(pulumi_exec.plugin_override_env(cfg.api_url, cfg.auth_token))
+
+    if phase in ("preview", "plan"):
+        argv = pulumi_exec.preview_argv(plan_file, cfg)
+        log_file = str(_PLAN_LOG)
+    elif phase in ("update", "apply"):
+        argv = pulumi_exec.update_argv(plan_file, cfg)
+        log_file = str(_APPLY_LOG)
+    else:
+        log.error("unknown pulumi phase", phase=phase)
+        return 1
+
+    log.info("running pulumi", phase=phase, argv=argv)
+    result = exec_subprocess.run(
+        ["pulumi", *argv],
+        log_file=log_file,
+        child_grace_seconds=float(child_grace),
+        tee_to_stdout=True,
+    )
+    return result.exit_code
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/services/terrapod/runner/phases/platform_tool.py
+++ b/services/terrapod/runner/phases/platform_tool.py
@@ -1,4 +1,4 @@
-"""Phase: fetch a platform tool (opa / trivy / checkov) from the binary cache (#1208).
+"""Phase: fetch a platform tool (opa / trivy / checkov / pulumi) from the binary cache (#1208, #1523).
 
 These three used to be baked into the runner image. They are now pulled through
 the same cache that serves terraform/tofu, so the version is an operator-set Helm
@@ -70,6 +70,8 @@ UNPACK: dict[str, _Unpack] = {
     "opa": _Unpack(kind="raw", member=""),
     "trivy": _Unpack(kind="targz", member="trivy"),
     "checkov": _Unpack(kind="zip", member="dist/checkov"),
+    # The tarball unpacks to `pulumi/pulumi` with the language plugins beside it.
+    "pulumi": _Unpack(kind="targz", member="pulumi/pulumi"),
 }
 
 
@@ -122,7 +124,9 @@ def fetch_versions(cfg: RunnerConfig, *, client: httpx.Client | None = None) -> 
         if own:
             c.close()
 
-    versions = {tool: attrs.get(f"{tool}-version", "") for tool in ("opa", "trivy", "checkov")}
+    versions = {
+        tool: attrs.get(f"{tool}-version", "") for tool in ("opa", "trivy", "checkov", "pulumi")
+    }
     if not any(versions.values()):
         raise PlatformToolError(
             "the API reported no platform-tool versions — the deployment's "

--- a/services/terrapod/runner/phases/pulumi_exec.py
+++ b/services/terrapod/runner/phases/pulumi_exec.py
@@ -1,0 +1,88 @@
+"""Running a Pulumi program inside the runner Job (#1523).
+
+Two phases, mirroring Terraform's plan/apply in Pulumi's own words:
+
+    pulumi preview --save-plan=<file>     the preview phase
+    pulumi up      --plan=<file>          the update phase
+
+#1501 verified that pairing end to end. Saving the plan and applying *that* plan
+is what makes the two phases one decision rather than two independent runs — the
+same property Terraform gets from `plan -out` / `apply <file>`, and the reason an
+approved preview cannot quietly apply something else.
+
+**Plugin downloads must be redirected, and the pattern must be `.*`.**
+`PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES` takes `pattern=url` pairs; a pattern that
+matches nothing makes the CLI fall back to `get.pulumi.com` **silently**, so the
+failure never appears for anyone with a route out and appears as a hang for
+someone air-gapped. That asymmetry is why it is `.*` rather than something
+anchored and tidier, and why the air-gap gate carries a Pulumi row (#1483,
+#1485).
+
+Kept in `runner/phases/` with the other phase modules, so the runner image ships
+it and nothing here reaches for a model or a session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from terrapod.logging_config import get_logger
+
+log = get_logger(__name__)
+
+
+def plugin_override_env(api_url: str, token: str) -> dict[str, str]:
+    """Point plugin downloads at Terrapod rather than get.pulumi.com.
+
+    The `.*` is load-bearing. An anchored pattern that fails to match does not
+    error — the CLI simply uses its default host, so a deployment with egress
+    keeps working and an air-gapped one hangs on a download nobody can see. The
+    only safe pattern is the one that cannot miss.
+    """
+    if not api_url:
+        return {}
+    base = api_url.rstrip("/")
+    env = {"PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES": f".*={base}/api/v1/package-cache/pulumi"}
+    if token:
+        # The proxy authenticates like every other Terrapod cache; the runner's
+        # own short-lived token is what it presents.
+        env["PULUMI_ACCESS_TOKEN"] = token
+    return env
+
+
+def _common_argv(cfg) -> list[str]:  # type: ignore[no-untyped-def]
+    """Flags both phases share."""
+    argv: list[str] = ["--non-interactive"]
+    stack = os.environ.get("TP_PULUMI_STACK", "")
+    if stack:
+        argv += ["--stack", stack]
+    if os.environ.get("TP_REFRESH", "").lower() == "false":
+        argv.append("--refresh=false")
+    parallelism = os.environ.get("TP_PARALLELISM", "")
+    if parallelism:
+        argv += ["--parallel", parallelism]
+    for urn in json.loads(os.environ.get("TP_TARGET_URNS", "[]") or "[]"):
+        argv += ["--target", urn]
+    return argv
+
+
+def preview_argv(plan_file: str, cfg=None) -> list[str]:  # type: ignore[no-untyped-def]
+    """`pulumi preview --save-plan=<file>`.
+
+    The saved plan is what the update consumes, so the two phases agree on one
+    file path — a mismatch surfaces as "no plan file" on the update, a long way
+    from the preview that should have written it.
+    """
+    return ["preview", f"--save-plan={plan_file}", *_common_argv(cfg)]
+
+
+def update_argv(plan_file: str, cfg=None) -> list[str]:  # type: ignore[no-untyped-def]
+    """`pulumi up --plan=<file>`, or `destroy` when the run is a destroy.
+
+    A destroy takes no plan: there is nothing to preview into a file that
+    `destroy` would read back, and passing one is rejected.
+    """
+    if os.environ.get("TP_DESTROY", "").lower() == "true":
+        return ["destroy", "--yes", *_common_argv(cfg)]
+    return ["up", "--yes", f"--plan={plan_file}", *_common_argv(cfg)]

--- a/services/terrapod/services/engine_gating.py
+++ b/services/terrapod/services/engine_gating.py
@@ -54,11 +54,15 @@ _CAPABILITY_ENGINES: dict[str, frozenset[str]] = {
 
 
 def engine_enabled(engine: str) -> bool:
-    """Whether an engine is offered by this deployment."""
-    config = getattr(settings.engines, engine, None)
-    if config is None:
-        raise ValueError(f"unknown engine: {engine}")
-    return bool(config.enabled)
+    """Whether an engine is offered by this deployment.
+
+    Delegates to `terrapod.engines`, which owns the answer because the strategy
+    registry has to consult it and the listener image ships `engines/` but no
+    `services/` (#1523). Re-exported here so callers keep one import for gating.
+    """
+    from terrapod.engines import engine_enabled as _engine_enabled
+
+    return _engine_enabled(engine)
 
 
 def capability_enabled(capability: str) -> bool:

--- a/services/terrapod/services/platform_tools.py
+++ b/services/terrapod/services/platform_tools.py
@@ -47,7 +47,15 @@ from terrapod.services.artifact_verification import VerificationError
 
 logger = structlog.get_logger(__name__)
 
-PLATFORM_TOOLS = frozenset({"opa", "trivy", "checkov"})
+PLATFORM_TOOLS = frozenset({"opa", "trivy", "checkov", "pulumi"})
+
+#: Pulumi's own platform naming, which differs from Go's for amd64.
+_PULUMI_PLATFORM = {
+    ("linux", "amd64"): "linux-x64",
+    ("linux", "arm64"): "linux-arm64",
+    ("darwin", "amd64"): "darwin-x64",
+    ("darwin", "arm64"): "darwin-arm64",
+}
 
 #: How each tool names the platform in its asset filenames. Terrapod speaks
 #: Go-style os/arch throughout; upstream does not always agree (Trivy uses
@@ -87,6 +95,10 @@ SPECS: dict[str, PlatformToolSpec] = {
     # A tarball whose only interesting member is the binary itself.
     "trivy": PlatformToolSpec(archive="targz", member="trivy", content_type="application/gzip"),
     # A PyInstaller bundle: one ~60MB self-contained executable in a zip.
+    # The tarball unpacks to `pulumi/pulumi` plus the language plugins beside it.
+    "pulumi": PlatformToolSpec(
+        archive="targz", member="pulumi/pulumi", content_type="application/gzip"
+    ),
     "checkov": PlatformToolSpec(
         archive="zip", member="dist/checkov", content_type="application/zip"
     ),
@@ -99,6 +111,7 @@ def _mirror(tool: str) -> str:
         "opa": cfg.opa_mirror_url,
         "trivy": cfg.trivy_mirror_url,
         "checkov": cfg.checkov_mirror_url,
+        "pulumi": cfg.pulumi_mirror_url,
     }[tool].rstrip("/")
 
 
@@ -109,6 +122,7 @@ def configured_version(tool: str) -> str:
         "opa": cfg.opa_version,
         "trivy": cfg.trivy_version,
         "checkov": cfg.checkov_version,
+        "pulumi": cfg.pulumi_version,
     }[tool]
 
 
@@ -136,6 +150,11 @@ def download_url(tool: str, version: str, os_: str, arch: str) -> str:
         if plat is None:
             raise UnsupportedPlatformError(f"checkov publishes no asset for {os_}/{arch}")
         return f"{base}/{version}/checkov_{plat}.zip"
+    if tool == "pulumi":
+        plat = _PULUMI_PLATFORM.get((os_, arch))
+        if plat is None:
+            raise UnsupportedPlatformError(f"pulumi publishes no asset for {os_}/{arch}")
+        return f"{base}/v{version}/pulumi-v{version}-{plat}.tar.gz"
     raise ValueError(f"not a platform tool: {tool!r}")
 
 

--- a/services/tests/config/config_key_contract.json
+++ b/services/tests/config/config_key_contract.json
@@ -274,6 +274,8 @@
   "registry.platform_tools.checkov_version",
   "registry.platform_tools.opa_mirror_url",
   "registry.platform_tools.opa_version",
+  "registry.platform_tools.pulumi_mirror_url",
+  "registry.platform_tools.pulumi_version",
   "registry.platform_tools.trivy_mirror_url",
   "registry.platform_tools.trivy_version",
   "registry.platform_tools.verify",

--- a/services/tests/helm/helm_values_contract.json
+++ b/services/tests/helm/helm_values_contract.json
@@ -210,6 +210,8 @@
   "api.config.registry.platform_tools.checkov_version",
   "api.config.registry.platform_tools.opa_mirror_url",
   "api.config.registry.platform_tools.opa_version",
+  "api.config.registry.platform_tools.pulumi_mirror_url",
+  "api.config.registry.platform_tools.pulumi_version",
   "api.config.registry.platform_tools.trivy_mirror_url",
   "api.config.registry.platform_tools.trivy_version",
   "api.config.registry.platform_tools.verify",

--- a/services/tests/integration/test_terminal_resolution.py
+++ b/services/tests/integration/test_terminal_resolution.py
@@ -25,7 +25,7 @@ import pytest
 from sqlalchemy import select
 
 from terrapod.db.models import ONBOARDING_DISCOVERY_SOURCE, Run, Workspace
-from terrapod.engines import strategy_for
+from terrapod.engines import known_engines, strategy_for
 from terrapod.engines.terraform import TerraformStrategy
 
 pytestmark = pytest.mark.asyncio
@@ -226,6 +226,119 @@ class TestTheEngineColumnDrivesIt:
             assert strategy_for(run.engine).name == "terraform"
 
     async def test_an_unresolvable_engine_refuses_rather_than_defaulting(self):
-        """Running the wrong tool against real infrastructure beats no answer."""
+        """Running the wrong tool against real infrastructure beats no answer.
+
+        `pulumi` used to be the example of an unknown engine here; it is a known
+        one since #1523, so the case is made with an engine that genuinely is
+        not built rather than by weakening the assertion.
+        """
         with pytest.raises(ValueError, match="unknown engine"):
-            strategy_for("pulumi")
+            strategy_for("bicep")
+
+    async def test_a_gated_off_engine_is_refused_differently_from_an_unknown_one(self):
+        """The two have completely different fixes.
+
+        "Unknown" means a row was written by a newer replica or by hand.
+        "Not enabled" means an operator turned it off and the message should say
+        so — telling them Terrapod has never heard of Pulumi would send them
+        looking for a missing install.
+        """
+        from unittest.mock import patch
+
+        with patch("terrapod.engines.engine_enabled", side_effect=lambda e: e != "pulumi"):
+            with pytest.raises(ValueError, match="not enabled"):
+                strategy_for("pulumi")
+
+    async def test_terraform_is_unaffected_by_the_pulumi_switch(self):
+        """The whole point of the gate: multi-engine ambition costs a terraform
+        user nothing, in either position of the switch."""
+        from unittest.mock import patch
+
+        for pulumi_on in (True, False):
+            with patch(
+                "terrapod.engines.engine_enabled",
+                side_effect=lambda e, on=pulumi_on: True if e == "terraform" else on,
+            ):
+                assert strategy_for("terraform").name == "terraform"
+                assert strategy_for(None).name == "terraform"
+
+    async def test_pulumi_resolves_when_enabled(self):
+        assert strategy_for("pulumi").name == "pulumi"
+        assert "pulumi" in known_engines()
+
+    async def test_a_gated_off_engine_is_absent_from_known_engines(self):
+        """Absent, not listed-and-then-refused — the same rule the surfaces
+        follow, so a caller enumerating engines never offers one that cannot
+        run."""
+        from unittest.mock import patch
+
+        with patch("terrapod.engines.engine_enabled", side_effect=lambda e: e != "pulumi"):
+            assert "pulumi" not in known_engines()
+            assert "terraform" in known_engines()
+
+
+class TestPulumiTerminalRules:
+    """Pulumi's rules, recorded rather than merely implemented (#1523).
+
+    #1489 pinned Terraform's for exactly this moment: a second engine answers the
+    same question differently, and the only way to add one safely is to know what
+    the first does. These are the counterpart, in the same shape.
+    """
+
+    @pytest.mark.parametrize(
+        ("run_status", "job_status", "action", "phase"),
+        [
+            # Succeeded, and which completion applies is chosen by run state —
+            # the same shape as Terraform, in Pulumi's vocabulary.
+            ("planning", "succeeded", "complete_plan", "preview"),
+            ("applying", "succeeded", "complete_apply", "update"),
+            # Failed and deleted both error, in either phase.
+            ("planning", "failed", "error", "preview"),
+            ("applying", "failed", "error", "update"),
+            ("planning", "deleted", "error", "preview"),
+            ("applying", "deleted", "error", "update"),
+            # Already resolved. For Pulumi this is the COMMON case rather than a
+            # race: the checkpoint is pushed over the #1522 surface during the
+            # run, so state is durable before the Job exits and there is nothing
+            # to collect afterwards.
+            ("planned", "succeeded", "none", "update"),
+            ("applied", "succeeded", "none", "update"),
+        ],
+    )
+    async def test_rule(self, run_status, job_status, action, phase):
+        from terrapod.engines.pulumi import PulumiStrategy
+
+        outcome = PulumiStrategy().resolve_terminal(
+            run_status=run_status, run_source="tfe-api", job_status=job_status
+        )
+        assert (outcome.action, outcome.phase) == (action, phase)
+
+    async def test_an_unknown_job_status_does_nothing(self):
+        """Treating an unfamiliar status as success would apply infrastructure on
+        the strength of a signal nobody defined."""
+        from terrapod.engines.pulumi import PulumiStrategy
+
+        outcome = PulumiStrategy().resolve_terminal(
+            run_status="planning", run_source="tfe-api", job_status="something-new"
+        )
+        assert outcome.action == "none"
+
+    async def test_the_phases_are_pulumi_s_words_not_terraform_s(self):
+        """A run is `planning` whatever engine it belongs to; what the user is
+        SHOWN differs, and that difference must survive into the outcome (#1521).
+        """
+        from terrapod.engines.pulumi import PulumiStrategy
+
+        strategy = PulumiStrategy()
+        assert strategy.phases == ("preview", "update")
+        assert strategy.status_phases["planning"] == "preview"
+        assert strategy.status_phases["applying"] == "update"
+
+    async def test_terraform_still_answers_in_its_own_words(self):
+        """The two coexist; adding Pulumi must not have edited Terraform's."""
+        from terrapod.engines.terraform import TerraformStrategy
+
+        outcome = TerraformStrategy().resolve_terminal(
+            run_status="planning", run_source="tfe-api", job_status="succeeded"
+        )
+        assert (outcome.action, outcome.phase) == ("complete_plan", "plan")

--- a/services/tests/runner/test_platform_tool.py
+++ b/services/tests/runner/test_platform_tool.py
@@ -74,6 +74,7 @@ class TestFetchVersions:
                         "opa-version": "1.19.0",
                         "trivy-version": "0.72.0",
                         "checkov-version": "3.3.8",
+                        "pulumi-version": "3.208.0",
                     }
                 }
             },
@@ -82,6 +83,7 @@ class TestFetchVersions:
             "opa": "1.19.0",
             "trivy": "0.72.0",
             "checkov": "3.3.8",
+            "pulumi": "3.208.0",
         }
 
     def test_raises_on_a_non_200(self):

--- a/services/tests/services/test_cache_warm_service.py
+++ b/services/tests/services/test_cache_warm_service.py
@@ -151,7 +151,7 @@ class TestPlatformToolDerivation:
 
     def test_derives_one_entry_per_platform_tool(self):
         entries = cache_warm_service.platform_tool_entries()
-        assert {e.tool for e in entries} == {"opa", "trivy", "checkov"}
+        assert {e.tool for e in entries} == {"opa", "trivy", "checkov", "pulumi"}
         assert all(e.version for e in entries)
 
     async def test_warms_platform_tools_without_being_asked(self):
@@ -161,9 +161,9 @@ class TestPlatformToolDerivation:
         ) as mock_warm:
             await warm_from_manifest(db, storage, [], [])
         warmed = {call.args[2] for call in mock_warm.await_args_list}
-        assert warmed == {"opa", "trivy", "checkov"}
-        # Three tools x the two default platforms.
-        assert mock_warm.await_count == 6
+        assert warmed == {"opa", "trivy", "checkov", "pulumi"}
+        # Four tools x the two default platforms.
+        assert mock_warm.await_count == 8
 
     async def test_opting_out_leaves_the_manifest_alone(self):
         db, storage = _db(), AsyncMock()
@@ -193,4 +193,4 @@ class TestPlatformToolDerivation:
                 db, storage, [WarmBinaryEntry(tool="tofu", version="1.9.0")], []
             )
         assert summary.failed == summary.total
-        assert summary.total == 8  # 3 platform tools + 1 listed entry, x2 platforms
+        assert summary.total == 10  # 4 platform tools + 1 listed entry, x2 platforms

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -3148,6 +3148,22 @@
         "planning": "جارٍ التخطيط",
         "applying": "جارٍ التطبيق"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "جارٍ تشغيل pulumi preview",
+        "applying": "جارٍ تشغيل pulumi up"
+      },
+      "runStatus": {
+        "planning": "جارٍ التخطيط",
+        "planned": "تم التخطيط",
+        "applying": "جارٍ التطبيق",
+        "applied": "تم التطبيق"
+      },
+      "status": {
+        "planning": "جارٍ التخطيط",
+        "applying": "جارٍ التطبيق"
+      }
     }
   }
 }

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -3148,6 +3148,22 @@
         "planning": "Plánování",
         "applying": "Aplikování"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Spouští se pulumi preview",
+        "applying": "Spouští se pulumi up"
+      },
+      "runStatus": {
+        "planning": "Plánování",
+        "planned": "Naplánováno",
+        "applying": "Aplikování",
+        "applied": "Aplikováno"
+      },
+      "status": {
+        "planning": "Plánování",
+        "applying": "Aplikování"
+      }
     }
   }
 }

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -3148,6 +3148,22 @@
         "planning": "Cynllunio",
         "applying": "Gweithredu"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Wrthi'n rhedeg pulumi preview",
+        "applying": "Wrthi'n rhedeg pulumi up"
+      },
+      "runStatus": {
+        "planning": "Cynllunio",
+        "planned": "Cynlluniwyd",
+        "applying": "Gweithredu",
+        "applied": "Gweithredwyd"
+      },
+      "status": {
+        "planning": "Cynllunio",
+        "applying": "Gweithredu"
+      }
     }
   }
 }

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -3148,6 +3148,22 @@
         "planning": "Planlægger",
         "applying": "Anvender"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Kører pulumi preview",
+        "applying": "Kører pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewlægger",
+        "planned": "Previewlagt",
+        "applying": "Anvender",
+        "applied": "Anvendt"
+      },
+      "status": {
+        "planning": "Previewlægger",
+        "applying": "Anvender"
+      }
     }
   }
 }

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -3148,6 +3148,22 @@
         "planning": "Wird geplant",
         "applying": "Wird angewendet"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi preview wird ausgeführt",
+        "applying": "pulumi up wird ausgeführt"
+      },
+      "runStatus": {
+        "planning": "Previewt",
+        "planned": "Gepreviewt",
+        "applying": "Wendet an",
+        "applied": "Angewendet"
+      },
+      "status": {
+        "planning": "Wird gepreviewt",
+        "applying": "Wird angewendet"
+      }
     }
   }
 }

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -3148,6 +3148,22 @@
         "planning": "Pl4nn1ng",
         "applying": "4pply1ng"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Runn1ng pulum1 pr3v13w",
+        "applying": "Runn1ng pulum1 up"
+      },
+      "runStatus": {
+        "planning": "Pr3v13w1ng",
+        "planned": "Pr3v13w3d",
+        "applying": "Upd471ng",
+        "applied": "Upd473d"
+      },
+      "status": {
+        "planning": "Pr3v13w1ng",
+        "applying": "Upd471ng"
+      }
     }
   }
 }

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -3148,6 +3148,22 @@
         "planning": "Plannin",
         "applying": "Applyin"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Runnin pulumi preview",
+        "applying": "Runnin pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewnin",
+        "planned": "Previewnd",
+        "applying": "Upin",
+        "applied": "Upd"
+      },
+      "status": {
+        "planning": "Previewnin",
+        "applying": "Upin"
+      }
     }
   }
 }

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -3148,6 +3148,22 @@
         "planning": "Planning",
         "applying": "Applying"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Running marklar marklar",
+        "applying": "Running marklar marklar"
+      },
+      "runStatus": {
+        "planning": "Previewning",
+        "planned": "Previewned",
+        "applying": "Uping",
+        "applied": "Applied"
+      },
+      "status": {
+        "planning": "Previewning",
+        "applying": "Uping"
+      }
     }
   }
 }

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -3148,6 +3148,22 @@
         "planning": "Plannin''",
         "applying": "Applyin''"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Runnin'' pulumi preview",
+        "applying": "Runnin'' pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewnin''",
+        "planned": "Previewned",
+        "applying": "Upin''",
+        "applied": "Applied"
+      },
+      "status": {
+        "planning": "Previewnin''",
+        "applying": "Upin''"
+      }
     }
   }
 }

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -3148,6 +3148,22 @@
         "planning": "Planning",
         "applying": "Applying"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi preview, running it",
+        "applying": "pulumi up, running it"
+      },
+      "runStatus": {
+        "planning": "Previewning",
+        "planned": "Previewned",
+        "applying": "Uping",
+        "applied": "Applied"
+      },
+      "status": {
+        "planning": "Previewning",
+        "applying": "Uping"
+      }
     }
   }
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -3148,6 +3148,22 @@
         "planning": "Planning",
         "applying": "Applying"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Running pulumi preview",
+        "applying": "Running pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewing",
+        "planned": "Previewed",
+        "applying": "Updating",
+        "applied": "Updated"
+      },
+      "status": {
+        "planning": "Previewing",
+        "applying": "Updating"
+      }
     }
   }
 }

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -3148,6 +3148,22 @@
         "planning": "Planificando",
         "applying": "Aplicando"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Ejecutando pulumi preview",
+        "applying": "Ejecutando pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewificando",
+        "planned": "Previewificado",
+        "applying": "Aplicando",
+        "applied": "Aplicado"
+      },
+      "status": {
+        "planning": "Previewificando",
+        "applying": "Aplicando"
+      }
     }
   }
 }

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -3148,6 +3148,22 @@
         "planning": "در حال طرح‌ریزی",
         "applying": "در حال اعمال"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "در حال اجرای pulumi preview",
+        "applying": "در حال اجرای pulumi up"
+      },
+      "runStatus": {
+        "planning": "در حال برنامه‌ریزی",
+        "planned": "برنامه‌ریزی‌شده",
+        "applying": "در حال اعمال",
+        "applied": "اعمال‌شده"
+      },
+      "status": {
+        "planning": "در حال طرح‌ریزی",
+        "applying": "در حال اعمال"
+      }
     }
   }
 }

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -3148,6 +3148,22 @@
         "planning": "Suunnitellaan",
         "applying": "Otetaan käyttöön"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Suoritetaan pulumi preview",
+        "applying": "Suoritetaan pulumi up"
+      },
+      "runStatus": {
+        "planning": "Suunnitellaan",
+        "planned": "Suunniteltu",
+        "applying": "Otetaan käyttöön",
+        "applied": "Otettu käyttöön"
+      },
+      "status": {
+        "planning": "Suunnitellaan",
+        "applying": "Otetaan käyttöön"
+      }
     }
   }
 }

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -3148,6 +3148,22 @@
         "planning": "Planification",
         "applying": "Application"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Exécution de pulumi preview",
+        "applying": "Exécution de pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewification",
+        "planned": "Previewifié",
+        "applying": "Application",
+        "applied": "Appliqué"
+      },
+      "status": {
+        "planning": "Previewification",
+        "applying": "Application"
+      }
     }
   }
 }

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -3148,6 +3148,22 @@
         "planning": "מתכנן",
         "applying": "מחיל"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "מריץ pulumi preview",
+        "applying": "מריץ pulumi up"
+      },
+      "runStatus": {
+        "planning": "מתכנן",
+        "planned": "תוכנן",
+        "applying": "מיישם",
+        "applied": "יושם"
+      },
+      "status": {
+        "planning": "מתכנן",
+        "applying": "מחיל"
+      }
     }
   }
 }

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -3148,6 +3148,22 @@
         "planning": "Pianificazione",
         "applying": "Applicazione"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Esecuzione di pulumi preview",
+        "applying": "Esecuzione di pulumi up"
+      },
+      "runStatus": {
+        "planning": "Pianificazione",
+        "planned": "Pianificato",
+        "applying": "Applicazione",
+        "applied": "Applicato"
+      },
+      "status": {
+        "planning": "Pianificazione",
+        "applying": "Applicazione"
+      }
     }
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -3148,6 +3148,22 @@
         "planning": "プラン実行中",
         "applying": "適用中"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi previewを実行中",
+        "applying": "pulumi upを実行中"
+      },
+      "runStatus": {
+        "planning": "プラン実行中",
+        "planned": "プラン完了",
+        "applying": "適用中",
+        "applied": "適用済み"
+      },
+      "status": {
+        "planning": "プラン実行中",
+        "applying": "適用中"
+      }
     }
   }
 }

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -3148,6 +3148,22 @@
         "planning": "계획 중",
         "applying": "적용 중"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi preview 실행 중",
+        "applying": "pulumi up 실행 중"
+      },
+      "runStatus": {
+        "planning": "계획 중",
+        "planned": "계획됨",
+        "applying": "적용 중",
+        "applied": "적용됨"
+      },
+      "status": {
+        "planning": "계획 중",
+        "applying": "적용 중"
+      }
     }
   }
 }

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -3148,6 +3148,22 @@
         "planning": "Consilium Fit",
         "applying": "Applicatur"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi preview curritur",
+        "applying": "pulumi up curritur"
+      },
+      "runStatus": {
+        "planning": "Consilium Fit",
+        "planned": "Consilium Factum",
+        "applying": "Applicatur",
+        "applied": "Applicatum"
+      },
+      "status": {
+        "planning": "Consilium Fit",
+        "applying": "Applicatur"
+      }
     }
   }
 }

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -3148,6 +3148,22 @@
         "planning": "Planlegger",
         "applying": "Anvender"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Kjører pulumi preview",
+        "applying": "Kjører pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewlegger",
+        "planned": "Previewlagt",
+        "applying": "Anvender",
+        "applied": "Anvendt"
+      },
+      "status": {
+        "planning": "Previewlegger",
+        "applying": "Anvender"
+      }
     }
   }
 }

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -3148,6 +3148,22 @@
         "planning": "Bezig met plannen",
         "applying": "Bezig met toepassen"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi preview uitvoeren",
+        "applying": "pulumi up uitvoeren"
+      },
+      "runStatus": {
+        "planning": "Bezig met previewnen",
+        "planned": "Gepreviewd",
+        "applying": "Bezig met toepassen",
+        "applied": "Toegepast"
+      },
+      "status": {
+        "planning": "Bezig met previewnen",
+        "applying": "Bezig met toepassen"
+      }
     }
   }
 }

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -3148,6 +3148,22 @@
         "planning": "Planowanie",
         "applying": "Zastosowywanie"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Uruchamianie pulumi preview",
+        "applying": "Uruchamianie pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewowanie",
+        "planned": "Zapreviewowane",
+        "applying": "Zastosowywanie",
+        "applied": "Zastosowane"
+      },
+      "status": {
+        "planning": "Previewowanie",
+        "applying": "Zastosowywanie"
+      }
     }
   }
 }

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -3148,6 +3148,22 @@
         "planning": "Planejando",
         "applying": "Aplicando"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Executando pulumi preview",
+        "applying": "Executando pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewejando",
+        "planned": "Previewejado",
+        "applying": "Aplicando",
+        "applied": "Aplicado"
+      },
+      "status": {
+        "planning": "Previewejando",
+        "applying": "Aplicando"
+      }
     }
   }
 }

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -3148,6 +3148,22 @@
         "planning": "A planear",
         "applying": "A aplicar"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "A executar pulumi preview",
+        "applying": "A executar pulumi up"
+      },
+      "runStatus": {
+        "planning": "A previewear",
+        "planned": "Previeweado",
+        "applying": "A aplicar",
+        "applied": "Aplicado"
+      },
+      "status": {
+        "planning": "A previewear",
+        "applying": "A aplicar"
+      }
     }
   }
 }

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -3148,6 +3148,22 @@
         "planning": "Планирование",
         "applying": "Применение"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Выполняется pulumi preview",
+        "applying": "Выполняется pulumi up"
+      },
+      "runStatus": {
+        "planning": "Планирование",
+        "planned": "Спланировано",
+        "applying": "Применение",
+        "applied": "Применено"
+      },
+      "status": {
+        "planning": "Планирование",
+        "applying": "Применение"
+      }
     }
   }
 }

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -3148,6 +3148,22 @@
         "planning": "Planerar",
         "applying": "Applicerar"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Kör pulumi preview",
+        "applying": "Kör pulumi up"
+      },
+      "runStatus": {
+        "planning": "Previewerar",
+        "planned": "Previewerad",
+        "applying": "Applicerar",
+        "applied": "Applicerad"
+      },
+      "status": {
+        "planning": "Previewerar",
+        "applying": "Applicerar"
+      }
     }
   }
 }

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -3148,6 +3148,22 @@
         "planning": "nabtaH",
         "applying": "lo'taH"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi preview vangtaH",
+        "applying": "pulumi up vangtaH"
+      },
+      "runStatus": {
+        "planning": "nabtaH",
+        "planned": "nabpu'",
+        "applying": "lo'taH",
+        "applied": "lo'pu'"
+      },
+      "status": {
+        "planning": "nabtaH",
+        "applying": "lo'taH"
+      }
     }
   }
 }

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -3148,6 +3148,22 @@
         "planning": "Planlanıyor",
         "applying": "Uygulanıyor"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "pulumi preview çalıştırılıyor",
+        "applying": "pulumi up çalıştırılıyor"
+      },
+      "runStatus": {
+        "planning": "Previewlanıyor",
+        "planned": "Previewlandı",
+        "applying": "Uygulanıyor",
+        "applied": "Uygulandı"
+      },
+      "status": {
+        "planning": "Previewlanıyor",
+        "applying": "Uygulanıyor"
+      }
     }
   }
 }

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -3148,6 +3148,22 @@
         "planning": "Планування",
         "applying": "Застосування"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "Виконання pulumi preview",
+        "applying": "Виконання pulumi up"
+      },
+      "runStatus": {
+        "planning": "Планування",
+        "planned": "Заплановано",
+        "applying": "Застосування",
+        "applied": "Застосовано"
+      },
+      "status": {
+        "planning": "Планування",
+        "applying": "Застосування"
+      }
     }
   }
 }

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -3148,6 +3148,22 @@
         "planning": "正在计划",
         "applying": "正在应用"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "正在运行 pulumi preview",
+        "applying": "正在运行 pulumi up"
+      },
+      "runStatus": {
+        "planning": "正在计划",
+        "planned": "已计划",
+        "applying": "正在应用",
+        "applied": "已应用"
+      },
+      "status": {
+        "planning": "正在计划",
+        "applying": "正在应用"
+      }
     }
   }
 }

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -3148,6 +3148,22 @@
         "planning": "正在計畫",
         "applying": "正在應用"
       }
+    },
+    "pulumi": {
+      "activity": {
+        "planning": "正在執行 pulumi preview",
+        "applying": "正在執行 pulumi up"
+      },
+      "runStatus": {
+        "planning": "正在計畫",
+        "planned": "已計畫",
+        "applying": "正在應用",
+        "applied": "已應用"
+      },
+      "status": {
+        "planning": "正在計畫",
+        "applying": "正在應用"
+      }
     }
   }
 }

--- a/web/src/lib/phase-vocabulary.ts
+++ b/web/src/lib/phase-vocabulary.ts
@@ -36,7 +36,7 @@ export const DEFAULT_ENGINE = 'terraform'
  * wrong wording, not like a broken page — and the i18n completeness gate is what
  * stops it staying wrong.
  */
-const KNOWN = new Set([DEFAULT_ENGINE])
+const KNOWN = new Set([DEFAULT_ENGINE, 'pulumi'])
 
 export function vocabularyFor(engine: Engine | null | undefined): string {
   const key = (engine ?? '').trim().toLowerCase()


### PR DESCRIPTION
Registers `PulumiStrategy` and wires the runner Job so an `engine=pulumi`
workspace executes. The second implementation of the seam #1487–#1489 built, and
the first time engine gating applies to a **strategy** rather than a surface.

## Where the gate had to live

`engines/` is imported by the listener, whose image ships no `services/` — so
`engine_gating.engine_enabled` could never be consulted by the strategy registry,
which is exactly where gating a strategy has to happen. The definition moved into
`engines/` (it needs only `settings.engines`) and `engine_gating` now delegates,
so there is still one answer to "is this engine on" rather than two that can
disagree.

**Applied at resolve time, not registry-build time.** The registry is built once
at import, so a config value read there would be frozen for the life of the
process — no test could vary it and no operator could change it without a
restart.

`strategy_for("pulumi")` refuses when the engine is off, and refuses
**differently** from an unknown engine. "Not enabled" and "never heard of it"
have completely different fixes; telling an operator the wrong one sends them
looking for a missing install.

## What Pulumi answers differently

`preview --save-plan` then `up --plan` (#1501 verified this end to end) —
Terraform's plan/apply in Pulumi's own words, so the Job is a **sibling** rather
than a new Pod shape and **Terraform's golden spec matrix does not move**.

Terminal resolution is the real divergence, and §11 named it: *Pulumi asks about
the checkpoint*. Pulumi's checkpoint arrives over the #1522 service surface
**during** the run, so state is already durable when the Job exits and completion
is a state transition with nothing left to collect. Its rules are pinned by
integration tests in #1489's shape — recorded, not merely implemented.

## The CLI is a platform tool, not a baked-in binary

A Terraform-only deployment should not carry another engine's binary, and
#1208's mechanism already exists for exactly this: fetched on demand through the
binary cache, version as a Helm value, so an upstream fix reaches an operator
without a Terrapod release. All four legs of the config-channel contract —
values, schema, configmap render, helm-smoke assertion.

`PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES` uses `.*` deliberately. A pattern that
matches nothing does not error: the CLI falls back to `get.pulumi.com`
**silently**, so a deployment with egress keeps working and an air-gapped one
hangs on a download nobody can see. The only safe pattern is the one that cannot
miss. The air-gap gate already carries the row.

## Two guards from #1521 caught real gaps

Which is what they were written for, one issue earlier:

- Pulumi declared a vocabulary the message catalogues did not carry — its runs
  would have rendered raw message keys.
- The frontend's fallback set did not know the engine — a Pulumi run would have
  been silently labelled "planning", which *renders fine* and is simply wrong.

`phases.pulumi.*` is now filled in all 32 locales, seeded from each locale's own
Terraform block so its dialect and register carry over. `en-x-leet` was
regenerated by character substitution rather than word-swapped: the swap left it
byte-identical to Terraform's, because the words never appear literally in leet.

## Acceptance

| | |
|---|---|
| `PulumiStrategy` registered, gated | ✅ absent when off, terraform unaffected either way |
| Pulumi terminal rules + integration tests | ✅ in #1489's shape |
| listener-safety invariant | ✅ still passes |
| Terraform behaviour unchanged | ✅ golden Job-spec matrix unmoved |
| air-gap gate with the Pulumi row | ✅ `.*` pattern, already covered |

**4717 passed, 0 failed.** Config and Helm contracts +2 each, none removed.
`ruff`, `helm lint`, `helm template`, and every frontend gate including
`i18n:check` (2551 keys × 32 catalogues) and `i18n:phases`.

Not yet done: the Tilt acceptance run of a real preview/update on an
`engine=pulumi` workspace. Everything it needs is in place — strategy, Job
wiring, CLI fetch and the #1522 service surface — but it wants a live stack and a
Pulumi program, so it is worth doing deliberately rather than as a footnote here.

Part of #1407 (phase 5).
