### PR TITLE
refactor(1536): store the engine on workspaces only

### DIFF
--- a/alembic/versions/697c42296453_engine_discriminator.py
+++ b/alembic/versions/697c42296453_engine_discriminator.py
@@ -1,4 +1,4 @@
-"""Add the engine discriminator to workspaces and runs
+"""Add the engine discriminator to workspaces
 
 #1407 phase 1 (#1487). Expand-only: the column is added with a server default of
 ``terraform``, so every existing row is correct without a backfill and an older
@@ -6,17 +6,23 @@ replica mid-rollout never reads a value it cannot interpret. Nothing to contract
 later — there is no old column being replaced.
 
 ``engine`` is deliberately *not* ``execution_backend``, which already sits on
-both of these tables and picks the binary (tofu vs terraform) *within* the
-Terraform family. This names the family itself.
+workspaces and picks the binary (tofu vs terraform) *within* the Terraform
+family. This names the family itself.
 
-**Not on ``configuration_versions`` (#1536).** This migration originally added it
-there too, for symmetry, and nothing ever read it: a configuration version is
-reachable only through its workspace, which carries the engine, and engine is
-identity — replace-forcing, never edited — so there is no mid-flight change to
-snapshot against. It was removed by amending this migration in place rather than
-by a contraction, which is sound only because the migration had never shipped in
-any release, so no deployment ever ran it and no replica could have read the
-column. Do not repeat that move on a released migration.
+**Workspaces only (#1536).** This migration originally added the column to
+``configuration_versions`` and ``runs`` too, as "the three tables a run's
+identity flows through". Neither copy earned its place. Engine is identity —
+replace-forcing, never edited — so there is nothing mid-flight to snapshot, and
+everything that needs it can reach the workspace: a configuration version only
+ever through it, a run by a join (the reconciler's one query per cycle) or from
+a workspace its caller already holds. A stored copy is also how #1523 happened:
+a run's copy defaulted to ``terraform`` and sent Pulumi runs down the Terraform
+path, reporting success.
+
+The other two columns were removed by amending this migration in place rather
+than by a contraction. That is sound only because the migration had shipped in
+no release, so no deployment ran it and no replica could have read the columns.
+Do not repeat that move on a released migration.
 
 Revision ID: 697c42296453
 Revises: edd2bcb183de
@@ -31,10 +37,8 @@ down_revision = "edd2bcb183de"
 branch_labels = None
 depends_on = None
 
-#: Where the engine is read. The workspace owns it; the run carries a copy because
-#: the reconciler holds a Run and no Workspace, every few seconds, over every
-#: in-flight run — the one place a join would cost something.
-_TABLES = ("workspaces", "runs")
+#: The one table that stores the engine. Everything else joins to it.
+_TABLES = ("workspaces",)
 
 
 def upgrade() -> None:

--- a/alembic/versions/697c42296453_engine_discriminator.py
+++ b/alembic/versions/697c42296453_engine_discriminator.py
@@ -1,13 +1,22 @@
-"""Add the engine discriminator to the three run-lifecycle tables
+"""Add the engine discriminator to workspaces and runs
 
 #1407 phase 1 (#1487). Expand-only: the column is added with a server default of
 ``terraform``, so every existing row is correct without a backfill and an older
 replica mid-rollout never reads a value it cannot interpret. Nothing to contract
 later — there is no old column being replaced.
 
-``engine`` is deliberately *not* ``execution_backend``, which already sits on two
-of these tables and picks the binary (tofu vs terraform) *within* the Terraform
-family. This names the family itself.
+``engine`` is deliberately *not* ``execution_backend``, which already sits on
+both of these tables and picks the binary (tofu vs terraform) *within* the
+Terraform family. This names the family itself.
+
+**Not on ``configuration_versions`` (#1536).** This migration originally added it
+there too, for symmetry, and nothing ever read it: a configuration version is
+reachable only through its workspace, which carries the engine, and engine is
+identity — replace-forcing, never edited — so there is no mid-flight change to
+snapshot against. It was removed by amending this migration in place rather than
+by a contraction, which is sound only because the migration had never shipped in
+any release, so no deployment ever ran it and no replica could have read the
+column. Do not repeat that move on a released migration.
 
 Revision ID: 697c42296453
 Revises: edd2bcb183de
@@ -22,9 +31,10 @@ down_revision = "edd2bcb183de"
 branch_labels = None
 depends_on = None
 
-#: The three tables a run's identity flows through: the workspace it belongs to,
-#: the configuration it runs, and the run itself.
-_TABLES = ("workspaces", "configuration_versions", "runs")
+#: Where the engine is read. The workspace owns it; the run carries a copy because
+#: the reconciler holds a Run and no Workspace, every few seconds, over every
+#: in-flight run — the one place a join would cost something.
+_TABLES = ("workspaces", "runs")
 
 
 def upgrade() -> None:

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -119,9 +119,23 @@ def _plan_summary_attr(run: Run) -> dict[str, int] | None:
     }
 
 
+async def _engine_of(run: Run, db: AsyncSession) -> str:
+    """The engine a run executes with, which is always its workspace's (#1536).
+
+    For handlers that have not loaded the workspace themselves. `db.get` is
+    served from the session's identity map when an RBAC check already did, so
+    this is usually no query at all.
+    """
+    ws = await db.get(Workspace, run.workspace_id)
+    return ws.engine
+
+
 def _run_json(
     run: Run,
     *,
+    # Required, with no default (#1536): a run has no engine of its own, and a
+    # default is how a Pulumi run came to be reported as a Terraform one (#1523).
+    engine: str,
     workspace_name: str = "",
     workspace_has_vcs: bool = False,
     state_version_id: str | None = None,
@@ -152,8 +166,9 @@ def _run_json(
                 "execution-backend": run.execution_backend,
                 # Which engine, not which binary (#1407). The UI resolves phase
                 # vocabulary from this — a run is `planning` internally whatever
-                # engine it is, but what a person is shown differs.
-                "engine": run.engine,
+                # engine it is, but what a person is shown differs. Derived from
+                # the workspace and passed in; runs store no copy (#1536).
+                "engine": engine,
                 "terraform-version": run.terraform_version,
                 "terragrunt-enabled": run.terragrunt_enabled,
                 "terragrunt-version": run.terragrunt_version,
@@ -546,6 +561,7 @@ async def create_run(
     return JSONResponse(
         content=_run_json(
             run,
+            engine=ws.engine,
             workspace_name=ws.name,
             workspace_has_vcs=ws.vcs_connection_id is not None,
         ),
@@ -574,6 +590,7 @@ async def show_run(
     return JSONResponse(
         content=_run_json(
             run,
+            engine=ws.engine,
             workspace_name=ws.name if ws else "",
             workspace_has_vcs=bool(ws and ws.vcs_connection_id),
             state_version_id=sv_id,
@@ -614,7 +631,9 @@ async def list_workspace_runs(
     return JSONResponse(
         content={
             "data": [
-                _run_json(r, workspace_name=ws.name, workspace_has_vcs=has_vcs)["data"]
+                _run_json(r, engine=ws.engine, workspace_name=ws.name, workspace_has_vcs=has_vcs)[
+                    "data"
+                ]
                 for r in runs
             ],
             "meta": build_meta(total, page_number, page_size),
@@ -690,7 +709,7 @@ async def confirm_run(
         raise HTTPException(status_code=422, detail=str(e.reason)) from e
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
-    return JSONResponse(content=_run_json(run))
+    return JSONResponse(content=_run_json(run, engine=await _engine_of(run, db)))
 
 
 @router.post("/runs/{run_id}/actions/discard")
@@ -707,7 +726,7 @@ async def discard_run(
         await db.commit()
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
-    return JSONResponse(content=_run_json(run))
+    return JSONResponse(content=_run_json(run, engine=await _engine_of(run, db)))
 
 
 @router.post("/runs/{run_id}/actions/cancel")
@@ -724,7 +743,7 @@ async def cancel_run(
         await db.commit()
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
-    return JSONResponse(content=_run_json(run))
+    return JSONResponse(content=_run_json(run, engine=await _engine_of(run, db)))
 
 
 @extensions_router.post("/runs/{run_id}/actions/retry")
@@ -810,7 +829,7 @@ async def retry_run(
     new_run = await run_service.queue_run(db, new_run)
     await db.commit()
 
-    return JSONResponse(content=_run_json(new_run), status_code=201)
+    return JSONResponse(content=_run_json(new_run, engine=ws.engine), status_code=201)
 
 
 # ── Phase Status Mapping ─────────────────────────────────────────────────
@@ -2108,13 +2127,13 @@ async def next_run(
 
     await db.commit()
 
-    run_data = _run_json(run)
+    run_data = _run_json(run, engine=ws.engine)
     # Which engine this run belongs to (#1407 phase 1). Sent on the runner wire
     # only, not on the public run serializer: nothing outside the listener has a
     # use for it yet, and adding it here keeps the attribute contract still.
     # A listener too old to read it is unaffected — it ignores unknown keys, and
     # its absence resolves to terraform on the far side.
-    run_data["data"]["attributes"]["engine"] = run.engine
+    run_data["data"]["attributes"]["engine"] = ws.engine
     run_data["data"]["attributes"]["env-vars"] = env_vars
     run_data["data"]["attributes"]["terraform-vars"] = terraform_vars
     run_data["data"]["attributes"]["execution-hooks"] = execution_hooks
@@ -2140,7 +2159,7 @@ async def next_run(
     # the Terraform wire is byte-identical.
     from terrapod.api.routers.pulumi_service import DEFAULT_ORG, PULUMI_ENGINE
 
-    if run.engine == PULUMI_ENGINE and ws is not None and "::" in ws.name:
+    if ws is not None and ws.engine == PULUMI_ENGINE and "::" in ws.name:
         project, _, stack = ws.name.partition("::")
         run_data["data"]["attributes"]["pulumi-stack"] = f"{DEFAULT_ORG}/{project}/{stack}"
 
@@ -2247,7 +2266,7 @@ async def update_run_status(
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
 
-    return JSONResponse(content=_run_json(run))
+    return JSONResponse(content=_run_json(run, engine=await _engine_of(run, db)))
 
 
 # ── Runner Token ──────────────────────────────────────────────────────

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -118,6 +118,12 @@ def _engine_filter(model):
     name was free and then hit an IntegrityError — turning a clean 422 into a 500.
     The introspection test knows about that exception by name.
     """
+    if model is Run:
+        # Runs store no engine (#1536); a run's is its workspace's. Every call
+        # site already reaches runs through engine-filtered workspaces, so this
+        # is defence in depth, kept because handing a non-Terraform row to a
+        # `terraform` client is a silent wrong answer.
+        return Run.workspace_id.in_(select(Workspace.id).where(Workspace.engine == TERRAFORM))
     return model.engine == TERRAFORM
 
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1754,14 +1754,8 @@ class ConfigurationVersion(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False
     )
-    #: Which IaC engine this belongs to (#1407). NOT `execution_backend`, which
-    #: picks the *binary* within the Terraform family (tofu vs terraform); this
-    #: names the family itself. A server default means every pre-existing row is
-    #: correct with no backfill, and an older replica mid-rollout never reads a
-    #: value it cannot interpret.
-    engine: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="terraform", server_default="terraform"
-    )
+    # No `engine` column, deliberately (#1536): a configuration version is reached
+    # only through its workspace, which carries the engine. Read it from there.
 
     __table_args__ = (Index("ix_configuration_versions_workspace_id", "workspace_id"),)
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1938,14 +1938,10 @@ class Run(Base):
     )
 
     workspace: Mapped[Workspace] = relationship(back_populates="runs")
-    #: Which IaC engine this belongs to (#1407). NOT `execution_backend`, which
-    #: picks the *binary* within the Terraform family (tofu vs terraform); this
-    #: names the family itself. A server default means every pre-existing row is
-    #: correct with no backfill, and an older replica mid-rollout never reads a
-    #: value it cannot interpret.
-    engine: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="terraform", server_default="terraform"
-    )
+    # No `engine` column, deliberately (#1536): a run's engine is its workspace's.
+    # Engine is identity and never changes, so unlike resource_cpu there is
+    # nothing to snapshot — join to the workspace, or take it from one already
+    # loaded. `workspaces.engine` is the only place the fact is stored.
 
     __table_args__ = (
         Index("ix_runs_workspace_id", "workspace_id"),

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -205,17 +205,21 @@ async def reconcile_runs() -> None:
         # check_job_status reports "deleted") and then resolves the
         # canceling run to applied/canceled/errored based on whether a
         # state-version was actually uploaded.
+        # The engine comes from the workspace (#1536) — runs store no copy.
+        # One join per cycle, not a lookup per in-flight run.
         result = await db.execute(
-            select(Run).where(Run.status.in_(["planning", "applying", "canceling"]))
+            select(Run, Workspace.engine)
+            .join(Workspace, Workspace.id == Run.workspace_id)
+            .where(Run.status.in_(["planning", "applying", "canceling"]))
         )
-        runs = list(result.scalars().all())
+        runs = list(result.all())
 
         if not runs:
             return
 
-        for run in runs:
+        for run, engine in runs:
             try:
-                await _reconcile_one(db, run)
+                await _reconcile_one(db, run, engine)
             except Exception as e:
                 logger.error(
                     "Failed to reconcile run",
@@ -226,7 +230,7 @@ async def reconcile_runs() -> None:
         await db.commit()
 
 
-async def _reconcile_one(db: AsyncSession, run: Run) -> None:
+async def _reconcile_one(db: AsyncSession, run: Run, engine: str) -> None:
     """Reconcile a single run."""
     from terrapod.redis.client import get_job_status_from_redis, publish_listener_event
 
@@ -304,7 +308,7 @@ async def _reconcile_one(db: AsyncSession, run: Run) -> None:
     # (#1407 phase 3). The strategy decides from plain values; the database work
     # of acting on that decision stays here, which is what keeps the engine
     # package free of the DB layer the listener image does not ship.
-    outcome = strategy_for(run.engine).resolve_terminal(
+    outcome = strategy_for(engine).resolve_terminal(
         run_status=run.status, run_source=run.source, job_status=status
     )
     if outcome.action in ("complete_plan", "complete_apply", "discovery_succeeded"):

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -730,13 +730,9 @@ async def create_run(
         auto_apply_mode=auto_apply_mode,
         plan_only=plan_only,
         source=source,
-        # Which engine, not which binary (#1523). Without this every run
-        # defaults to terraform whatever its workspace is, so a Pulumi
-        # workspace's runs execute down the Terraform path — and succeed,
-        # because `tofu init` in a directory holding only a Pulumi.yaml plans
-        # nothing and applies nothing. The run reports "applied" having never
-        # invoked Pulumi, which is the failure mode this line prevents.
-        engine=workspace.engine,
+        # No engine here (#1536): a run has none of its own and always executes
+        # with its workspace's. Storing a copy is what let #1523 happen — a copy
+        # that defaulted to terraform sent Pulumi runs down the Terraform path.
         execution_backend=workspace.execution_backend,
         terraform_version=pinned_version,
         terragrunt_enabled=workspace.terragrunt_enabled,

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -503,6 +503,7 @@ class TestRunDetailStateVersion:
 
         result = _run_json(
             _mock_run(run_id=run_id),
+            engine="terraform",
             workspace_has_vcs=False,
             state_version_id=f"sv-{sv_id}",
         )
@@ -524,6 +525,7 @@ class TestRunDetailStateVersion:
 
         result = _run_json(
             _mock_run(),
+            engine="terraform",
             workspace_has_vcs=False,
             state_version_id=None,
         )

--- a/services/tests/db/test_engine_column_placement.py
+++ b/services/tests/db/test_engine_column_placement.py
@@ -1,14 +1,15 @@
-"""Where the `engine` discriminator lives, and where it must not (#1536).
+"""The `engine` discriminator lives on workspaces and nowhere else (#1536).
 
 Migration 697c42296453 first put `engine` on three tables for symmetry —
-workspaces, configuration_versions and runs — and nothing ever read the
-configuration-version copy. A configuration version is reachable only through
-its workspace, which carries the engine, and engine is identity (replace-forcing,
-never edited), so there is no mid-flight change a copy would snapshot against.
+workspaces, configuration_versions and runs. The configuration-version copy was
+never read; the run's copy was read, but only because it was there, and it is
+how #1523 happened: it defaulted to terraform and sent a Pulumi workspace's runs
+down the Terraform path, reporting success.
 
-Pinned because the symmetry argument is attractive and will be made again. The
-only copy that earns its place is the run's: the reconciler holds a Run and no
-Workspace, every few seconds, over every in-flight run.
+Engine is identity — replace-forcing, never edited — so there is nothing to
+snapshot. One row owns the fact and everything else joins to it. Pinned because
+"store a copy next to where it is read" is attractive and will be proposed
+again.
 """
 
 from __future__ import annotations
@@ -42,20 +43,23 @@ def _migration_tables() -> tuple[str, ...]:
 
 def test_configuration_versions_carry_no_engine() -> None:
     assert "engine" not in ConfigurationVersion.__table__.columns, (
-        "configuration_versions.engine is back. Nothing reads it — read the engine "
-        "from the workspace the configuration version belongs to (#1536)."
+        "configuration_versions.engine is back. Read the engine from the workspace "
+        "the configuration version belongs to (#1536)."
     )
 
 
-def test_the_migration_does_not_add_it_either() -> None:
-    """The model and the migration must agree, or a fresh install grows a column
-    the ORM never maps — invisible until someone inserts without the server default."""
-    assert "configuration_versions" not in _migration_tables()
+def test_runs_carry_no_engine() -> None:
+    assert "engine" not in Run.__table__.columns, (
+        "runs.engine is back. A run's engine is its workspace's: join to it, or take "
+        "it from a workspace already loaded. A stored copy is what caused #1523."
+    )
 
 
-def test_workspaces_and_runs_keep_theirs() -> None:
-    """The other half of the acceptance: this was a removal from one table, not
-    a general retreat from the discriminator."""
+def test_the_workspace_is_the_one_place_it_is_stored() -> None:
     assert "engine" in Workspace.__table__.columns
-    assert "engine" in Run.__table__.columns
-    assert set(_migration_tables()) == {"workspaces", "runs"}
+
+
+def test_the_migration_agrees_with_the_models() -> None:
+    """Or a fresh install grows columns the ORM never maps — invisible until
+    something inserts without the server default."""
+    assert _migration_tables() == ("workspaces",)

--- a/services/tests/db/test_engine_column_placement.py
+++ b/services/tests/db/test_engine_column_placement.py
@@ -1,0 +1,61 @@
+"""Where the `engine` discriminator lives, and where it must not (#1536).
+
+Migration 697c42296453 first put `engine` on three tables for symmetry —
+workspaces, configuration_versions and runs — and nothing ever read the
+configuration-version copy. A configuration version is reachable only through
+its workspace, which carries the engine, and engine is identity (replace-forcing,
+never edited), so there is no mid-flight change a copy would snapshot against.
+
+Pinned because the symmetry argument is attractive and will be made again. The
+only copy that earns its place is the run's: the reconciler holds a Run and no
+Workspace, every few seconds, over every in-flight run.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from terrapod.db.models import ConfigurationVersion, Run, Workspace
+
+
+def _migration() -> Path:
+    for base in (
+        Path("/app/alembic/versions"),  # test image
+        Path(__file__).resolve().parents[3] / "alembic" / "versions",  # repo
+    ):
+        candidate = base / "697c42296453_engine_discriminator.py"
+        if candidate.exists():
+            return candidate
+    raise AssertionError("Could not locate the engine-discriminator migration")
+
+
+def _migration_tables() -> tuple[str, ...]:
+    tree = ast.parse(_migration().read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "_TABLES" for t in node.targets
+        ):
+            return tuple(ast.literal_eval(node.value))
+    raise AssertionError("_TABLES not found in the engine-discriminator migration")
+
+
+def test_configuration_versions_carry_no_engine() -> None:
+    assert "engine" not in ConfigurationVersion.__table__.columns, (
+        "configuration_versions.engine is back. Nothing reads it — read the engine "
+        "from the workspace the configuration version belongs to (#1536)."
+    )
+
+
+def test_the_migration_does_not_add_it_either() -> None:
+    """The model and the migration must agree, or a fresh install grows a column
+    the ORM never maps — invisible until someone inserts without the server default."""
+    assert "configuration_versions" not in _migration_tables()
+
+
+def test_workspaces_and_runs_keep_theirs() -> None:
+    """The other half of the acceptance: this was a removal from one table, not
+    a general retreat from the discriminator."""
+    assert "engine" in Workspace.__table__.columns
+    assert "engine" in Run.__table__.columns
+    assert set(_migration_tables()) == {"workspaces", "runs"}

--- a/services/tests/integration/test_terminal_resolution.py
+++ b/services/tests/integration/test_terminal_resolution.py
@@ -125,9 +125,9 @@ class TestWhatTheRunActuallyBecomes:
             await session.commit()
             run_id = run.id
 
-            outcome = strategy_for(run.engine).resolve_terminal(
-                run_status=run.status, run_source=run.source, job_status="succeeded"
-            )
+            outcome = strategy_for(
+                (await session.get(Workspace, run.workspace_id)).engine
+            ).resolve_terminal(run_status=run.status, run_source=run.source, job_status="succeeded")
             assert outcome.action == "complete_plan"
             await run_reconciler._handle_succeeded(session, run, outcome)
             await session.commit()
@@ -198,9 +198,9 @@ class TestWhatTheRunActuallyBecomes:
             await session.commit()
             run_id = run.id
 
-            outcome = strategy_for(run.engine).resolve_terminal(
-                run_status=run.status, run_source=run.source, job_status="succeeded"
-            )
+            outcome = strategy_for(
+                (await session.get(Workspace, run.workspace_id)).engine
+            ).resolve_terminal(run_status=run.status, run_source=run.source, job_status="succeeded")
             assert outcome.action == "none"
             await session.commit()
 
@@ -220,10 +220,11 @@ class TestTheEngineColumnDrivesIt:
         from terrapod.db.session import get_db_session
 
         async with get_db_session() as session:
-            _, run = await _mk(session, status="planning")
+            ws, run = await _mk(session, status="planning")
             await session.commit()
-            assert run.engine == "terraform"
-            assert strategy_for(run.engine).name == "terraform"
+            # The run carries no engine (#1536); it resolves through its workspace's.
+            assert ws.engine == "terraform"
+            assert strategy_for(ws.engine).name == "terraform"
 
     async def test_an_unresolvable_engine_refuses_rather_than_defaulting(self):
         """Running the wrong tool against real infrastructure beats no answer.

--- a/services/tests/services/test_run_inherits_engine.py
+++ b/services/tests/services/test_run_inherits_engine.py
@@ -1,49 +1,79 @@
-"""A run belongs to its workspace's engine (#1523).
+"""A run executes with its workspace's engine (#1523, #1536).
 
 Found by a live run, not by a test — which is the point of recording it here.
 Every unit test passed, the Job completed, and the run reported `applied`,
-because a run created on a Pulumi workspace carried `engine="terraform"` and so
-took the Terraform path: `tofu init` in a directory holding only a `Pulumi.yaml`
-initialises an empty directory, plans nothing and applies nothing. A green run
-that never invoked Pulumi at all.
+because a run created on a Pulumi workspace carried its own `engine="terraform"`
+and so took the Terraform path: `tofu init` in a directory holding only a
+`Pulumi.yaml` plans nothing and applies nothing. A green run that never invoked
+Pulumi at all.
 
-Nothing downstream can recover from this. `strategy_for(run.engine)` in the
-reconciler and the listener's Job construction both key on the run, so the
-engine being wrong at creation makes every later decision wrong in a way that
-looks like success.
+#1523 fixed it by copying the engine onto the run. #1536 removed the copy: a run
+has no engine of its own, so there is nothing that can disagree with its
+workspace. These pin the ways the copy could creep back.
 """
 
 from __future__ import annotations
 
 import inspect
+import re
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
-from terrapod.services import run_service
+import terrapod
+
+_SRC = Path(next(iter(terrapod.__path__))).resolve()
 
 
-def test_the_run_is_constructed_with_the_workspaces_engine() -> None:
-    """Asserted on the source rather than by building a Run.
+def test_no_source_reads_an_engine_off_a_run() -> None:
+    """With the column gone, `run.engine` raises — but only on the path that
+    runs it. Read the source so an untested path cannot hide one."""
+    offenders = [
+        f"{p.relative_to(_SRC)}:{n}: {line.strip()}"
+        for p in sorted(_SRC.rglob("*.py"))
+        for n, line in enumerate(p.read_text().splitlines(), 1)
+        if re.search(r"\b(run|new_run|Run)\.engine\b", line) and not line.lstrip().startswith("#")
+    ]
+    assert not offenders, "a run has no engine; use its workspace's:\n  " + "\n  ".join(offenders)
 
-    `create_run` needs a workspace row, a configuration version, pool
-    resolution and a live session before it reaches the constructor; the
-    property worth pinning is one line of that constructor, and reading it is
-    both cheaper and harder to satisfy accidentally than a mock that returns
-    whatever it was told to.
-    """
-    src = inspect.getsource(run_service)
-    assert "engine=workspace.engine," in src, (
-        "Run() must inherit `engine` from its workspace. Without it every run "
-        "defaults to terraform and a non-Terraform workspace's runs execute "
-        "down the Terraform path, reporting success while never running the "
-        "engine the workspace asked for."
-    )
+
+def test_the_serializer_takes_the_engine_with_no_default() -> None:
+    """A default is exactly the #1523 shape: a caller that forgets gets
+    `terraform`, and a Pulumi run is reported as a Terraform one."""
+    from terrapod.api.routers.runs import _run_json
+
+    param = inspect.signature(_run_json).parameters["engine"]
+    assert param.kind is inspect.Parameter.KEYWORD_ONLY
+    assert param.default is inspect.Parameter.empty
+
+
+async def test_a_handler_without_a_workspace_reads_the_workspaces_engine() -> None:
+    from terrapod.api.routers.runs import _engine_of
+
+    ws = MagicMock()
+    ws.engine = "pulumi"
+    db = AsyncMock()
+    db.get.return_value = ws
+    run = MagicMock()
+    run.workspace_id = uuid.uuid4()
+
+    assert await _engine_of(run, db) == "pulumi"
+    assert db.get.await_args.args[1] == run.workspace_id
+
+
+def test_the_reconciler_joins_for_it() -> None:
+    """One join per cycle rather than a lookup per in-flight run."""
+    from terrapod.services import run_reconciler
+
+    src = inspect.getsource(run_reconciler.reconcile_runs)
+    assert "select(Run, Workspace.engine)" in src
+    assert "strategy_for(engine)" in inspect.getsource(run_reconciler._reconcile_one)
 
 
 def test_it_is_not_hardcoded_to_a_literal() -> None:
-    """A future refactor that pins the engine to a constant would pass the test
-    above only if it also removed the line — this catches the other shape,
-    where the field is set but always to Terraform."""
+    """The other shape of the bug: an engine set, but always to Terraform."""
+    from terrapod.services import run_service
+
     src = inspect.getsource(run_service)
     for bad in ('engine="terraform"', "engine='terraform'"):
-        assert bad not in src, (
-            f"run_service hardcodes {bad} instead of using the workspace's engine"
-        )
+        assert bad not in src, f"run_service hardcodes {bad}"

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -17,7 +17,7 @@ from terrapod.services.run_reconciler import (
 )
 
 
-def _outcome_for(run):
+def _outcome_for(run, engine="terraform"):
     """The decision the reconciler would have obtained for this run.
 
     Tests that drive `_handle_succeeded` directly are exercising the *execution*
@@ -27,7 +27,7 @@ def _outcome_for(run):
     """
     from terrapod.engines import strategy_for
 
-    return strategy_for(run.engine).resolve_terminal(
+    return strategy_for(engine).resolve_terminal(
         run_status=run.status, run_source=run.source, job_status="succeeded"
     )
 
@@ -36,10 +36,6 @@ def _mock_run(**kwargs):
     run = MagicMock()
     run.id = kwargs.get("id", uuid.uuid4())
     run.status = kwargs.get("status", "planning")
-    # Matches the column default. A MagicMock here would reach `strategy_for`
-    # as an unknown engine and raise, which is the intended behaviour — a run
-    # whose engine cannot be resolved must not be executed as Terraform.
-    run.engine = kwargs.get("engine", "terraform")
     run.workspace_id = kwargs.get("workspace_id", uuid.uuid4())
     run.pool_id = kwargs.get("pool_id", uuid.uuid4())
     run.job_name = kwargs.get("job_name", "tprun-abc123-plan")
@@ -74,7 +70,7 @@ class TestReconcileOne:
         run = _mock_run()
         mock_get_status.return_value = "running"
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         assert mock_publish.call_count == 2
         events = [call.args[1]["event"] for call in mock_publish.call_args_list]
@@ -93,7 +89,7 @@ class TestReconcileOne:
         run = _mock_run(status="applying")
         mock_get_status.return_value = "running"
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         for call in mock_publish.call_args_list:
             assert call.args[1]["phase"] == "apply"
@@ -108,7 +104,7 @@ class TestReconcileOne:
         run = _mock_run()
         mock_get_status.return_value = "succeeded"
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         # Now carries the engine's decision as well as the run: the reconciler
         # asks what a finished Job means before acting on it.
@@ -125,7 +121,7 @@ class TestReconcileOne:
         run = _mock_run()
         mock_get_status.return_value = "failed"
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         mock_handle.assert_called_once_with(db, run, "Job failed")
 
@@ -137,7 +133,7 @@ class TestReconcileOne:
         run = _mock_run()
         mock_get_status.return_value = None
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         mock_stale.assert_called_once_with(db, run)
 
@@ -149,7 +145,7 @@ class TestReconcileOne:
         run = _mock_run()
         mock_get_status.return_value = "running"
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         # No transition calls — just publish events and return
         assert mock_publish.call_count == 2
@@ -765,7 +761,7 @@ class TestReconcileOneWithoutJobName:
         db = AsyncMock()
         run = _mock_run(job_name=None)
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         mock_publish.assert_not_called()
         mock_status.assert_not_called()
@@ -786,7 +782,7 @@ class TestUnschedulable:
         run = _mock_run()
         mock_get_status.return_value = "unschedulable"
 
-        await _reconcile_one(db, run)
+        await _reconcile_one(db, run, "terraform")
 
         mock_unsched.assert_called_once_with(db, run)
 


### PR DESCRIPTION
Closes #1536, including the revised scope in its comment.

`engine` is now stored on **workspaces only**. It is dropped from both `configuration_versions` (never read) and `runs` (read, but only because it was there). Engine is identity — replace-forcing, never edited — so there is nothing mid-flight to snapshot, and everything that needs it can reach the workspace. A stored copy on the run is also what caused #1523: it defaulted to `terraform` and sent a Pulumi workspace's runs down the Terraform path, reporting success.

**Where the engine now comes from**

- **Reconciler** — `select(Run, Workspace.engine)` with a join, handed to `_reconcile_one`. Still one query per cycle, not one per run.
- **`_run_json`** — takes `engine` as a required keyword with no default. A default is exactly the #1523 shape: a caller that forgets gets `terraform`. Five callers already hold the workspace and pass `ws.engine`; the four that do not (`confirm`, `discard`, `cancel`, `update_run_status`) use `_engine_of`, a `db.get` that the session's identity map usually serves without a query because the RBAC check loaded it.
- **`next_run` and the Pulumi stack derivation** — read `ws.engine`.
- **`_engine_filter(Run)`** — re-expressed as a subquery through workspaces rather than dropped. It is redundant at every call site (each already reaches runs through engine-filtered workspaces), but it is kept as defence in depth on the surface where handing a non-Terraform row to a `terraform` client is a silent wrong answer. The introspection test is unchanged.
- **`run_service`** — no longer sets it; the #1523 line that copied it is gone, since there is no longer a copy that could disagree with its workspace.

**No consumer-visible change.** The `engine` attribute stays in the run JSON and on the runner wire, derived rather than stored. No route, attribute, wire or config snapshot moves.

**Migration amended in place, not contracted.** `697c42296453` is in no tag at all (`git tag --contains` on the commit that added it is empty), so no deployment ever ran it and no replica could read either column. That is what makes an in-place edit sound here: no expand/contract gap, no contraction-ledger entry, and the migration contract test passes unchanged. The migration's docstring records why, and warns against doing the same to a released migration.

**Guards**, run against the pre-change code to prove they bite: 7 of their 9 assertions fail there, and the other two pin what must hold either way (workspaces keep the column; the engine is never hardcoded):
- `tests/db/test_engine_column_placement.py` — neither `configuration_versions` nor `runs` has the column, `workspaces` does, and the migration agrees with the models.
- `tests/services/test_run_inherits_engine.py` — no source reads `run.engine`, the serializer's `engine` has no default, `_engine_of` reads the workspace, the reconciler joins.

**Engine gating (#1429):** not applicable — this adds no surface, route, task or UI.

**Verified**
- Local venv suite (`api`, `services`, `db`, `runner`): 4,550 passed; the only failures are the seven venv-only ones that fail identically on a clean checkout and pass in the container. PR CI is the gate for the full suite.
- Live, on the dev stack with both columns dropped from its database: a configuration version creates (201) and reads back (200); a plan-only Pulumi run reaches `planned` through the reconciler's join, its runner gets `TP_ENGINE=pulumi` and `TP_PULUMI_STACK=default/smoke/dev` and runs a real `pulumi preview`, and the run JSON still reports `engine: pulumi`.

A dev database that already ran the old migration keeps orphan columns (NOT NULL with a server default, so inserts still work). Drop them locally with `ALTER TABLE configuration_versions DROP COLUMN engine; ALTER TABLE runs DROP COLUMN engine;`.
