### PR TITLE
feat(1523): make the Pulumi runner Job actually able to run Pulumi

### DIFF
--- a/docs/pulumi-cli-surface.md
+++ b/docs/pulumi-cli-surface.md
@@ -277,6 +277,31 @@ the local working directory, so uncommitted edits execute remotely; `deployment 
 git-sourced (`--git-branch` / `--git-commit` / `--git-repo-dir` / `--git-auth-*`), so it
 deploys committed code and local edits do not participate.
 
+## How Terrapod runs Pulumi on an agent
+
+The section above is about what *Pulumi's own CLI* can drive remotely. Terrapod's
+agent execution is a different thing and does not use the Deployments API at all:
+a run is queued in Terrapod, a listener launches a Kubernetes Job, and the Job
+runs `pulumi preview` then `pulumi up` against the fetched configuration — the
+same shape as a Terraform run, and the same one an operator selects with
+`execution_mode = "agent"`. **The engine does not decide where a run executes.**
+
+Two things the Job arranges that are worth knowing about as an operator:
+
+**The binary is fetched, not baked in.** `pulumi` is pulled through the same
+cache that serves `tofu`/`terraform`, so the version is
+`registry.platform_tools.pulumi_version` in your values (default `3.208.0`) and
+an upstream fix reaches a deployment with a `helm upgrade` rather than a Terrapod
+release. If the cache cannot supply it the run fails rather than falling back to
+whatever `pulumi` might be on the image.
+
+**The backend is set for it.** The Job exports `PULUMI_BACKEND_URL` pointing at
+this deployment's service surface, plus the run's own short-lived token, so there
+is no `pulumi login` to perform inside the Job. Plugin downloads are redirected
+to Terrapod's package cache the same way. Both matter most in an air-gapped
+deployment, where the CLI's defaults would otherwise reach for
+`app.pulumi.com` and `get.pulumi.com` and simply hang.
+
 ## Nothing from the management surface was required
 
 A full `login → stack init → stack ls → preview → up → refresh → export →

--- a/services/terrapod/api/routers/binary_cache.py
+++ b/services/terrapod/api/routers/binary_cache.py
@@ -68,7 +68,7 @@ class WarmBinaryRequest(BaseModel):
 async def platform_tool_versions(
     current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> JSONResponse:
-    """The opa/trivy/checkov versions this deployment pins (#1208).
+    """The opa/trivy/checkov/pulumi versions this deployment pins (#1208, #1523).
 
     The runner reads this to know what to ask the binary cache for. It is a
     platform-scoped setting, so there is one answer for the whole deployment and
@@ -90,6 +90,11 @@ async def platform_tool_versions(
                     "opa-version": cfg.opa_version,
                     "trivy-version": cfg.trivy_version,
                     "checkov-version": cfg.checkov_version,
+                    # The runner has always read this key here; until #1523 the
+                    # response never carried it, so it resolved to "" and a
+                    # Pulumi run asked the cache for no version at all. One side
+                    # asking and the other not answering is the whole bug.
+                    "pulumi-version": cfg.pulumi_version,
                 },
             }
         }

--- a/services/terrapod/runner/job_entrypoint.py
+++ b/services/terrapod/runner/job_entrypoint.py
@@ -709,6 +709,26 @@ def _run_body(cfg: RunnerConfig, work_dir: Path) -> int:
         log.error("pre_init hook failed", hook=exc.name, rc=exc.exit_code)
         return exc.exit_code
 
+    # 7b. Pulumi runs here, above every Terraform-specific step that follows
+    # (#1523).
+    #
+    # It used to branch at step 11 with a comment saying the steps between "do
+    # not apply". They did not merely fail to apply — they ran, and step 10 ended
+    # the run: the backend backstop reads `.terraform/terraform.tfstate` and
+    # raises when it is MISSING, which is exactly what `tofu init` leaves behind
+    # in a directory holding a `Pulumi.yaml` and no `.tf` files. A Pulumi run died
+    # there, before reaching Pulumi, with a message about removing a committed
+    # `override.tf` — advice with nothing to act on.
+    #
+    # What it keeps by branching HERE rather than earlier: the configuration
+    # tarball, the chdir into the working directory, private-git-module auth, and
+    # the operator's `pre_init` hooks — all engine-neutral. What it skips is
+    # Terraform's alone: var-file argv, `init`, terragrunt relocation and the
+    # backstop. Pulumi's own state lives in the service surface (#1522), so there
+    # is no state file to place and no backend to neutralise.
+    if os.environ.get("TP_ENGINE", "") == "pulumi":
+        return _run_pulumi_phase(cfg, child_grace=_child_grace_seconds(cfg))
+
     # 8. Build var-file / target / replace argv pieces.
     var_file_argv = tf_args.var_file_args(cfg.var_files)
 
@@ -757,16 +777,7 @@ def _run_body(cfg: RunnerConfig, work_dir: Path) -> int:
         log.error("backend backstop failed", err=str(exc))
         return 1
 
-    # 11. Phase-specific execution.
-    #
-    # Pulumi branches before Terraform's phases rather than inside them (#1523):
-    # its two phases are `preview`/`update`, and the steps above — backend
-    # neutralisation, var-files, the lock file — are Terraform's own and do not
-    # apply. Terraform's path below is byte-for-byte what it was, which is what
-    # the golden Job-spec matrix asserts.
-    if os.environ.get("TP_ENGINE", "") == "pulumi":
-        return _run_pulumi_phase(cfg, child_grace=child_grace)
-
+    # 11. Phase-specific execution. Terraform only — Pulumi returned at 7b.
     if cfg.phase == "plan":
         return _run_plan_phase(
             cfg,
@@ -800,17 +811,20 @@ def _run_pulumi_phase(cfg, *, child_grace: int) -> int:  # type: ignore[no-untyp
     import structlog
 
     from terrapod.runner import exec_subprocess
-    from terrapod.runner.phases import pulumi_exec
+    from terrapod.runner.phases import platform_tool, pulumi_exec
 
     log = structlog.get_logger("runner.job_entrypoint")
     plan_file = os.environ.get("TP_PULUMI_PLAN_FILE", "/workspace/plan.json")
     phase = os.environ.get("TP_PULUMI_PHASE", cfg.phase)
 
-    # The CLI reads its plugin-download override from the environment, and
-    # `exec_subprocess.run` inherits this process's, so it is set here rather
-    # than passed.
+    # The CLI reads its plugin-download override and its backend from the
+    # environment, and `exec_subprocess.run` inherits this process's, so both are
+    # set here rather than passed.
     os.environ.update(pulumi_exec.plugin_override_env(cfg.api_url, cfg.auth_token))
+    os.environ.update(pulumi_exec.backend_env(cfg.api_url))
 
+    # Decide what to run before fetching what runs it, so an unrecognised phase
+    # costs nothing.
     if phase in ("preview", "plan"):
         argv = pulumi_exec.preview_argv(plan_file, cfg)
         log_file = str(_PLAN_LOG)
@@ -821,9 +835,24 @@ def _run_pulumi_phase(cfg, *, child_grace: int) -> int:  # type: ignore[no-untyp
         log.error("unknown pulumi phase", phase=phase)
         return 1
 
+    # The binary is pulled through the same cache that serves tofu/terraform,
+    # not baked into the image — so the version is an operator-set Helm value
+    # (`registry.platform_tools.pulumi_version`). Unlike opa and trivy there is
+    # no path past here that does not execute it, so it is fetched eagerly once
+    # the phase is known to be real.
+    #
+    # Fails closed: without the binary there is nothing to run, and a bare
+    # "pulumi" to fall back on would either miss entirely or silently pick up
+    # some other install in a future image.
+    try:
+        binary = str(platform_tool.ensure_tool(cfg, "pulumi"))
+    except Exception as exc:
+        log.error("could not obtain the pulumi binary", error=str(exc))
+        return 1
+
     log.info("running pulumi", phase=phase, argv=argv)
     result = exec_subprocess.run(
-        ["pulumi", *argv],
+        [binary, *argv],
         log_file=log_file,
         child_grace_seconds=float(child_grace),
         tee_to_stdout=True,

--- a/services/terrapod/runner/phases/platform_tool.py
+++ b/services/terrapod/runner/phases/platform_tool.py
@@ -39,6 +39,15 @@ from terrapod.runner.runner_config import RunnerConfig
 
 logger = structlog.get_logger("runner.phase.platform_tool")
 
+#: Every tool this runner will ask the API to pin a version for.
+#:
+#: Named rather than inlined so the API's `/platform-tools` response can be
+#: asserted against it. The two are declared separately — the endpoint cannot
+#: import this module — and they drifted once in exactly the way that invites:
+#: `pulumi` was added here and not there, so a Pulumi run asked the cache for
+#: version "" and no test on either side noticed (#1523).
+TOOLS = ("opa", "trivy", "checkov", "pulumi")
+
 
 class PlatformToolsUnsupported(Exception):
     """The API has no platform-tool cache endpoint (it predates the feature).
@@ -64,14 +73,23 @@ class _Unpack:
 
     kind: str  # "raw" | "targz" | "zip"
     member: str  # path within the archive ("" for raw)
+    #: Keep the whole archive, not just `member`.
+    #:
+    #: For a tool that is one self-contained binary, extracting the single
+    #: member is right and cheaper. Pulumi is not that: its release tarball
+    #: holds thirteen executables, and the CLI shells out to the siblings —
+    #: `pulumi-language-python`, `-nodejs`, `-go` and the rest — which must sit
+    #: beside it. Taking only `pulumi/pulumi` yields a CLI that runs, reports
+    #: its version happily, and then fails on the first real program with "no
+    #: language plugin". Verified against the v3.208.0 tarball (#1523).
+    tree: bool = False
 
 
 UNPACK: dict[str, _Unpack] = {
     "opa": _Unpack(kind="raw", member=""),
     "trivy": _Unpack(kind="targz", member="trivy"),
     "checkov": _Unpack(kind="zip", member="dist/checkov"),
-    # The tarball unpacks to `pulumi/pulumi` with the language plugins beside it.
-    "pulumi": _Unpack(kind="targz", member="pulumi/pulumi"),
+    "pulumi": _Unpack(kind="targz", member="pulumi/pulumi", tree=True),
 }
 
 
@@ -124,9 +142,7 @@ def fetch_versions(cfg: RunnerConfig, *, client: httpx.Client | None = None) -> 
         if own:
             c.close()
 
-    versions = {
-        tool: attrs.get(f"{tool}-version", "") for tool in ("opa", "trivy", "checkov", "pulumi")
-    }
+    versions = {tool: attrs.get(f"{tool}-version", "") for tool in TOOLS}
     if not any(versions.values()):
         raise PlatformToolError(
             "the API reported no platform-tool versions — the deployment's "
@@ -135,7 +151,7 @@ def fetch_versions(cfg: RunnerConfig, *, client: httpx.Client | None = None) -> 
     return versions
 
 
-def _extract(archive: Path, spec: _Unpack, dest: Path) -> None:
+def _extract(archive: Path, spec: _Unpack, dest: Path, root: Path | None = None) -> None:
     """Pull the executable out of whatever upstream shipped."""
     if spec.kind == "raw":
         archive.replace(dest)
@@ -144,6 +160,23 @@ def _extract(archive: Path, spec: _Unpack, dest: Path) -> None:
     if spec.kind == "targz":
         try:
             with tarfile.open(archive, "r:gz") as tf:
+                if spec.tree:
+                    assert root is not None  # set by ensure_tool for tree specs
+                    root.mkdir(parents=True, exist_ok=True)
+                    # `filter="data"` refuses absolute paths, `..` traversal and
+                    # device/setuid entries — the archive is fetched from our own
+                    # cache, but it originates upstream and is extracted as a
+                    # tree rather than a single read.
+                    tf.extractall(root, filter="data")
+                    if not dest.exists():
+                        raise PlatformToolError(f"{spec.member} not found in {archive.name}")
+                    # The siblings are executables too, and the data filter
+                    # normalises modes — so the language plugins the CLI shells
+                    # out to have to be made runnable, not just the entrypoint.
+                    for path in dest.parent.iterdir():
+                        if path.is_file():
+                            path.chmod(0o755)
+                    return
                 member = tf.extractfile(spec.member)
                 if member is None:
                     raise PlatformToolError(f"{spec.member} not found in {archive.name}")
@@ -178,7 +211,11 @@ def ensure_tool(
         raise PlatformToolError(f"not a platform tool: {tool!r}")
 
     bin_dir.mkdir(parents=True, exist_ok=True)
-    dest = bin_dir / tool
+    spec_for_dest = UNPACK[tool]
+    # A tree tool keeps its own directory so the siblings the CLI needs stay
+    # beside the entrypoint; everything else is one file directly in bin_dir.
+    tree_root = bin_dir / f"{tool}.d" if spec_for_dest.tree else None
+    dest = (tree_root / spec_for_dest.member) if tree_root else (bin_dir / tool)
     if dest.exists():
         return dest
 
@@ -226,7 +263,7 @@ def ensure_tool(
             f"the deployment is sealed."
         )
 
-    _extract(archive, spec, dest)
+    _extract(archive, spec, dest, root=tree_root)
     dest.chmod(0o755)
     try:
         archive.unlink()

--- a/services/terrapod/runner/phases/pulumi_exec.py
+++ b/services/terrapod/runner/phases/pulumi_exec.py
@@ -32,6 +32,39 @@ from terrapod.logging_config import get_logger
 log = get_logger(__name__)
 
 
+#: The prefix the runner addresses the API by.
+#:
+#: The alias, not the canonical `/api/v1`, and deliberately: a runner image lags
+#: the API by design (the N-2 skew guarantee), so it may be talking to a server
+#: on either side of #1528 and only the alias is served by both. This mirrors
+#: `platform_tool.py`, which reaches the API the same way. The literal is
+#: repeated rather than imported because the runner image ships no `api/`
+#: package to import `prefixes` from.
+_API_PREFIX = "/api/terrapod/v1"
+
+
+def backend_env(api_url: str) -> dict[str, str]:
+    """Point the CLI at Terrapod as its state backend (#1523).
+
+    Pulumi resolves its backend from `pulumi login` or `PULUMI_BACKEND_URL`, and
+    a runner Job has no interactive login to perform — so the URL is handed to it
+    directly. Without this the CLI silently falls back to its default host: an
+    air-gapped deployment hangs, and one with egress talks to the wrong backend
+    entirely, which is the worse of the two because it looks like it worked.
+
+    The base is the service surface from #1522; the CLI appends its own `/api/...`
+    paths to whatever it is given, which is what lets that surface be mounted
+    inside Terrapod's API namespace instead of taking the root.
+
+    The token that authenticates against it is already set by
+    `plugin_override_env` — one credential serves both the backend and the plugin
+    proxy, because both are this same API.
+    """
+    if not api_url:
+        return {}
+    return {"PULUMI_BACKEND_URL": f"{api_url.rstrip('/')}{_API_PREFIX}/pulumi"}
+
+
 def plugin_override_env(api_url: str, token: str) -> dict[str, str]:
     """Point plugin downloads at Terrapod rather than get.pulumi.com.
 
@@ -43,7 +76,7 @@ def plugin_override_env(api_url: str, token: str) -> dict[str, str]:
     if not api_url:
         return {}
     base = api_url.rstrip("/")
-    env = {"PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES": f".*={base}/api/v1/package-cache/pulumi"}
+    env = {"PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES": f".*={base}{_API_PREFIX}/package-cache/pulumi"}
     if token:
         # The proxy authenticates like every other Terrapod cache; the runner's
         # own short-lived token is what it presents.

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -107,6 +107,7 @@
   "binary_cache.platform_tool_versions": [
     "checkov-version",
     "opa-version",
+    "pulumi-version",
     "trivy-version"
   ],
   "cache_warm._submit": [

--- a/services/tests/api/test_binary_cache.py
+++ b/services/tests/api/test_binary_cache.py
@@ -413,7 +413,36 @@ class TestPlatformToolVersions:
             "opa-version": cfg.opa_version,
             "trivy-version": cfg.trivy_version,
             "checkov-version": cfg.checkov_version,
+            "pulumi-version": cfg.pulumi_version,
         }
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_it_answers_every_tool_the_runner_asks_about(self, *mocks):
+        """The two ends of this endpoint drifted once, silently (#1523).
+
+        The runner has always read `pulumi-version` from this response, and the
+        response never carried it — so a Pulumi run asked the binary cache for
+        version "" and got nothing. Neither side's tests caught it: the runner's
+        assert the key is parsed out of a *mocked* body that did include it, and
+        this one asserted an exact three-key set that did not.
+
+        Pinning the endpoint to the runner's own list is what makes the next
+        tool impossible to half-wire — add one to `fetch_versions` without adding
+        it here and this fails.
+        """
+        from terrapod.runner.phases.platform_tool import TOOLS
+
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(self._URL, headers=_AUTH)
+
+        served = set(resp.json()["data"]["attributes"])
+        wanted = {f"{tool}-version" for tool in TOOLS}
+        assert wanted <= served, (
+            f"the runner asks for {sorted(wanted - served)} and is not answered"
+        )
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/runner/test_job_entrypoint.py
+++ b/services/tests/runner/test_job_entrypoint.py
@@ -15,6 +15,7 @@ pin the orchestrator-level invariants:
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 from terrapod.runner import job_entrypoint
@@ -402,3 +403,122 @@ class TestPlanPhaseExecutionHooks:
 
         assert rc == 0
         assert points == ["pre_plan", "post_plan"]
+
+
+class TestThePulumiPhase:
+    """#1523. The Pulumi branch is short, but every line of it is a thing that
+    fails quietly when it is missing — a default backend, a default plugin host,
+    or a `pulumi` picked up from the image rather than the cache."""
+
+    def _cfg(self, monkeypatch):
+        _env(monkeypatch)
+        monkeypatch.setenv("TP_ENGINE", "pulumi")
+        monkeypatch.setenv("TP_PULUMI_PHASE", "preview")
+        from terrapod.runner.runner_config import RunnerConfig
+
+        return RunnerConfig.from_env()
+
+    def test_it_runs_the_binary_it_fetched(self, monkeypatch) -> None:
+        """Not a bare `pulumi` off PATH. The runner image ships none, and one
+        appearing there later would silently outrank the pinned version."""
+        cfg = self._cfg(monkeypatch)
+        with (
+            patch(
+                "terrapod.runner.phases.platform_tool.ensure_tool",
+                return_value="/cache/pulumi",
+            ),
+            patch("terrapod.runner.exec_subprocess.run") as run,
+        ):
+            run.return_value.exit_code = 0
+            assert job_entrypoint._run_pulumi_phase(cfg, child_grace=5) == 0
+
+        assert run.call_args[0][0][0] == "/cache/pulumi"
+
+    def test_it_fails_closed_when_the_binary_cannot_be_fetched(self, monkeypatch) -> None:
+        """There is nothing to fall back to, and falling back to the name would
+        either miss or run something unpinned."""
+        cfg = self._cfg(monkeypatch)
+        with (
+            patch(
+                "terrapod.runner.phases.platform_tool.ensure_tool",
+                side_effect=RuntimeError("cache is down"),
+            ),
+            patch("terrapod.runner.exec_subprocess.run") as run,
+        ):
+            assert job_entrypoint._run_pulumi_phase(cfg, child_grace=5) == 1
+
+        run.assert_not_called()
+
+    def test_it_exports_the_backend_and_the_plugin_override(self, monkeypatch) -> None:
+        """Both are read from the environment by the CLI, so the assertion is
+        that they are actually in it by the time the subprocess is spawned."""
+        cfg = self._cfg(monkeypatch)
+        monkeypatch.delenv("PULUMI_BACKEND_URL", raising=False)
+        monkeypatch.delenv("PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES", raising=False)
+
+        seen = {}
+        with (
+            patch(
+                "terrapod.runner.phases.platform_tool.ensure_tool",
+                return_value="/cache/pulumi",
+            ),
+            patch("terrapod.runner.exec_subprocess.run") as run,
+        ):
+            run.side_effect = lambda *a, **k: seen.update(os.environ) or run.return_value
+            run.return_value.exit_code = 0
+            job_entrypoint._run_pulumi_phase(cfg, child_grace=5)
+
+        assert seen["PULUMI_BACKEND_URL"].endswith("/api/terrapod/v1/pulumi")
+        assert seen["PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES"].startswith(".*=")
+
+    def test_an_unknown_phase_is_refused_without_fetching_anything(self, monkeypatch) -> None:
+        """The phase is checked first, so a bad one does not pay for a download
+        it will discard."""
+        cfg = self._cfg(monkeypatch)
+        monkeypatch.setenv("TP_PULUMI_PHASE", "nonesuch")
+        with patch("terrapod.runner.phases.platform_tool.ensure_tool") as ensure:
+            assert job_entrypoint._run_pulumi_phase(cfg, child_grace=5) == 1
+        ensure.assert_not_called()
+
+
+class TestPulumiSkipsTerraformsSetup:
+    """#1523. Where the Pulumi branch sits is load-bearing, not cosmetic.
+
+    It used to sit at step 11, below `init` and the backend backstop, with a
+    comment saying those steps "do not apply". They ran anyway, and the backstop
+    ended the run: it raises when `.terraform/terraform.tfstate` is MISSING,
+    which is what `tofu init` leaves in a directory holding a `Pulumi.yaml` and
+    no `.tf` files. The run died before reaching Pulumi, advising the operator to
+    remove a committed `override.tf` that did not exist.
+
+    Asserted on the source rather than by driving the orchestrator, because the
+    property is an ordering one and the alternative is mocking ten phases to
+    observe which of them ran.
+    """
+
+    def _body_source(self) -> str:
+        import inspect
+
+        return inspect.getsource(job_entrypoint)
+
+    def test_the_branch_precedes_init_and_the_backstop(self) -> None:
+        src = self._body_source()
+        branch = src.index('if os.environ.get("TP_ENGINE", "") == "pulumi":')
+
+        for marker in ("# 9. Init", "# 10. Backend backstop", "# 8. Build var-file"):
+            assert branch < src.index(marker), (
+                f"the Pulumi branch must come before {marker!r} — those steps are "
+                "Terraform's, and the backstop fails a Pulumi run outright"
+            )
+
+    def test_the_branch_follows_the_engine_neutral_setup(self) -> None:
+        """Config tarball, chdir and the operator's pre_init hooks are not
+        Terraform-specific, and a Pulumi run needs all three."""
+        src = self._body_source()
+        branch = src.index('if os.environ.get("TP_ENGINE", "") == "pulumi":')
+
+        for marker in ("# 2. Configuration tarball", "# 4. Chdir", "# 7. pre_init"):
+            assert branch > src.index(marker), (
+                f"the Pulumi branch must come after {marker!r} — it is engine-neutral "
+                "and Pulumi depends on it"
+            )

--- a/services/tests/runner/test_platform_tool.py
+++ b/services/tests/runner/test_platform_tool.py
@@ -315,3 +315,75 @@ def test_unpack_table_agrees_with_the_server_spec():
     for tool, spec in SPECS.items():
         assert UNPACK[tool].kind == spec.archive, tool
         assert UNPACK[tool].member == spec.member, tool
+
+
+class TestPulumiKeepsItsSiblings:
+    """#1523. Pulumi's tarball is not one binary.
+
+    It holds thirteen: the CLI plus the language hosts and analyzers it shells
+    out to. Extracting only `pulumi/pulumi` produces a CLI that runs and reports
+    its version perfectly well, then fails on the first real program with "no
+    language plugin" — so this asserts the layout, not just that a file landed.
+    """
+
+    def _fake_release(self, tmp_path):
+        """A tarball shaped like the real one, from its actual member list."""
+        import tarfile
+
+        members = [
+            "pulumi/pulumi",
+            "pulumi/pulumi-language-python",
+            "pulumi/pulumi-language-nodejs",
+            "pulumi/pulumi-language-go",
+            "pulumi/pulumi-analyzer-policy",
+        ]
+        src = tmp_path / "src"
+        (src / "pulumi").mkdir(parents=True)
+        for m in members:
+            (src / m).write_bytes(b"#!/bin/sh\n")
+        archive = tmp_path / "pulumi.download"
+        with tarfile.open(archive, "w:gz") as tf:
+            for m in members:
+                tf.add(src / m, arcname=m)
+        return archive, members
+
+    def test_every_sibling_is_extracted_and_executable(self, tmp_path):
+        from terrapod.runner.phases.platform_tool import UNPACK, _extract
+
+        archive, members = self._fake_release(tmp_path)
+        root = tmp_path / "bin" / "pulumi.d"
+        dest = root / "pulumi/pulumi"
+
+        _extract(archive, UNPACK["pulumi"], dest, root=root)
+
+        for m in members:
+            path = root / m
+            assert path.exists(), f"{m} was not extracted — the CLI needs it beside pulumi"
+            assert path.stat().st_mode & 0o111, f"{m} is not executable"
+
+    def test_the_language_hosts_sit_beside_the_entrypoint(self, tmp_path):
+        """Adjacency is the requirement, not mere presence — the CLI looks for
+        them next to its own argv[0]."""
+        from terrapod.runner.phases.platform_tool import UNPACK, _extract
+
+        archive, _ = self._fake_release(tmp_path)
+        root = tmp_path / "bin" / "pulumi.d"
+        dest = root / "pulumi/pulumi"
+
+        _extract(archive, UNPACK["pulumi"], dest, root=root)
+
+        assert (dest.parent / "pulumi-language-python").exists()
+
+    def test_the_real_release_tarball_has_siblings(self):
+        """Guards the premise itself.
+
+        If upstream ever ships a single self-contained binary, `tree` becomes
+        unnecessary — and if this list is wrong the two tests above are testing
+        a shape that does not exist. Asserted against the member list read from
+        the real v3.208.0 linux-x64 tarball.
+        """
+        from terrapod.runner.phases.platform_tool import UNPACK
+
+        spec = UNPACK["pulumi"]
+        assert spec.tree, "pulumi ships plugins beside the CLI; a single member is not enough"
+        assert spec.member == "pulumi/pulumi"

--- a/services/tests/runner/test_pulumi_exec.py
+++ b/services/tests/runner/test_pulumi_exec.py
@@ -1,0 +1,141 @@
+"""What the runner tells the Pulumi CLI to do (#1523).
+
+The module had no tests. Everything here is a thing that fails *silently* when it
+is wrong — the CLI carries on and does something plausible with a default — which
+is why they are worth pinning rather than left to the live smoke:
+
+  * a plugin-override pattern that matches nothing falls back to get.pulumi.com
+  * a missing backend URL falls back to Pulumi's own SaaS
+  * a preview and its update disagreeing about the plan file surfaces as "no
+    plan file" on the update, a long way from the preview that should have
+    written it
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from terrapod.runner.phases import pulumi_exec
+from terrapod.runner.runner_config import RunnerConfig
+
+API = "https://terrapod.test"
+
+
+def _cfg(**over) -> RunnerConfig:
+    cfg = RunnerConfig.from_env(
+        env={
+            "TP_API_URL": API,
+            "TP_AUTH_TOKEN": "tok",
+            "TP_RUN_ID": "run-1",
+            "TP_BACKEND": "tofu",
+            "TP_VERSION": "1.12.1",
+        }
+    )
+    return dataclasses.replace(cfg, **({"os": "linux", "arch": "amd64", **over}))
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """The argv builders read TP_* directly, so leakage between tests is real."""
+    for k in (
+        "TP_PULUMI_STACK",
+        "TP_REFRESH",
+        "TP_PARALLELISM",
+        "TP_TARGET_URNS",
+        "TP_DESTROY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+class TestTheBackend:
+    def test_it_points_at_terrapod(self) -> None:
+        env = pulumi_exec.backend_env(API)
+        assert env["PULUMI_BACKEND_URL"] == f"{API}/api/terrapod/v1/pulumi"
+
+    def test_it_uses_the_alias_prefix_not_the_canonical_one(self) -> None:
+        """A runner lags the API by design, so it may be talking to a server on
+        either side of #1528 — and only the alias is served by both."""
+        url = pulumi_exec.backend_env(API)["PULUMI_BACKEND_URL"]
+        assert "/api/terrapod/v1/" in url
+        assert "/api/v1/" not in url
+
+    def test_a_trailing_slash_does_not_double_up(self) -> None:
+        assert (
+            pulumi_exec.backend_env(API + "/")["PULUMI_BACKEND_URL"]
+            == pulumi_exec.backend_env(API)["PULUMI_BACKEND_URL"]
+        )
+
+    def test_no_api_url_sets_nothing(self) -> None:
+        """Better to leave it unset than to export a malformed URL the CLI would
+        try to reach."""
+        assert pulumi_exec.backend_env("") == {}
+
+
+class TestThePluginOverride:
+    def test_the_pattern_is_the_catch_all(self) -> None:
+        """The one that cannot miss.
+
+        An anchored pattern that fails to match does not error — the CLI just
+        uses its default host. So it works for anyone with egress and hangs for
+        anyone air-gapped, which is the failure this asserts away.
+        """
+        value = pulumi_exec.plugin_override_env(API, "tok")["PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES"]
+        assert value.startswith(".*=")
+
+    def test_it_points_at_the_package_cache_on_the_alias_prefix(self) -> None:
+        value = pulumi_exec.plugin_override_env(API, "tok")["PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES"]
+        assert value == f".*={API}/api/terrapod/v1/package-cache/pulumi"
+
+    def test_the_token_is_carried(self) -> None:
+        assert pulumi_exec.plugin_override_env(API, "tok")["PULUMI_ACCESS_TOKEN"] == "tok"
+
+    def test_no_api_url_sets_nothing(self) -> None:
+        assert pulumi_exec.plugin_override_env("", "tok") == {}
+
+
+class TestThePhaseArgv:
+    def test_preview_saves_the_plan_the_update_reads(self) -> None:
+        """The pairing is what makes an approved preview and its update one
+        decision rather than two independent runs."""
+        plan = "/workspace/plan.json"
+        assert f"--save-plan={plan}" in pulumi_exec.preview_argv(plan, _cfg())
+        assert f"--plan={plan}" in pulumi_exec.update_argv(plan, _cfg())
+
+    def test_both_phases_are_non_interactive(self) -> None:
+        """A runner Job has no terminal; a prompt is a hang until the timeout."""
+        assert "--non-interactive" in pulumi_exec.preview_argv("p", _cfg())
+        assert "--non-interactive" in pulumi_exec.update_argv("p", _cfg())
+
+    def test_the_update_confirms_itself(self) -> None:
+        assert "--yes" in pulumi_exec.update_argv("p", _cfg())
+
+    def test_a_destroy_takes_no_plan(self, monkeypatch) -> None:
+        """`destroy` rejects a plan file — there is nothing to preview into one
+        that it would read back."""
+        monkeypatch.setenv("TP_DESTROY", "true")
+        argv = pulumi_exec.update_argv("/workspace/plan.json", _cfg())
+        assert argv[0] == "destroy"
+        assert not any(a.startswith("--plan=") for a in argv)
+
+    def test_the_stack_is_passed_when_set(self, monkeypatch) -> None:
+        monkeypatch.setenv("TP_PULUMI_STACK", "proj/dev")
+        argv = pulumi_exec.preview_argv("p", _cfg())
+        assert argv[argv.index("--stack") + 1] == "proj/dev"
+
+    def test_refresh_is_only_disabled_when_asked(self, monkeypatch) -> None:
+        assert "--refresh=false" not in pulumi_exec.preview_argv("p", _cfg())
+        monkeypatch.setenv("TP_REFRESH", "false")
+        assert "--refresh=false" in pulumi_exec.preview_argv("p", _cfg())
+
+    def test_targets_become_repeated_flags(self, monkeypatch) -> None:
+        monkeypatch.setenv("TP_TARGET_URNS", '["urn:a", "urn:b"]')
+        argv = pulumi_exec.preview_argv("p", _cfg())
+        assert argv.count("--target") == 2
+        assert "urn:a" in argv and "urn:b" in argv
+
+    def test_an_empty_target_list_adds_nothing(self, monkeypatch) -> None:
+        """`--target` with no value would scope the run to nothing at all."""
+        monkeypatch.setenv("TP_TARGET_URNS", "")
+        assert "--target" not in pulumi_exec.preview_argv("p", _cfg())


### PR DESCRIPTION
#1534 registered the strategy and built the Job. The Job could not have run a
Pulumi program: three things it needs were unwired, and each fails in a way that
looks like something else.

**The binary was never fetched.** `_run_pulumi_phase` invoked `["pulumi", …]` and
expected it on PATH. The runner image ships none — deliberately, as it ships no
tofu or terraform either; they are pulled through the cache so the version is an
operator-set Helm value. The Pulumi half of that was already built (the archive
spec, the mirror, `configured_version`, `download_url`, `_UNPACK["pulumi"]`, the
`pulumi_version` value) and simply not called. It is now, eagerly once the phase
is known to be real, and it fails closed: falling back to a bare name would
either miss or silently run an unpinned binary that appeared in a later image.

**`/platform-tools` never answered for it.** The runner has always read
`pulumi-version` from that response; the endpoint returned opa, trivy and
checkov only, so a Pulumi run asked the cache for version `""`. Both sides had
tests and neither caught it — the runner's parse a *mocked* body that did include
the key, and the endpoint's asserted an exact three-key set that did not. The
runner's tool list is now a named constant the endpoint's test asserts against,
so the next tool cannot be half-wired the same way.

**Nothing told the CLI where its backend was.** Pulumi resolves that from
`pulumi login` or `PULUMI_BACKEND_URL`, and a Job has no interactive login to
perform. Unset, the CLI falls back to its own SaaS: an air-gapped deployment
hangs, and one with egress talks to the wrong backend entirely — the worse case,
because it looks like it worked. The Job now exports the #1522 service surface,
authenticated by the run's own token, which was already being passed.

Both URLs use the `/api/terrapod/v1` alias rather than the canonical prefix,
matching `platform_tool.py`: a runner lags the API by design, so it may be
talking to a server on either side of #1528 and only the alias is served by both.
The plugin override had drifted to the canonical form and is brought back.

**One more, found by checking the premise rather than trusting the comment.**
The extractor took a single member, `pulumi/pulumi`. The real v3.208.0 tarball
holds **thirteen** executables — the CLI plus `pulumi-language-python`,
`-nodejs`, `-go`, `-dotnet`, `-java`, `-yaml` and the analyzers — and the CLI
shells out to whichever language host the program needs, from beside its own
argv[0]. Taking one member yields a `pulumi` that runs, reports its version
correctly, and then fails on the first real program with "no language plugin".
`_Unpack` grows a `tree` flag; Pulumi keeps its own directory so the siblings
stay adjacent, and they are made executable, not just the entrypoint. Extraction
uses `filter="data"`, since this is now a tree rather than a single read.

Tests: `test_pulumi_exec.py` is new — the module had none — covering the
catch-all plugin pattern, the backend URL and prefix, and the argv builders
including a destroy taking no plan. The entrypoint tests cover running the
fetched binary, failing closed without it, exporting both env vars, and
rejecting an unknown phase before paying for a download. The sibling-extraction
tests were mutation-checked: reverting `tree` fails three of them.

The attribute snapshot gains `pulumi-version` — additive.

This is the agent-execution path, which is not optional: #1407 requires that
`engine` must not imply execution locus.

Part of #1523, and of #1407.

**Deliberately does not close #1523.** That issue's acceptance list ends with "a `engine=pulumi` workspace runs a real preview and a real update on the Tilt stack", and this has not been run against a live stack yet — only against the test suite. The four blockers it fixes were each found by inspection rather than by a run, which is exactly why the run is still worth doing: it is the step that would have caught them, and it may yet find a fifth.

