### PR TITLE
fix(1550): authorize every Pulumi service call against its workspace

### DIFF
--- a/docs/pulumi-cli-surface.md
+++ b/docs/pulumi-cli-surface.md
@@ -199,6 +199,15 @@ without a valid lease learns nothing about which stacks exist. A preview's lease
 `checkpoint` — a preview never writes state, and allowing it would let `run:plan` buy
 `state:write`.
 
+**A run's own CLI.** Agent-mode Pulumi runs call this API from the runner Job with the
+run's runner token, which holds no workspace role of its own. It is authorized from the
+run instead, mirroring what the Terraform surface allows a runner: on its **own** run's
+stack it may read, read state and preview, plus `run:apply` for an apply run and
+`run:apply-destroy` for a destroy run — never `stack import` or `stack rm`, which no run
+performs. On **another** stack it may only read, and only where that stack's remote-state
+consumer allowlist names the run's workspace (a `StackReference`, governed exactly as
+`terraform_remote_state` is).
+
 `stack init` never creates a stack (below), and it reports a name as already taken only
 to someone who can read that stack.
 

--- a/docs/pulumi-cli-surface.md
+++ b/docs/pulumi-cli-surface.md
@@ -168,6 +168,40 @@ CLI's behaviour rather than observed traffic — treat their shapes as unconfirm
   read back. `encrypt` was called six times during an ordinary `up`, so the
   provider obligation itself is confirmed; only the read direction is not.
 
+## Who may call what
+
+Every stack is a Terrapod workspace, and every call addressed at one is authorized
+against that workspace exactly as the Terraform routes are (#1550): owner, label RBAC,
+platform roles and the `everyone` floor all apply unchanged. What each call needs:
+
+| Call | Requires |
+|---|---|
+| `stack ls` | `workspace:read` on each stack — stacks you cannot read are not listed |
+| stack lookup | `workspace:read` |
+| `stack rm` | `workspace:delete` |
+| `stack export` | `state:read` |
+| `stack import` | `state:write` |
+| `encrypt`, `decrypt`, `batch-decrypt` | `state:read` — decrypt returns secret values |
+| `preview` | `run:plan` |
+| `up`, `refresh` | `run:apply` |
+| `destroy` | `run:apply-destroy` |
+| starting an update | whatever beginning it required — read from the update, not the URL |
+| polling an update | `run:read` |
+
+Without `workspace:read`, every call answers exactly as it would for a stack that does
+not exist — the same 404 and the same message — so stack names cannot be probed. With
+read access but without the capability a call needs, the answer is a 403 naming it.
+
+The in-update calls (`checkpoint`, `events/batch`, `complete`, `renew_lease`) carry a
+lease rather than a user. A lease authorizes one update on one stack: it is refused
+against any other stack, and it is checked before the stack is looked up, so a caller
+without a valid lease learns nothing about which stacks exist. A preview's lease cannot
+`checkpoint` — a preview never writes state, and allowing it would let `run:plan` buy
+`state:write`.
+
+`stack init` never creates a stack (below), and it reports a name as already taken only
+to someone who can read that stack.
+
 ## `stack init` does not create a stack
 
 `POST /api/stacks/{org}/{project}` is served, but it always refuses: a 404 whose

--- a/services/terrapod/api/routers/pulumi_service.py
+++ b/services/terrapod/api/routers/pulumi_service.py
@@ -36,6 +36,25 @@ otherwise have been built wrong:
    verbatim. Terrapod's existing per-workspace serialisation maps straight onto
    it.
 
+**Authorization is the workspace's (#1550).** Authenticating a caller says who
+they are, not what they may do to a given stack, and this surface first shipped
+doing only the former. Every route addressed at a stack now resolves the caller's
+capabilities on the workspace behind it — the same resolution the Terraform routes
+use — through exactly two doors:
+
+- `_authorized_stack` for calls made with the user's token. A caller who cannot
+  read the workspace gets the same 404 as for a stack that does not exist, so
+  names cannot be probed; one who can read it but lacks the capability the call
+  needs gets a 403 saying which.
+- `_require_lease` for the three in-update calls, which carry a lease instead of
+  a user. A lease authorizes one update on one stack: it is checked before the
+  stack is even looked up (so an unauthenticated caller learns nothing about which
+  stacks exist) and then bound to the stack in the URL.
+
+`_find_stack` is the lookup both are built on and is never called by a route
+directly; `tests/api/test_pulumi_authz.py` enforces that, and pins which
+capability each route requires.
+
 **Mounted natively, not at the root.** The CLI appends `/api/...` to whatever
 base URL it is given, path prefix included, so this lives under the Terrapod
 prefix. Root space is reserved for the two surfaces genuinely forced there — the
@@ -59,9 +78,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.services.workspace_rbac_service import resolve_workspace_capabilities_for
 
 
 class PulumiError(HTTPException):
@@ -118,6 +140,18 @@ DEFAULT_ORG = "default"
 #: The engine discriminator a Pulumi-backed workspace carries (#1487).
 PULUMI_ENGINE = "pulumi"
 
+#: What each kind of update requires, the same verbs a Terraform run needs. Used
+#: both where an update is begun and where it is started, so the two can never
+#: disagree about what, say, a destroy costs.
+_KIND_CAPABILITY: dict[str, str] = {
+    "preview": cap.RUN_PLAN,
+    "update": cap.RUN_APPLY,
+    "refresh": cap.RUN_APPLY,
+    "destroy": cap.RUN_APPLY_DESTROY,
+}
+
+_STACK_NOT_FOUND = "Stack not found"
+
 
 def _stack_workspace_name(project: str, stack: str) -> str:
     """The workspace name backing a stack.
@@ -161,11 +195,17 @@ def _split_stack_id(stack_id: str) -> tuple[str, str, str]:
     return parts[0], parts[1], parts[2]
 
 
-async def _load_stack(db: AsyncSession, stack_id: str) -> Workspace:
-    """The workspace backing a stack, or 404.
+async def _find_stack(db: AsyncSession, stack_id: str) -> Workspace:
+    """The workspace backing a stack, or 404. A lookup and NOTHING more.
 
-    404 is load-bearing here: `stack init` probes with a GET first and reads a
-    404 as "does not exist, safe to create".
+    It authorizes no one, so no route calls it directly: user calls go through
+    `_authorized_stack` and lease calls through `_require_lease`, both of which
+    call this and then decide whether the caller may proceed. A guard test fails
+    if a route reaches for it on its own — which is exactly how every handler here
+    once ended up authenticated but unauthorized (#1550).
+
+    404 is load-bearing: `stack init` probes with a GET first and reads a 404 as
+    "does not exist, safe to create".
     """
     _, project, stack = _split_stack_id(stack_id)
     name = _stack_workspace_name(project, stack)
@@ -174,7 +214,37 @@ async def _load_stack(db: AsyncSession, stack_id: str) -> Workspace:
     )
     ws = result.scalar_one_or_none()
     if ws is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Stack not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_STACK_NOT_FOUND)
+    return ws
+
+
+async def _authorized_stack(
+    db: AsyncSession, user: AuthenticatedUser, stack_id: str, required: str
+) -> Workspace:
+    """The workspace backing a stack, provided the caller holds `required` on it.
+
+    The same capability resolution the Terraform routes use, so a Pulumi
+    workspace is governed exactly as a Terraform one is — owner, label RBAC,
+    platform roles and the `everyone` floor all apply unchanged.
+
+    Two refusals, deliberately different. A caller who cannot even read the
+    workspace gets the same 404, with the same message, as for a stack that does
+    not exist: a 403 would confirm the name to someone with no access to it, and
+    the CLI already reads 404 as "no such stack". A caller who can read it but
+    lacks the capability this call needs gets a 403 naming it — they can see the
+    stack, so saying what they are missing gives nothing away and tells them what
+    to ask for. (The Terraform surface answers 403 in both cases; this one differs
+    because of what a 404 means to the Pulumi CLI.)
+    """
+    ws = await _find_stack(db, stack_id)
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.WORKSPACE_READ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_STACK_NOT_FOUND)
+    if not has_capability(caps, required):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Requires the {required} capability on stack {ws.name}",
+        )
     return ws
 
 
@@ -262,7 +332,12 @@ async def list_stacks(
     user: AuthenticatedUser = Depends(pulumi_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
-    """`pulumi stack ls`."""
+    """`pulumi stack ls` — the stacks this caller can read, not every stack.
+
+    RBAC-filtered the same way the workspace list is (#1550): a stack the caller
+    cannot read is absent, not listed-then-refused. The project filter runs first
+    so capabilities are only resolved for rows that would be shown.
+    """
     query = select(Workspace).where(Workspace.engine == PULUMI_ENGINE).order_by(Workspace.name)
     rows = (await db.execute(query)).scalars().all()
 
@@ -270,6 +345,9 @@ async def list_stacks(
     for ws in rows:
         proj, _, stack = ws.name.partition("::")
         if project and proj != project:
+            continue
+        caps = await resolve_workspace_capabilities_for(db, user, ws)
+        if not has_capability(caps, cap.WORKSPACE_READ):
             continue
         stacks.append(
             {
@@ -309,14 +387,20 @@ async def create_stack(
         await db.execute(select(Workspace).where(Workspace.name == name))
     ).scalar_one_or_none()
     if existing is not None:
-        # The CLI probes with GET first, so reaching here means a genuine race or
-        # a name already taken by another engine's workspace. 409 either way —
-        # silently adopting someone else's workspace would be worse.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT, detail=f"Stack {project}/{stack} already exists"
-        )
+        # "Already exists" is only said to someone who can read it (#1550).
+        # Saying it to anyone would make this an oracle for which workspace names
+        # are taken — the caller could probe names they have no access to. A
+        # caller who cannot read it gets the ordinary refusal below instead.
+        caps = await resolve_workspace_capabilities_for(db, user, existing)
+        if has_capability(caps, cap.WORKSPACE_READ):
+            # The CLI probes with GET first, so reaching here means a genuine
+            # race or a name already taken by another engine's workspace.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Stack {project}/{stack} already exists",
+            )
 
-    # The stack does not exist, and this endpoint will not create it (#1535).
+    # This endpoint will not create the stack (#1535).
     #
     # Terraform's CLI has never created a workspace — `init` looks one up and
     # fails if it is absent, and the operator creates it in Terrapod first. Doing
@@ -331,10 +415,10 @@ async def create_stack(
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=(
-            f"Stack {project}/{stack} does not exist, and `pulumi stack init` cannot "
-            f"create it. Terrapod workspaces are created in the UI, with the Terrapod "
-            f"Terraform provider, or via the API — then select the stack with "
-            f"`pulumi stack select {org}/{project}/{stack}`."
+            f"Stack {project}/{stack} does not exist or is not visible to you, and "
+            f"`pulumi stack init` cannot create it. Terrapod workspaces are created in "
+            f"the UI, with the Terrapod Terraform provider, or via the API — then "
+            f"select the stack with `pulumi stack select {org}/{project}/{stack}`."
         ),
     )
 
@@ -348,7 +432,7 @@ async def get_stack(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Stack lookup. A 404 here is how the CLI decides a stack needs creating."""
-    ws = await _load_stack(db, f"{org}/{project}/{stack}")
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.WORKSPACE_READ)
     return {
         "orgName": org,
         "projectName": project,
@@ -366,7 +450,7 @@ async def delete_stack(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """`pulumi stack rm`."""
-    ws = await _load_stack(db, f"{org}/{project}/{stack}")
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.WORKSPACE_DELETE)
     await db.delete(ws)
     await db.commit()
     logger.info("pulumi_stack_deleted", stack=ws.name, actor=user.email)
@@ -467,7 +551,7 @@ async def export_stack(
     deployment, so "nothing yet" has to be expressed as null rather than as an
     empty shape that looks tidier.
     """
-    ws = await _load_stack(db, f"{org}/{project}/{stack}")
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.STATE_READ)
     return {"version": DEPLOYMENT_VERSION, "deployment": await _read_deployment(ws, db)}
 
 
@@ -481,7 +565,7 @@ async def import_stack(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """`pulumi stack import` — writes state wholesale. Body may be gzipped."""
-    ws = await _load_stack(db, f"{org}/{project}/{stack}")
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.STATE_WRITE)
     body = await read_body(request)
     await _write_deployment(ws, db, body.get("deployment"))
     logger.info("pulumi_state_imported", stack=ws.name, actor=user.email)
@@ -505,6 +589,12 @@ async def import_stack(
 # An operator who would rather Terrapod did not hold that key keeps a passphrase
 # or KMS provider instead (`pulumi stack init --secrets-provider=...`), in which
 # case the CLI encrypts locally and never calls these.
+#
+# All three require `state:read` (#1550). Decrypt returns secret values, which is
+# exactly what reading raw state would reveal, so it costs the same. Encrypt
+# reveals nothing, but it is called during `up` and `preview`, and `state:read`
+# is held by every preset that can run either — so asking for it refuses nobody
+# who needs it while keeping the oracle closed to someone with no grant at all.
 
 
 @router.post("/api/stacks/{org}/{project}/{stack}/encrypt")
@@ -526,7 +616,7 @@ async def encrypt_secret(
 
     from terrapod.crypto.service import get_encryption
 
-    await _load_stack(db, f"{org}/{project}/{stack}")
+    await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.STATE_READ)
     body = await read_body(request)
     plaintext = body.get("plaintext")
     if plaintext is None:
@@ -557,7 +647,7 @@ async def decrypt_secret(
 
     from terrapod.crypto.service import get_encryption
 
-    await _load_stack(db, f"{org}/{project}/{stack}")
+    await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.STATE_READ)
     body = await read_body(request)
     ciphertext = body.get("ciphertext")
     if ciphertext is None:
@@ -584,7 +674,7 @@ async def batch_decrypt(
 
     from terrapod.crypto.service import get_encryption
 
-    await _load_stack(db, f"{org}/{project}/{stack}")
+    await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.STATE_READ)
     body = await read_body(request)
     svc = get_encryption()
     out: dict[str, str] = {}
@@ -619,6 +709,14 @@ def _update_key(update_id: str) -> str:
 #: the stack forever.
 def _stack_lock_key(workspace_id: str) -> str:
     return f"tp:pulumi:stack_active:{workspace_id}"
+
+
+def _decode_record(raw: dict | None) -> dict[str, str]:
+    """A Redis hash as plain strings, whichever way the client returned it."""
+    return {
+        (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
+        for k, v in (raw or {}).items()
+    }
 
 
 async def _begin_update(ws: Workspace, kind: str, user: AuthenticatedUser) -> dict[str, Any]:
@@ -659,13 +757,27 @@ async def _begin_update(ws: Workspace, kind: str, user: AuthenticatedUser) -> di
     return {"updateID": update_id}
 
 
-async def _require_lease(request: Request, update_id: str) -> dict[str, str]:
-    """Authenticate an in-update call by its lease.
+async def _require_lease(
+    request: Request, update_id: str, db: AsyncSession, stack_id: str
+) -> tuple[dict[str, str], Workspace]:
+    """Authenticate an in-update call by its lease, bound to the stack it names.
 
     The second auth scheme, and the reason it needs its own dependency: these
-    three endpoints are called with `Authorization: update-token <lease>` rather
-    than the user's API token. A test that injects an authenticated client never
-    exercises this path, so the scheme would look fine and be wrong.
+    calls are made with `Authorization: update-token <lease>` rather than the
+    user's API token. A test that injects an authenticated client never exercises
+    this path, so the scheme would look fine and be wrong.
+
+    Two properties matter as much as the token check itself (#1550):
+
+    - **Order.** The lease is checked BEFORE the stack is looked up. These calls
+      carry no user, so answering 404 for a missing stack but 401 for a bad lease
+      on an existing one would let anyone, unauthenticated, test which stacks
+      exist. With the lease first, every bad-lease request gets the same 401.
+    - **Binding.** A lease authorizes one update on one stack. It is refused when
+      the stack in the URL is not the one the update was begun on, so a lease
+      obtained for a stack the caller may write cannot be pointed at one they may
+      not. The lookup and the comparison live here, in one function, so no route
+      can do the first without the second.
     """
     from terrapod.redis.client import get_redis_client
 
@@ -677,11 +789,7 @@ async def _require_lease(request: Request, update_id: str) -> dict[str, str]:
             detail="This endpoint requires an update-token lease",
         )
 
-    record = await get_redis_client().hgetall(_update_key(update_id))
-    record = {
-        (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
-        for k, v in (record or {}).items()
-    }
+    record = _decode_record(await get_redis_client().hgetall(_update_key(update_id)))
     if not record:
         # Expired or never existed — the same answer either way, because a lease
         # that has timed out is exactly as invalid as one that was invented.
@@ -690,7 +798,14 @@ async def _require_lease(request: Request, update_id: str) -> dict[str, str]:
         )
     if record.get("lease") != value:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid lease token")
-    return record
+
+    ws = await _find_stack(db, stack_id)
+    if record.get("workspace_id") != str(ws.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This lease was issued for a different stack",
+        )
+    return record, ws
 
 
 @router.post("/api/stacks/{org}/{project}/{stack}/preview")
@@ -702,7 +817,8 @@ async def begin_preview(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """A preview IS an update — same creation, same start path, same lease."""
-    return await _begin_update(await _load_stack(db, f"{org}/{project}/{stack}"), "preview", user)
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", _KIND_CAPABILITY["preview"])
+    return await _begin_update(ws, "preview", user)
 
 
 @router.post("/api/stacks/{org}/{project}/{stack}/update")
@@ -713,7 +829,8 @@ async def begin_up(
     user: AuthenticatedUser = Depends(pulumi_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
-    return await _begin_update(await _load_stack(db, f"{org}/{project}/{stack}"), "update", user)
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", _KIND_CAPABILITY["update"])
+    return await _begin_update(ws, "update", user)
 
 
 @router.post("/api/stacks/{org}/{project}/{stack}/refresh")
@@ -724,7 +841,8 @@ async def begin_refresh(
     user: AuthenticatedUser = Depends(pulumi_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
-    return await _begin_update(await _load_stack(db, f"{org}/{project}/{stack}"), "refresh", user)
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", _KIND_CAPABILITY["refresh"])
+    return await _begin_update(ws, "refresh", user)
 
 
 @router.post("/api/stacks/{org}/{project}/{stack}/destroy")
@@ -735,7 +853,8 @@ async def begin_destroy(
     user: AuthenticatedUser = Depends(pulumi_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
-    return await _begin_update(await _load_stack(db, f"{org}/{project}/{stack}"), "destroy", user)
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", _KIND_CAPABILITY["destroy"])
+    return await _begin_update(ws, "destroy", user)
 
 
 @router.post("/api/stacks/{org}/{project}/{stack}/update/{update_id}")
@@ -752,12 +871,24 @@ async def start_update(
     The token is not optional decoration: without it the CLI aborts with
     `fatal: An assertion has failed: persisted actions require a token` before
     doing any work. That failure mode is why this is asserted in its own test.
+
+    Starting costs what beginning cost — the capability the update's kind
+    requires, looked up from the record rather than trusted from the URL — and
+    the update must belong to the stack addressed (#1550). Otherwise the lease,
+    which is what authorizes everything after this, could be minted for a stack
+    other than the one the update was begun on.
     """
     from terrapod.redis.client import get_redis_client
 
-    await _load_stack(db, f"{org}/{project}/{stack}")
     redis = get_redis_client()
-    if not await redis.exists(_update_key(update_id)):
+    record = _decode_record(await redis.hgetall(_update_key(update_id)))
+    required = _KIND_CAPABILITY.get(record.get("kind", "")) if record else None
+    if required is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown update")
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", required)
+    if record.get("workspace_id") != str(ws.id):
+        # Same answer as an update that does not exist: from this stack's point
+        # of view, it doesn't.
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown update")
 
     lease = str(uuid.uuid4())
@@ -778,17 +909,16 @@ async def get_update_status(
     """Poll an update. `stack import` waits on this."""
     from terrapod.redis.client import get_redis_client
 
-    await _load_stack(db, f"{org}/{project}/{stack}")
-    record = await get_redis_client().hgetall(_update_key(update_id))
+    ws = await _authorized_stack(db, user, f"{org}/{project}/{stack}", cap.RUN_READ)
+    record = _decode_record(await get_redis_client().hgetall(_update_key(update_id)))
     if not record:
         # A completed update's record is gone, and the CLI reads "succeeded" as
         # done rather than erroring — which is the right answer for anything it
         # is still polling after the fact.
         return {"status": "succeeded"}
-    status_value = record.get(b"status") or record.get("status") or b"running"
-    if isinstance(status_value, bytes):
-        status_value = status_value.decode()
-    return {"status": status_value}
+    if record.get("workspace_id") != str(ws.id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown update")
+    return {"status": record.get("status") or "running"}
 
 
 @router.patch("/api/stacks/{org}/{project}/{stack}/update/{update_id}/checkpoint")
@@ -800,9 +930,20 @@ async def write_checkpoint(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
-    """Write state mid-update. Lease-authenticated, and gzipped."""
-    await _require_lease(request, update_id)
-    ws = await _load_stack(db, f"{org}/{project}/{stack}")
+    """Write state mid-update. Lease-authenticated, and gzipped.
+
+    A preview's lease may not write state (#1550). A preview never persists a
+    checkpoint — on a live stack, previews leave no state version behind and
+    every one that exists was written by an update — so refusing costs nothing.
+    Accepting would let `run:plan`, the capability that begins a preview, buy a
+    `state:write` its holder was never granted.
+    """
+    record, ws = await _require_lease(request, update_id, db, f"{org}/{project}/{stack}")
+    if record.get("kind") == "preview":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="A preview does not write state; this lease cannot checkpoint",
+        )
     body = await read_body(request)
     await _write_deployment(ws, db, body.get("deployment"))
     return {}
@@ -815,6 +956,7 @@ async def post_events(
     stack: str,
     update_id: str,
     request: Request,
+    db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Engine events. Lease-authenticated, gzipped, and accepted-and-dropped.
 
@@ -823,7 +965,7 @@ async def post_events(
     for no gain, and storing them without a reader would be storage nobody asked
     for — worth revisiting when there is a run view to feed.
     """
-    await _require_lease(request, update_id)
+    await _require_lease(request, update_id, db, f"{org}/{project}/{stack}")
     await read_body(request)
     return {}
 
@@ -840,8 +982,7 @@ async def complete_update(
     """End the update and release the stack."""
     from terrapod.redis.client import get_redis_client
 
-    record = await _require_lease(request, update_id)
-    ws = await _load_stack(db, f"{org}/{project}/{stack}")
+    record, ws = await _require_lease(request, update_id, db, f"{org}/{project}/{stack}")
     body = await read_body(request)
 
     redis = get_redis_client()
@@ -870,13 +1011,14 @@ async def renew_lease(
     stack: str,
     update_id: str,
     request: Request,
+    db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Extend a lease. Not exercised by the capture — the runs were too short to
     need it — so the shape follows the CLI's expectations and is covered by test
     rather than by observed traffic."""
     from terrapod.redis.client import get_redis_client
 
-    await _require_lease(request, update_id)
+    await _require_lease(request, update_id, db, f"{org}/{project}/{stack}")
     redis = get_redis_client()
     await redis.expire(_update_key(update_id), LEASE_TTL_SECONDS)
     return {}

--- a/services/terrapod/api/routers/pulumi_service.py
+++ b/services/terrapod/api/routers/pulumi_service.py
@@ -80,7 +80,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.api.dependencies import AuthenticatedUser
 from terrapod.auth import capabilities as cap
 from terrapod.auth.capabilities import has_capability
-from terrapod.db.models import Workspace
+from terrapod.db.models import Run, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import resolve_workspace_capabilities_for
@@ -218,6 +218,72 @@ async def _find_stack(db: AsyncSession, stack_id: str) -> Workspace:
     return ws
 
 
+async def _runner_caps_on(
+    db: AsyncSession, user: AuthenticatedUser, ws: Workspace
+) -> frozenset[str]:
+    """What a run's own runner token may do on a stack.
+
+    Agent-mode Pulumi runs call this API from the runner Job with the run's
+    runner token, which carries only the `everyone` role — so ordinary
+    resolution grants it nothing, and the gates below would 404 the run's own
+    `pulumi preview`. That is not hypothetical: it is what a live run did the
+    first time these gates existed, with every test green.
+
+    Mirrors what the Terraform surface allows a runner
+    (`tfe_v2._runner_state_read_allowed`), derived from the run rather than from
+    roles:
+
+    - On its **own** run's stack: read, state read and preview always; apply for
+      an apply run; destroy for a destroy run. Never `state:write` (wholesale
+      import) or `workspace:delete` — no run does either, and a runner token
+      that could would be a far wider credential than the run it was minted for.
+      A run writes state through checkpoints, which its update's lease governs.
+    - On **another** stack: read only, and only where #344's consumer allowlist
+      names the run's workspace — a StackReference, governed exactly as
+      `terraform_remote_state` is.
+
+    Fails safe: no run, a malformed id, or a run that has gone yields nothing.
+    """
+    if not user.run_id:
+        return frozenset()
+    try:
+        run_uuid = uuid.UUID(user.run_id)
+    except (ValueError, TypeError):
+        return frozenset()
+    row = (
+        await db.execute(
+            select(Run.workspace_id, Run.plan_only, Run.is_destroy).where(Run.id == run_uuid)
+        )
+    ).first()
+    if row is None:
+        return frozenset()
+    if row.workspace_id != ws.id:
+        from terrapod.api.routers.tfe_v2 import _runner_state_read_allowed
+
+        if await _runner_state_read_allowed(db, user, ws):
+            return frozenset({cap.WORKSPACE_READ, cap.STATE_READ})
+        return frozenset()
+    caps = {cap.WORKSPACE_READ, cap.RUN_READ, cap.STATE_READ, cap.RUN_PLAN}
+    if not row.plan_only:
+        caps.add(cap.RUN_APPLY)
+        if row.is_destroy:
+            caps.add(cap.RUN_APPLY_DESTROY)
+    return frozenset(caps)
+
+
+async def _caps_on(db: AsyncSession, user: AuthenticatedUser, ws: Workspace) -> frozenset[str]:
+    """The caller's capabilities on a stack's workspace.
+
+    One place for both kinds of caller: a run's runner token is authorized from
+    its run (`_runner_caps_on`); everyone else through the same RBAC resolution
+    the Terraform routes use. Every gate on this surface asks this, so the two
+    can never be decided differently in different handlers.
+    """
+    if user.auth_method == "runner_token":
+        return await _runner_caps_on(db, user, ws)
+    return await resolve_workspace_capabilities_for(db, user, ws)
+
+
 async def _authorized_stack(
     db: AsyncSession, user: AuthenticatedUser, stack_id: str, required: str
 ) -> Workspace:
@@ -237,7 +303,7 @@ async def _authorized_stack(
     because of what a 404 means to the Pulumi CLI.)
     """
     ws = await _find_stack(db, stack_id)
-    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    caps = await _caps_on(db, user, ws)
     if not has_capability(caps, cap.WORKSPACE_READ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_STACK_NOT_FOUND)
     if not has_capability(caps, required):
@@ -346,7 +412,7 @@ async def list_stacks(
         proj, _, stack = ws.name.partition("::")
         if project and proj != project:
             continue
-        caps = await resolve_workspace_capabilities_for(db, user, ws)
+        caps = await _caps_on(db, user, ws)
         if not has_capability(caps, cap.WORKSPACE_READ):
             continue
         stacks.append(
@@ -391,7 +457,7 @@ async def create_stack(
         # Saying it to anyone would make this an oracle for which workspace names
         # are taken — the caller could probe names they have no access to. A
         # caller who cannot read it gets the ordinary refusal below instead.
-        caps = await resolve_workspace_capabilities_for(db, user, existing)
+        caps = await _caps_on(db, user, existing)
         if has_capability(caps, cap.WORKSPACE_READ):
             # The CLI probes with GET first, so reaching here means a genuine
             # race or a name already taken by another engine's workspace.

--- a/services/tests/api/test_pulumi_authz.py
+++ b/services/tests/api/test_pulumi_authz.py
@@ -1,0 +1,474 @@
+"""Workspace authorization on the Pulumi service API (#1550).
+
+The surface first shipped authenticating callers and authorizing no one: any
+signed-in principal could list, read, overwrite and delete any Pulumi stack's
+state, and a lease issued for one stack's update was accepted against another's.
+Every unit test passed, because each one injected a user and none asked what that
+user was *allowed* to do.
+
+So these are the negative paths, which is where the defect lived:
+
+- no workspace grant → every stack route refuses, and says nothing a stranger
+  could use to tell a real stack from an imaginary one;
+- a grant on workspace A → refused on workspace B, for read, write and delete;
+- read access alone → refused wherever the call needs more, naming what;
+- a lease for an update on A → refused against B; a preview's lease → refused
+  on the one route that writes state;
+- a bad lease → the same 401 whether or not the stack exists.
+
+And a guard reading the router's source, so a handler added later cannot quietly
+skip authorization the way every handler here once did.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.dependencies import AuthenticatedUser
+from terrapod.auth import capabilities as cap
+from terrapod.db.session import get_db
+
+pytestmark = pytest.mark.asyncio
+
+BASE = "/api/v1/pulumi/api"
+MOD = "terrapod.api.routers.pulumi_service"
+_ROUTER = pathlib.Path(__file__).resolve().parents[2] / "terrapod/api/routers/pulumi_service.py"
+
+#: What a `read` preset holds on a workspace.
+READ_ONLY = frozenset({cap.WORKSPACE_READ, cap.RUN_READ, cap.STATE_READ_METADATA})
+EVERYTHING = frozenset(
+    {
+        cap.WORKSPACE_READ,
+        cap.RUN_READ,
+        cap.STATE_READ_METADATA,
+        cap.STATE_READ,
+        cap.STATE_WRITE,
+        cap.RUN_PLAN,
+        cap.RUN_APPLY,
+        cap.RUN_APPLY_DESTROY,
+        cap.WORKSPACE_DELETE,
+    }
+)
+
+#: Every user-authenticated route addressed at a stack, and what it requires.
+STACK_ROUTES = [
+    ("get", "", cap.WORKSPACE_READ),
+    ("delete", "", cap.WORKSPACE_DELETE),
+    ("get", "/export", cap.STATE_READ),
+    ("post", "/import", cap.STATE_WRITE),
+    ("post", "/encrypt", cap.STATE_READ),
+    ("post", "/decrypt", cap.STATE_READ),
+    ("post", "/batch-decrypt", cap.STATE_READ),
+    ("post", "/preview", cap.RUN_PLAN),
+    ("post", "/update", cap.RUN_APPLY),
+    ("post", "/refresh", cap.RUN_APPLY),
+    ("post", "/destroy", cap.RUN_APPLY_DESTROY),
+    ("get", "/update/u-1", cap.RUN_READ),
+]
+
+LEASE_ROUTES = [
+    ("patch", "/update/u-1/checkpoint"),
+    ("post", "/update/u-1/events/batch"),
+    ("post", "/update/u-1/complete"),
+    ("post", "/update/u-1/renew_lease"),
+]
+
+
+def _user() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        email="someone@example.test",
+        display_name="Someone",
+        roles=["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _ws(name: str) -> MagicMock:
+    ws = MagicMock()
+    ws.id = uuid.uuid4()
+    ws.name = name
+    ws.labels = {}
+    ws.engine = "pulumi"
+    ws.updated_at = None
+    return ws
+
+
+A = _ws("proj::a")
+B = _ws("proj::b")
+_BY_ID = {"default/proj/a": A, "default/proj/b": B}
+
+
+async def _find(db, stack_id):
+    from fastapi import HTTPException
+
+    if stack_id not in _BY_ID:
+        raise HTTPException(status_code=404, detail="Stack not found")
+    return _BY_ID[stack_id]
+
+
+def _caps(grants: dict[str, frozenset[str]]):
+    """Capabilities by workspace name — the whole of what the tests vary."""
+
+    async def resolve(db, user, ws, **_):
+        return grants.get(ws.name, frozenset())
+
+    return resolve
+
+
+def _app(db=None):
+    from terrapod.api.app import create_application
+    from terrapod.api.routers.pulumi_service import pulumi_user
+
+    app = create_application()
+    app.dependency_overrides[pulumi_user] = lambda: _user()
+    app.dependency_overrides[get_db] = lambda: db or AsyncMock()
+    return app
+
+
+def _quiet_redis() -> AsyncMock:
+    """No update records and no locks — what a store with nothing in flight returns."""
+    r = AsyncMock()
+    r.hgetall.return_value = {}
+    r.get.return_value = None
+    return r
+
+
+async def _call(method: str, path: str, grants: dict, *, headers=None, redis=None, db=None):
+    """One request through the real app, with lookup and resolution controlled."""
+    patches = [
+        patch(f"{MOD}._find_stack", _find),
+        patch(f"{MOD}.resolve_workspace_capabilities_for", _caps(grants)),
+        # Past the gate, a call should not need a real store to answer; these stop
+        # a correctly-authorized request failing for reasons unrelated to authz.
+        patch(f"{MOD}._read_deployment", AsyncMock(return_value=None)),
+        patch(f"{MOD}._write_deployment", AsyncMock()),
+        patch(f"{MOD}._begin_update", AsyncMock(return_value={"updateID": "u-new"})),
+        patch("terrapod.redis.client.get_redis_client", return_value=redis or _quiet_redis()),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=_app(db)), base_url="http://t") as c:
+            return await c.request(method, f"{BASE}{path}", headers=headers or {}, json={})
+    finally:
+        for p in patches:
+            p.stop()
+
+
+# ── the user-authenticated routes ────────────────────────────────────────────
+
+
+class TestNoGrantMeansNothing:
+    """A signed-in principal with no grant on the workspace — the advisory's
+    case, and the one every earlier test skipped by injecting a user."""
+
+    @pytest.mark.parametrize(("method", "suffix", "_required"), STACK_ROUTES)
+    async def test_every_stack_route_refuses(self, method, suffix, _required) -> None:
+        r = await _call(method, f"/stacks/default/proj/a{suffix}", grants={})
+        assert r.status_code == 404, f"{method.upper()} {suffix or '/'} answered {r.status_code}"
+
+    @pytest.mark.parametrize(("method", "suffix", "_required"), STACK_ROUTES)
+    async def test_and_says_nothing_a_real_stack_would_not(self, method, suffix, _required) -> None:
+        """Refused on a stack that exists must be byte-identical to asked about
+        one that does not, or the refusal is an oracle for which names are real."""
+        real = await _call(method, f"/stacks/default/proj/a{suffix}", grants={})
+        imaginary = await _call(method, f"/stacks/default/proj/nope{suffix}", grants={})
+        assert (real.status_code, real.json()) == (imaginary.status_code, imaginary.json())
+
+    async def test_the_stack_list_omits_what_cannot_be_read(self) -> None:
+        db = AsyncMock()
+        rows = MagicMock()
+        rows.scalars.return_value.all.return_value = [A, B]
+        db.execute.return_value = rows
+
+        r = await _call("get", "/user/stacks", grants={"proj::a": READ_ONLY}, db=db)
+        assert r.status_code == 200
+        assert [s["stackName"] for s in r.json()["stacks"]] == ["a"]
+
+
+class TestAGrantOnOneWorkspaceIsNotAGrantOnAnother:
+    """The issue's cross-workspace cases: allowed everything on A, nothing on B."""
+
+    @pytest.mark.parametrize(
+        ("what", "method", "suffix"),
+        [
+            ("read", "get", "/export"),
+            ("write", "post", "/import"),
+            ("delete", "delete", ""),
+            ("decrypt", "post", "/decrypt"),
+            ("apply", "post", "/update"),
+        ],
+    )
+    async def test_refused_on_b(self, what, method, suffix) -> None:
+        on_a = await _call(method, f"/stacks/default/proj/a{suffix}", {"proj::a": EVERYTHING})
+        on_b = await _call(method, f"/stacks/default/proj/b{suffix}", {"proj::a": EVERYTHING})
+        assert on_a.status_code not in (403, 404), f"{what} on A should be allowed"
+        assert on_b.status_code == 404, f"{what} on B answered {on_b.status_code}"
+
+
+class TestReadAccessAloneIsReadAccess:
+    @pytest.mark.parametrize(
+        ("method", "suffix", "required"),
+        [r for r in STACK_ROUTES if r[2] not in READ_ONLY],
+    )
+    async def test_anything_more_is_refused_by_name(self, method, suffix, required) -> None:
+        r = await _call(method, f"/stacks/default/proj/a{suffix}", {"proj::a": READ_ONLY})
+        assert r.status_code == 403
+        # They can see the stack, so saying what is missing gives nothing away.
+        assert required in r.json()["message"]
+
+    @pytest.mark.parametrize(("method", "suffix", "required"), STACK_ROUTES)
+    async def test_exactly_the_required_capability_is_enough(
+        self, method, suffix, required
+    ) -> None:
+        """Per verb, not per preset: holding read plus the one capability the
+        call needs gets it through, which is the capability-model contract."""
+        r = await _call(
+            method, f"/stacks/default/proj/a{suffix}", {"proj::a": READ_ONLY | {required}}
+        )
+        assert r.status_code not in (403, 404), f"{method.upper()} {suffix} -> {r.status_code}"
+
+
+class TestStackInitIsNotANameOracle:
+    async def _init(self, grants) -> object:
+        db = AsyncMock()
+        found = MagicMock()
+        found.scalar_one_or_none.return_value = A  # the name is taken
+        db.execute.return_value = found
+        with patch(f"{MOD}.resolve_workspace_capabilities_for", _caps(grants)):
+            async with AsyncClient(transport=ASGITransport(app=_app(db)), base_url="http://t") as c:
+                return await c.post(f"{BASE}/stacks/default/proj", json={"stackName": "a"})
+
+    async def test_a_taken_name_you_cannot_read_gets_the_ordinary_refusal(self) -> None:
+        r = await self._init({})
+        assert r.status_code == 404
+        assert "already exists" not in r.json()["message"]
+
+    async def test_a_taken_name_you_can_read_is_reported_as_taken(self) -> None:
+        r = await self._init({"proj::a": READ_ONLY})
+        assert r.status_code == 409
+
+
+class TestStartingAnUpdate:
+    def _redis(self, *, workspace, kind="update") -> AsyncMock:
+        redis = AsyncMock()
+        redis.hgetall.return_value = {"workspace_id": str(workspace.id), "kind": kind}
+        return redis
+
+    async def test_an_update_begun_on_a_cannot_be_started_through_b(self) -> None:
+        """Starting mints the lease that authorizes everything after it, so an
+        update must only ever be started on the stack it was begun on."""
+        r = await _call(
+            "post",
+            "/stacks/default/proj/b/update/u-1",
+            {"proj::a": EVERYTHING, "proj::b": EVERYTHING},
+            redis=self._redis(workspace=A),
+        )
+        assert r.status_code == 404
+
+    async def test_starting_costs_what_beginning_cost(self) -> None:
+        """The kind comes from the record, not the URL: a destroy is started with
+        the destroy capability even though the start route is the same for all."""
+        r = await _call(
+            "post",
+            "/stacks/default/proj/a/update/u-1",
+            {"proj::a": READ_ONLY | {cap.RUN_APPLY}},
+            redis=self._redis(workspace=A, kind="destroy"),
+        )
+        assert r.status_code == 403
+        assert cap.RUN_APPLY_DESTROY in r.json()["message"]
+
+    async def test_the_right_caller_on_the_right_stack_gets_a_lease(self) -> None:
+        r = await _call(
+            "post",
+            "/stacks/default/proj/a/update/u-1",
+            {"proj::a": READ_ONLY | {cap.RUN_APPLY}},
+            redis=self._redis(workspace=A),
+        )
+        assert r.status_code == 200
+        assert r.json()["token"]
+
+    async def test_polling_an_update_on_another_stack_finds_nothing(self) -> None:
+        r = await _call(
+            "get",
+            "/stacks/default/proj/b/update/u-1",
+            {"proj::b": READ_ONLY},
+            redis=self._redis(workspace=A),
+        )
+        assert r.status_code == 404
+
+
+# ── the lease-authenticated routes ───────────────────────────────────────────
+
+
+class TestALeaseIsBoundToItsStack:
+    def _redis(self, *, workspace, kind="update") -> AsyncMock:
+        redis = AsyncMock()
+        redis.hgetall.return_value = {
+            "workspace_id": str(workspace.id),
+            "kind": kind,
+            "lease": "good",
+        }
+        redis.get.return_value = None
+        return redis
+
+    @pytest.mark.parametrize(("method", "suffix"), LEASE_ROUTES)
+    async def test_a_lease_for_a_is_refused_against_b(self, method, suffix) -> None:
+        r = await _call(
+            method,
+            f"/stacks/default/proj/b{suffix}",
+            {},
+            headers={"authorization": "update-token good"},
+            redis=self._redis(workspace=A),
+        )
+        assert r.status_code == 403
+
+    @pytest.mark.parametrize(("method", "suffix"), LEASE_ROUTES)
+    async def test_and_accepted_against_a(self, method, suffix) -> None:
+        r = await _call(
+            method,
+            f"/stacks/default/proj/a{suffix}",
+            {},
+            headers={"authorization": "update-token good"},
+            redis=self._redis(workspace=A),
+        )
+        assert r.status_code == 200
+
+    async def test_a_previews_lease_cannot_write_state(self) -> None:
+        """Otherwise run:plan, which begins a preview, would buy state:write."""
+        r = await _call(
+            "patch",
+            "/stacks/default/proj/a/update/u-1/checkpoint",
+            {},
+            headers={"authorization": "update-token good"},
+            redis=self._redis(workspace=A, kind="preview"),
+        )
+        assert r.status_code == 403
+
+    @pytest.mark.parametrize(("method", "suffix"), LEASE_ROUTES)
+    async def test_a_bad_lease_says_the_same_thing_whether_or_not_the_stack_exists(
+        self, method, suffix
+    ) -> None:
+        """These calls carry no user. If a missing stack answered 404 and an
+        existing one 401, anyone could map which stacks exist without signing in."""
+        redis = AsyncMock()
+        redis.hgetall.return_value = {}
+        hdr = {"authorization": "update-token invented"}
+        real = await _call(method, f"/stacks/default/proj/a{suffix}", {}, headers=hdr, redis=redis)
+        fake = await _call(
+            method, f"/stacks/default/proj/nope{suffix}", {}, headers=hdr, redis=redis
+        )
+        assert real.status_code == fake.status_code == 401
+        assert real.json() == fake.json()
+
+
+# ── the guard ────────────────────────────────────────────────────────────────
+
+
+def _routes() -> list[ast.AsyncFunctionDef]:
+    tree = ast.parse(_ROUTER.read_text())
+    out = []
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef) and any(
+            isinstance(d, ast.Call)
+            and isinstance(d.func, ast.Attribute)
+            and isinstance(d.func.value, ast.Name)
+            and d.func.value.id == "router"
+            for d in node.decorator_list
+        ):
+            out.append(node)
+    return out
+
+
+def _params(fn: ast.AsyncFunctionDef) -> set[str]:
+    return {a.arg for a in fn.args.args}
+
+
+def _is_user_route(fn: ast.AsyncFunctionDef) -> bool:
+    return any(
+        isinstance(d, ast.Call)
+        and isinstance(d.func, ast.Name)
+        and d.func.id == "Depends"
+        and d.args
+        and isinstance(d.args[0], ast.Name)
+        and d.args[0].id == "pulumi_user"
+        for d in fn.args.defaults
+    )
+
+
+def _calls(fn: ast.AsyncFunctionDef, name: str) -> list[ast.Call]:
+    return [
+        n
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == name
+    ]
+
+
+#: The capability each user route passes to `_authorized_stack`. Adding a route
+#: means adding it here — a conscious statement of what it costs.
+EXPECTED = {
+    "get_stack": "cap.WORKSPACE_READ",
+    "delete_stack": "cap.WORKSPACE_DELETE",
+    "export_stack": "cap.STATE_READ",
+    "import_stack": "cap.STATE_WRITE",
+    "encrypt_secret": "cap.STATE_READ",
+    "decrypt_secret": "cap.STATE_READ",
+    "batch_decrypt": "cap.STATE_READ",
+    "begin_preview": "_KIND_CAPABILITY['preview']",
+    "begin_up": "_KIND_CAPABILITY['update']",
+    "begin_refresh": "_KIND_CAPABILITY['refresh']",
+    "begin_destroy": "_KIND_CAPABILITY['destroy']",
+    "start_update": "required",
+    "get_update_status": "cap.RUN_READ",
+}
+
+
+class TestTheRouterCannotQuietlySkipAuthorization:
+    def test_every_user_route_on_a_stack_is_authorized_with_the_pinned_capability(
+        self,
+    ) -> None:
+        seen = {}
+        for fn in _routes():
+            if not (_is_user_route(fn) and "stack" in _params(fn)):
+                continue
+            calls = _calls(fn, "_authorized_stack")
+            assert calls, f"{fn.name} addresses a stack but never calls _authorized_stack"
+            seen[fn.name] = ast.unparse(calls[0].args[3])
+        assert seen == EXPECTED
+
+    def test_every_lease_route_binds_its_lease_to_the_stack(self) -> None:
+        lease_routes = [
+            fn for fn in _routes() if "update_id" in _params(fn) and not _is_user_route(fn)
+        ]
+        assert len(lease_routes) == 4
+        for fn in lease_routes:
+            calls = _calls(fn, "_require_lease")
+            assert calls and len(calls[0].args) == 4, (
+                f"{fn.name} must call _require_lease(request, update_id, db, stack_id) — "
+                "the form that binds the lease to the stack in the URL"
+            )
+
+    def test_no_route_looks_a_stack_up_without_authorizing(self) -> None:
+        """`_find_stack` authorizes no one; only the two gates may call it."""
+        offenders = [fn.name for fn in _routes() if _calls(fn, "_find_stack")]
+        assert not offenders, f"these call _find_stack directly: {offenders}"
+
+    def test_the_unauthorized_loader_is_gone(self) -> None:
+        assert "def _load_stack" not in _ROUTER.read_text()
+
+    def test_the_kinds_cost_what_the_equivalent_terraform_runs_cost(self) -> None:
+        from terrapod.api.routers.pulumi_service import _KIND_CAPABILITY
+
+        assert _KIND_CAPABILITY == {
+            "preview": cap.RUN_PLAN,
+            "update": cap.RUN_APPLY,
+            "refresh": cap.RUN_APPLY,
+            "destroy": cap.RUN_APPLY_DESTROY,
+        }

--- a/services/tests/api/test_pulumi_runner_authz.py
+++ b/services/tests/api/test_pulumi_runner_authz.py
@@ -1,0 +1,145 @@
+"""A run's own Pulumi CLI must still reach its own stack (#1550).
+
+Agent-mode Pulumi runs call this API from the runner Job, authenticated with the
+run's runner token (`PULUMI_ACCESS_TOKEN`). A runner token carries only the
+`everyone` role, so ordinary capability resolution grants it nothing on the
+workspace — and the authorization #1550 added would have answered every one of
+the runner's calls with 404, breaking the agent runs #1523 had just delivered.
+No other test sends a runner token, which is why CI stayed green.
+
+The allowance mirrors the Terraform surface's `_runner_state_read_allowed`:
+
+- on its **own** run's stack, a runner holds what that run needs — read, state
+  read and preview always; apply for an apply run; destroy for a destroy run —
+  and never `state:write` (import) or `workspace:delete`, which no run performs;
+- on **another** stack, read only, and only where #344's consumer allowlist
+  grants it (a StackReference, governed as `terraform_remote_state` is).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import namedtuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.api.dependencies import AuthenticatedUser
+from terrapod.auth import capabilities as cap
+
+pytestmark = pytest.mark.asyncio
+
+MOD = "terrapod.api.routers.pulumi_service"
+_RunRow = namedtuple("_RunRow", "workspace_id plan_only is_destroy")
+
+
+def _runner(run_id: uuid.UUID | None = None) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        email="runner",
+        display_name="runner",
+        roles=["everyone"],
+        provider_name="runner",
+        auth_method="runner_token",
+        run_id=str(run_id or uuid.uuid4()),
+    )
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.id = uuid.uuid4()
+    ws.name = "proj::a"
+    return ws
+
+
+def _db(row) -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    result.first.return_value = row
+    db.execute.return_value = result
+    return db
+
+
+async def _caps(user, ws, row, *, allowlisted=False) -> frozenset[str]:
+    from terrapod.api.routers.pulumi_service import _caps_on
+
+    with (
+        patch(
+            "terrapod.api.routers.tfe_v2._runner_state_read_allowed",
+            AsyncMock(return_value=allowlisted),
+        ),
+        patch(f"{MOD}.resolve_workspace_capabilities_for", AsyncMock(return_value=frozenset())),
+    ):
+        return await _caps_on(_db(row), user, ws)
+
+
+class TestOnItsOwnStack:
+    async def test_a_plan_only_run_can_preview_and_read_but_not_apply(self) -> None:
+        ws = _ws()
+        caps = await _caps(_runner(), ws, _RunRow(ws.id, True, False))
+        for needed in (cap.WORKSPACE_READ, cap.RUN_READ, cap.STATE_READ, cap.RUN_PLAN):
+            assert needed in caps, needed
+        assert cap.RUN_APPLY not in caps
+        assert cap.RUN_APPLY_DESTROY not in caps
+
+    async def test_an_apply_run_can_update(self) -> None:
+        ws = _ws()
+        caps = await _caps(_runner(), ws, _RunRow(ws.id, False, False))
+        assert cap.RUN_APPLY in caps
+        assert cap.RUN_APPLY_DESTROY not in caps
+
+    async def test_only_a_destroy_run_can_destroy(self) -> None:
+        ws = _ws()
+        caps = await _caps(_runner(), ws, _RunRow(ws.id, False, True))
+        assert cap.RUN_APPLY_DESTROY in caps
+
+    @pytest.mark.parametrize("plan_only", [True, False])
+    async def test_no_run_imports_state_or_deletes_its_stack(self, plan_only) -> None:
+        """Checkpoints are how a run writes state, and those are lease-authorized
+        by the update the run started. Wholesale import and `stack rm` are
+        operator actions; a runner token that could do them would be a far
+        wider credential than the run it was minted for."""
+        ws = _ws()
+        caps = await _caps(_runner(), ws, _RunRow(ws.id, plan_only, True))
+        assert cap.STATE_WRITE not in caps
+        assert cap.WORKSPACE_DELETE not in caps
+
+
+class TestOnAnotherStack:
+    async def test_nothing_without_the_consumer_allowlist(self) -> None:
+        caps = await _caps(_runner(), _ws(), _RunRow(uuid.uuid4(), False, True))
+        assert caps == frozenset()
+
+    async def test_read_only_with_it(self) -> None:
+        """A StackReference: read the other stack's outputs, as
+        `terraform_remote_state` may, and nothing that changes it."""
+        caps = await _caps(_runner(), _ws(), _RunRow(uuid.uuid4(), False, True), allowlisted=True)
+        assert caps == frozenset({cap.WORKSPACE_READ, cap.STATE_READ})
+
+
+class TestFailingSafe:
+    async def test_a_token_whose_run_is_gone_holds_nothing(self) -> None:
+        assert await _caps(_runner(), _ws(), None) == frozenset()
+
+    async def test_a_malformed_run_id_holds_nothing(self) -> None:
+        user = _runner()
+        user.run_id = "not-a-uuid"
+        assert await _caps(user, _ws(), _RunRow(uuid.uuid4(), False, False)) == frozenset()
+
+
+class TestOrdinaryUsersAreUnaffected:
+    async def test_a_session_user_still_goes_through_rbac(self) -> None:
+        """The runner branch must not become a way round RBAC for anyone else."""
+        from terrapod.api.routers.pulumi_service import _caps_on
+
+        user = AuthenticatedUser(
+            email="someone@example.test",
+            display_name="S",
+            roles=["everyone"],
+            provider_name="local",
+            auth_method="session",
+        )
+        resolved = AsyncMock(return_value=frozenset({cap.WORKSPACE_READ}))
+        with patch(f"{MOD}.resolve_workspace_capabilities_for", resolved):
+            caps = await _caps_on(AsyncMock(), user, _ws())
+        assert caps == frozenset({cap.WORKSPACE_READ})
+        resolved.assert_awaited_once()

--- a/services/tests/api/test_pulumi_service.py
+++ b/services/tests/api/test_pulumi_service.py
@@ -103,7 +103,7 @@ class TestTheSecondAuthScheme:
         request = MagicMock()
         request.headers = {}
         with pytest.raises(HTTPException) as exc:
-            await _require_lease(request, "u-1")
+            await _require_lease(request, "u-1", AsyncMock(), "default/p/d")
         assert exc.value.status_code == 401
         assert "update-token" in exc.value.detail
 
@@ -116,7 +116,7 @@ class TestTheSecondAuthScheme:
         request = MagicMock()
         request.headers = {"authorization": "Bearer some-api-token"}
         with pytest.raises(HTTPException) as exc:
-            await _require_lease(request, "u-1")
+            await _require_lease(request, "u-1", AsyncMock(), "default/p/d")
         assert exc.value.status_code == 401
 
     async def test_a_wrong_lease_is_refused(self) -> None:
@@ -128,19 +128,28 @@ class TestTheSecondAuthScheme:
         request.headers = {"authorization": "update-token not-the-real-one"}
         with patch("terrapod.redis.client.get_redis_client", return_value=redis):
             with pytest.raises(HTTPException) as exc:
-                await _require_lease(request, "u-1")
+                await _require_lease(request, "u-1", AsyncMock(), "default/p/d")
         assert exc.value.status_code == 401
 
     async def test_the_right_lease_is_accepted(self) -> None:
         from terrapod.api.routers.pulumi_service import _require_lease
 
         redis = AsyncMock()
-        redis.hgetall.return_value = {"lease": "good", "kind": "update"}
+        ws = MagicMock(id=uuid.uuid4())
+        redis.hgetall.return_value = {
+            "lease": "good",
+            "kind": "update",
+            "workspace_id": str(ws.id),
+        }
         request = MagicMock()
         request.headers = {"authorization": "update-token good"}
-        with patch("terrapod.redis.client.get_redis_client", return_value=redis):
-            record = await _require_lease(request, "u-1")
+        with (
+            patch("terrapod.redis.client.get_redis_client", return_value=redis),
+            patch("terrapod.api.routers.pulumi_service._find_stack", AsyncMock(return_value=ws)),
+        ):
+            record, bound = await _require_lease(request, "u-1", AsyncMock(), "default/p/d")
         assert record["kind"] == "update"
+        assert bound is ws
 
     async def test_an_expired_lease_reads_as_invalid(self) -> None:
         """A lease is a TTL, so "expired" and "never existed" are the same
@@ -153,7 +162,7 @@ class TestTheSecondAuthScheme:
         request.headers = {"authorization": "update-token whatever"}
         with patch("terrapod.redis.client.get_redis_client", return_value=redis):
             with pytest.raises(HTTPException) as exc:
-                await _require_lease(request, "gone")
+                await _require_lease(request, "gone", AsyncMock(), "default/p/d")
         assert exc.value.status_code == 401
 
 
@@ -272,7 +281,7 @@ class TestSecrets:
         with (
             patch("terrapod.crypto.service.get_encryption", return_value=svc),
             patch(
-                "terrapod.api.routers.pulumi_service._load_stack",
+                "terrapod.api.routers.pulumi_service._authorized_stack",
                 AsyncMock(return_value=MagicMock(id=uuid.uuid4())),
             ),
         ):

--- a/services/tests/api/test_workspace_create_engine.py
+++ b/services/tests/api/test_workspace_create_engine.py
@@ -115,19 +115,30 @@ class TestPulumiStackInitRefuses:
         db.add.assert_not_called()
         db.commit.assert_not_called()
 
-    async def test_an_existing_stack_still_conflicts(self) -> None:
-        """Unchanged, and distinct from the refusal: "already there" and "cannot
-        be created here" have different fixes."""
+    async def test_an_existing_stack_still_conflicts_for_someone_who_can_see_it(self) -> None:
+        """Distinct from the refusal: "already there" and "cannot be created here"
+        have different fixes.
+
+        Only for a caller who can read the stack, though (#1550). Telling anyone
+        at all that a name is taken would make this an oracle for workspace names
+        they have no access to; that side is covered in test_pulumi_authz.py.
+        """
+        from terrapod.auth import capabilities as cap
+
         db = AsyncMock()
         result = MagicMock()
         result.scalar_one_or_none.return_value = MagicMock()
         db.execute.return_value = result
 
-        async with _client(_app(db)) as c:
-            r = await c.post(
-                f"{PULUMI_BASE}/stacks/default/proj",
-                content=json.dumps({"stackName": "dev"}),
-            )
+        with patch(
+            "terrapod.api.routers.pulumi_service.resolve_workspace_capabilities_for",
+            AsyncMock(return_value=frozenset({cap.WORKSPACE_READ})),
+        ):
+            async with _client(_app(db)) as c:
+                r = await c.post(
+                    f"{PULUMI_BASE}/stacks/default/proj",
+                    content=json.dumps({"stackName": "dev"}),
+                )
         assert r.status_code == 409
 
 


### PR DESCRIPTION
Closes #1550.

The Pulumi service API authenticated callers but never authorized them against the workspace a stack maps to, and update leases were not bound to their stack. This code is in no release; `engines.pulumi.enabled` defaults to `true`, so it had to be fixed before the next release from `main`.

**Two gates, and no route bypasses them**

- `_authorized_stack` — user-token calls. Capabilities come from `_caps_on`, which for ordinary callers is the same `resolve_workspace_capabilities_for` the Terraform routes use: owner, label RBAC, platform roles and the `everyone` floor apply unchanged. A caller without `workspace:read` gets the same 404 and message as for a stack that does not exist, so names cannot be probed. A caller with read but not the needed capability gets a 403 naming it. (The Terraform surface answers 403 in both cases; this one differs because 404 is what the Pulumi CLI reads as "no such stack".)
- `_require_lease` — in-update calls. The lease is validated **before** the stack is looked up, so a caller without a valid lease gets the same 401 on real and invented stacks. Then it is bound to the stack in the URL and refused for any other.

`_load_stack` is renamed `_find_stack`, so any caller I missed would break rather than silently stay unauthorized; no route calls it directly.

| Call | Requires |
|---|---|
| stack lookup | `workspace:read` |
| `stack ls` | `workspace:read` per stack (the list is filtered) |
| `stack rm` | `workspace:delete` |
| export / import | `state:read` / `state:write` |
| encrypt, decrypt, batch-decrypt | `state:read` |
| preview | `run:plan` |
| update, refresh | `run:apply` |
| destroy | `run:apply-destroy` |
| start an update | whatever beginning it required, read from the update record, not the URL |
| poll an update | `run:read` |

**A run's own runner token (second commit)**

The first commit, with CI fully green, **broke every agent-mode Pulumi run** — found by a live run before merge, not by a test. Agent runs call this API from the runner Job with the run's runner token, which holds only the `everyone` role, so every gate answered 404: the runner's `pulumi preview` failed with `error: no stack named 'default/smoke/dev' found`. No test sent a runner token.

`_caps_on` now authorizes a runner token from its run, mirroring the Terraform surface's `_runner_state_read_allowed`:
- **its own run's stack** — read, state read and preview always; `run:apply` for an apply run; `run:apply-destroy` for a destroy run; never `state:write` (import) or `workspace:delete`, which no run performs (a run writes state through checkpoints, governed by its update's lease);
- **another stack** — read only, and only where #344's consumer allowlist names the run's workspace (a StackReference, governed as `terraform_remote_state` is);
- fails safe on a missing, malformed or vanished run.

**Two further rules the issue did not spell out but the same analysis demands**
- **A preview's lease may not checkpoint.** A preview never persists state — on a live dev stack every state version was written by an update and none by a preview — so refusing costs nothing, and without it `run:plan` would buy `state:write`.
- **`stack init` says a name is taken only to someone who can read it**, rather than to anyone.

**Tests**
- `tests/api/test_pulumi_authz.py` — the issue's negative paths: no grant → every stack route refuses, byte-identically to a missing stack; a grant on A → refused on B for read, write, delete, decrypt and apply; read alone → refused wherever more is needed, naming the capability, and exactly the required capability suffices; update start and polling bound to their stack; every lease route refuses another stack's lease; a preview lease cannot checkpoint; a bad lease answers the same on real and invented stacks; plus an AST guard pinning every route's capability and that no route looks a stack up without authorizing.
- `tests/api/test_pulumi_runner_authz.py` — each runner case above, and that a session user still goes through RBAC.

**Mutation-checked** in an isolated worktree — each of these breaks fails the suite: removing the gate on one route (6 failures), the lease binding (4), the preview refusal (1), the list filter (1), the runner branch (4).

**Verified**
- Live, on the dev stack: before the runner fix, a plan-only Pulumi run errored with "no stack named … found"; after it, the same run reached `planned` with a real `pulumi preview` (exit 0) under the runner token.
- Local: the Pulumi, engine-create and contract tests pass after the runner fix (139); the broad venv suite, run before it, was 4,626 passed with only the seven venv-only failures that fail identically on a clean checkout. Route, attribute and wire contracts unchanged. PR CI is the gate for the full suite.
- **Not verified live:** a non-admin user being refused. The dev stack's only principal is a platform admin, so the refusal paths are covered by the tests above, not by a live call.

**Engine gating (#1429):** unchanged — no new surface; the router is still unmounted when the Pulumi engine is off, and Terraform routes are untouched.

`docs/pulumi-cli-surface.md` gains a "Who may call what" section, including the runner rules.
