### PR TITLE
docs: EKS Pod Identity breaks role chaining without sts:TagSession

### DIFF
--- a/docs/cloud-credentials.md
+++ b/docs/cloud-credentials.md
@@ -414,6 +414,59 @@ runners:
 That is the whole Terrapod-side change: the same values as IRSA with the
 `eks.amazonaws.com/role-arn` annotations removed.
 
+### Role chaining needs `sts:TagSession`
+
+If your Terraform assumes a *further* role — a cross-account `automation` role,
+say — Pod Identity changes what that requires, and the failure does not look
+like an identity problem:
+
+```
+User: arn:aws:sts::111122223333:assumed-role/terrapod-runner-prod/eks-my-cluster-...
+is not authorized to perform: sts:TagSession
+on resource: arn:aws:iam::444455556666:role/automation
+```
+
+It names **`sts:TagSession`**, not `sts:AssumeRole`, which is why it reads like
+something unrelated to credentials.
+
+Pod Identity attaches session tags to the pod's credentials — cluster, namespace,
+ServiceAccount — and marks them **transitive**, so they persist into any role
+the pod then assumes. A chained `AssumeRole` carrying transitive tags needs
+permission to set them. IRSA attaches no such tags, so the same policies work
+under IRSA and stop working the moment a deployment switches, with nothing in
+those policies having changed.
+
+**Both ends need it.** The runner's own policy, to make the call:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["sts:AssumeRole", "sts:TagSession"],
+  "Resource": "arn:aws:iam::444455556666:role/automation"
+}
+```
+
+and the destination role's trust policy, to accept it:
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": { "AWS": "arn:aws:iam::111122223333:role/terrapod-runner-prod" },
+  "Action": ["sts:AssumeRole", "sts:TagSession"]
+}
+```
+
+Where the trust policy names an account root rather than the role, the decision
+is delegated to the caller's own IAM policy — so the first block is what
+matters, and adding `sts:TagSession` only to the trust policy will not fix it.
+
+This bites unevenly across an estate: accounts whose trust policies happened to
+grant `sts:TagSession` already keep working, and the rest fail. That makes the
+switch look intermittent rather than systematic. Auditing every role your
+runners can assume is quicker than following the failures one at a time.
+
+Nothing in Terrapod needs changing for this — it is entirely IAM.
+
 ### Do not configure both
 
 If a ServiceAccount carries `eks.amazonaws.com/role-arn` *and* has a Pod

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -577,6 +577,51 @@ Redis is the backbone for sessions, the scheduler, listener data, and live log s
 
 ---
 
+## Plan fails with `sts:TagSession` after switching to EKS Pod Identity
+
+**Symptom.** Runs that assume a further role fail at plan time, and the error
+names an action nobody granted or asked for:
+
+```
+Error: Cannot assume IAM Role
+IAM Role (arn:aws:iam::444455556666:role/automation) cannot be assumed.
+
+Error: operation error STS: AssumeRole, https response error StatusCode: 403,
+api error AccessDenied: User:
+arn:aws:sts::111122223333:assumed-role/terrapod-runner-prod/eks-my-cluster-...
+is not authorized to perform: sts:TagSession
+on resource: arn:aws:iam::444455556666:role/automation
+```
+
+Two things identify it: the action is **`sts:TagSession`**, not `sts:AssumeRole`,
+and the session name begins **`eks-`**, which is Pod Identity's own naming. An
+IRSA session does not look like that.
+
+**Cause.** EKS Pod Identity attaches session tags to the pod's credentials and
+marks them transitive, so they persist into any role the pod subsequently
+assumes — and that chained call needs permission to set them. IRSA attaches no
+tags. So policies that were correct under IRSA start failing the moment a
+deployment switches, without anything in them changing.
+
+**It will look intermittent.** Accounts whose trust policies already granted
+`sts:TagSession` keep working; the rest fail. Expect a subset of workspaces to
+break rather than all of them, which is misleading when you are trying to work
+out what changed.
+
+**Fix.** Grant `sts:TagSession` alongside `sts:AssumeRole` at **both** ends —
+the runner's own policy and the destination role's trust policy. Full detail and
+the exact statements: [Role chaining needs `sts:TagSession`](cloud-credentials.md#role-chaining-needs-ststagsession).
+
+Where a trust policy names an account **root** rather than a role, the decision
+is delegated to the caller's IAM policy — so the runner-side grant is the one
+that matters and a trust-policy-only change will not fix it.
+
+**Check every role your runners can assume**, not just the one that failed. The
+failure is generic to every cross-account hop from a Pod Identity runner;
+fixing them one at a time as they surface just defers the next.
+
+Nothing in Terrapod changes for this — it is entirely IAM.
+
 ## Storage Errors
 
 Object storage (S3, Azure Blob, GCS, or filesystem) failures prevent state uploads, config downloads, log persistence, and cache operations.

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -506,6 +506,10 @@ For Tilt local development, `values-local.yaml` overrides `listener_cert_ttl_sec
 
 ---
 
+## Troubleshooting
+
+**`sts:TagSession` denied on a cross-account assume.** The deployment uses EKS Pod Identity and the workspace assumes a further role; both ends need that action granted. See the [runbook entry](runbooks.md#plan-fails-with-ststagsession-after-switching-to-eks-pod-identity).
+
 ## See Also
 
 - [Architecture](architecture.md) -- runner listener, reconciler, ARC pattern


### PR DESCRIPTION
Terrapod's cloud-credentials guide already says `sts:TagSession` is mandatory in
the trust policy for the pod-to-role hop. It said nothing about what happens when
the workspace's Terraform then assumes a *further* role, which is where this
actually bites — and the failure is unusually hard to place:

  is not authorized to perform: sts:TagSession
  on resource: arn:aws:iam::444455556666:role/automation

It names TagSession rather than AssumeRole, so it does not read as a credentials
problem at all. Pod Identity marks its injected session tags transitive, so they
persist into a chained assume and that call needs permission to set them; IRSA
injects none, which is why the same policies work right up to a switch and then
stop with nothing in them having changed.

The part worth documenting beyond the fix is that it looks **intermittent**:
accounts whose trust policies already granted the action keep working and the
rest fail, so a subset of workspaces breaks rather than all of them. That is
misleading precisely when someone is trying to work out what changed.

Also documents the case that makes a trust-policy-only fix insufficient — where
the trust policy names an account root, the decision is delegated to the caller's
own IAM policy, so the runner-side grant is the one that matters.

Adds a symptom-first runbook entry, since an operator meets this as a failing
plan rather than as an identity question, and a pointer from the runner doc.
Nothing in Terrapod changes; this is IAM.
