### PR TITLE
fix(1547): reserve the run log pane's full height while a phase streams

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -118,6 +118,12 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
     {
+      // #1547: the run log pane is full height from first paint while streaming.
+      name: 'log-reserve',
+      testMatch: 'log-reserve.spec.ts',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
+    },
+    {
       name: 'impact-graph',
       testMatch: 'impact-graph.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },

--- a/e2e/tests/log-reserve.spec.ts
+++ b/e2e/tests/log-reserve.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * The run log pane is its final size from first paint while a phase streams (#1547).
+ *
+ * It used to grow from nothing as output arrived: the empty state rendered no
+ * pane at all, and the <pre> was only CAPPED at 70vh, so every chunk reflowed it
+ * until it hit the cap. You could not scroll to where the tail would be until it
+ * was already there.
+ *
+ * The only two states a streaming pane can be in are "no output yet" and "some
+ * output", so the test measures both on one streaming run and requires the same
+ * height — no SSE timing, no race. And the other half, so the reservation cannot
+ * spread: a finished short log shrinks to fit rather than sitting in a 70vh box.
+ *
+ * The E2E stack has no runner pool, so the run's status and its plan log are
+ * served by interception; everything else goes through the real BFF chain.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { getStoredToken, createWorkspace, seedRun, uniqueName } from '../helpers/api';
+
+const LOG_URL = '/__e2e_reserve_log';
+
+async function stubRun(page: Page, runId: string, status: string, log: string) {
+  await page.route(`**/api/v2/runs/${runId}`, async (route) => {
+    const res = await route.fetch();
+    const body = await res.json();
+    body.data.attributes.status = status;
+    await route.fulfill({ response: res, body: JSON.stringify(body) });
+  });
+  await page.route(`**/api/terrapod/v1/runs/${runId}/plan`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: JSON.stringify({
+        data: { id: 'plan-1', type: 'plans', attributes: { 'log-read-url': LOG_URL, status: 'running' } },
+      }),
+    }));
+  // Serve the whole log at offset 0 and nothing after, so the content is fixed
+  // while it is measured.
+  await page.route(`**${LOG_URL}*`, (route) => {
+    const first = new URL(route.request().url()).searchParams.get('offset') === '0';
+    return route.fulfill({ status: 200, contentType: 'text/plain', body: first ? log : '' });
+  });
+}
+
+async function paneHeight(page: Page): Promise<number> {
+  const pane = page.getByTestId('log-pane-plan');
+  await expect(pane).toBeVisible({ timeout: 20_000 });
+  return (await pane.boundingBox())!.height;
+}
+
+function lines(n: number): string {
+  return Array.from({ length: n }, (_, i) => `plan ${i}  data.external.wait: Still reading...`).join('\n') + '\n';
+}
+
+test.describe('Run log pane height', () => {
+  test('a streaming pane is full height before output and stays that size', async ({ page }) => {
+    test.setTimeout(90_000);
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('e2e-reserve'));
+    const runId = await seedRun(token, wsId);
+    const vh = page.viewportSize()!.height;
+
+    // Streaming, no output yet: the pane must already be at its reserved size.
+    await stubRun(page, runId, 'planning', '');
+    await page.goto(`/workspaces/${wsId}/runs/${runId}?view=plan`);
+    const empty = await paneHeight(page);
+    expect(empty).toBeGreaterThanOrEqual(vh * 0.7);
+
+    // Streaming, output arrived: the same height. A short log too — the
+    // reservation, not the content, sets the size while the phase runs.
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await stubRun(page, runId, 'planning', lines(12));
+    await page.reload();
+    await expect(page.getByTestId('log-pre-plan')).toBeVisible({ timeout: 20_000 });
+    const withOutput = await paneHeight(page);
+    expect(Math.abs(withOutput - empty)).toBeLessThanOrEqual(2);
+  });
+
+  test('a finished short log shrinks to fit', async ({ page }) => {
+    test.setTimeout(90_000);
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('e2e-reserve-done'));
+    const runId = await seedRun(token, wsId);
+    const vh = page.viewportSize()!.height;
+
+    await stubRun(page, runId, 'planned', lines(5));
+    await page.goto(`/workspaces/${wsId}/runs/${runId}?view=plan`);
+    await expect(page.getByTestId('log-pre-plan')).toBeVisible({ timeout: 20_000 });
+    expect(await paneHeight(page)).toBeLessThan(vh * 0.5);
+  });
+});

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -428,6 +428,54 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expectNoHorizontalPageScroll(page);
   });
 
+  test('the run log pane reserves no height on touch (#1547, #722)', async ({ page }) => {
+    // #1547 reserves the pane's full height while a phase streams — with a
+    // precise pointer only. On touch the page is the scroll container (#722):
+    // no fixed-height box, no inner scrollbar. This project is a Pixel 7, so
+    // `pointer: coarse`, which is exactly the case the `fine:` gate must exclude.
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('resp-log'));
+    const runId = await seedRun(token, wsId);
+    const body = Array.from({ length: 40 }, (_, i) => `plan ${i}  Still reading...`).join('\n') + '\n';
+
+    await page.route(`**/api/v2/runs/${runId}`, async (route: Route) => {
+      const res = await route.fetch();
+      const json = await res.json();
+      json.data.attributes.status = 'planning';
+      await route.fulfill({ response: res, body: JSON.stringify(json) });
+    });
+    await page.route(`**/api/terrapod/v1/runs/${runId}/plan`, (route: Route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: JSON.stringify({
+          data: { id: 'p', type: 'plans', attributes: { 'log-read-url': '/__e2e_resp_log', status: 'running' } },
+        }),
+      }));
+    await page.route('**/__e2e_resp_log*', (route: Route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: new URL(route.request().url()).searchParams.get('offset') === '0' ? body : '',
+      }));
+
+    await page.goto(`/workspaces/${wsId}/runs/${runId}?view=plan`);
+    const pre = page.getByTestId('log-pre-plan');
+    await expect(pre).toBeVisible({ timeout: 20_000 });
+
+    const reserved = await page
+      .getByTestId('log-reserve-plan')
+      .evaluate((el) => getComputedStyle(el).minHeight);
+    expect(reserved).toBe('0px');
+    const { overflowY, maxHeight } = await pre.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { overflowY: s.overflowY, maxHeight: s.maxHeight };
+    });
+    expect(overflowY).toBe('visible');
+    expect(maxHeight).toBe('none');
+    await expectNoHorizontalPageScroll(page);
+  });
+
   test('run detail page: native view picker drives navigation at phone width', async ({ page }) => {
     // The run-detail page is the hard mobile surface (#721/#722): the view
     // tabs collapse to a native <select> (no horizontal-scroll strip), the URL

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -426,7 +426,19 @@ function LogPanel({
     return () => el.removeEventListener('scroll', onScroll)
   }, [isTouch, isAtBottom, pre])
 
-  if (loading) {
+  // While this phase is producing output, the pane is its final size from the
+  // first paint (#1547). It used to grow from nothing as the log arrived —
+  // reflowing on every chunk until it hit its cap, worst exactly when output
+  // was fastest — so there was nowhere to scroll to in anticipation of the
+  // tail. Now the box, and with it the page, is laid out before the first
+  // line, and you can park at the bottom and let the output come to you.
+  //
+  // Only while streaming. A finished short log shrinks to fit rather than
+  // sitting in a mostly empty 70vh box, and a phase that never runs (the apply
+  // tab of a plan-only run) keeps its one-line empty state.
+  const reserve = isStreaming
+
+  if (loading && !reserve) {
     return (
       <div className="bg-slate-900 rounded-lg border border-slate-700/50 p-6">
         <LoadingSpinner />
@@ -434,7 +446,7 @@ function LogPanel({
     )
   }
 
-  if (!log) {
+  if (!log && !reserve) {
     return (
       <div className="bg-slate-900 rounded-lg border border-slate-700/50 p-6 text-sm text-slate-500">
         {emptyMessage}
@@ -445,7 +457,10 @@ function LogPanel({
   const shortId = runId.replace(/^run-/, '').split('-').pop() ?? runId
 
   return (
-    <div className="bg-slate-900 rounded-lg border border-slate-700/50 overflow-hidden">
+    <div
+      data-testid={`log-pane-${phase}`}
+      className="bg-slate-900 rounded-lg border border-slate-700/50 overflow-hidden"
+    >
       <div className="flex items-center justify-between gap-2 flex-wrap px-4 py-2 border-b border-slate-700/50 bg-slate-800/50">
         <div className="flex items-center gap-2">
           {/* Single Color toggle (checkbox-style): on = ANSI colours, off =
@@ -499,7 +514,10 @@ function LogPanel({
             )}
             {/* One download button — the current Color/Plain mode decides what
                 it saves: colored (ANSI codes preserved) in Color mode, stripped
-                plain text in Plain mode. */}
+                plain text in Plain mode. Absent until there is a log to save, now
+                that the toolbar shows while a streaming phase is still waiting
+                for its first line. */}
+            {cleanLog && (
             <button
               onClick={() =>
                 colorMode
@@ -513,6 +531,7 @@ function LogPanel({
               <Download className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">{t('log.download')}</span>
             </button>
+            )}
           </div>
           {/* Scroll-nav group, divider-separated from the utilities. Both keep
               their text label at all widths so they never read as another icon. */}
@@ -561,22 +580,44 @@ function LogPanel({
           trap) — regardless of width, so a wide touch tablet is safe too. The
           `fine:` CSS variant matches `useIsTouch()`, so the CSS scroller and
           the JS tail-follow logic agree. */}
-      {colorMode ? (
-        <pre
-          ref={setPre}
-          data-testid={`log-pre-${phase}`}
-          className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
-          dangerouslySetInnerHTML={{ __html: htmlContent }}
-        />
-      ) : (
-        <pre
-          ref={setPre}
-          data-testid={`log-pre-${phase}`}
-          className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
-        >
-          {plainContent}
-        </pre>
-      )}
+      {/* The reserved height lives on this wrapper, not on the <pre>, and only
+          with a precise pointer — the same `fine:` gate as the inner scroll
+          (#1547). On touch the wrapper has no height of its own, so the page
+          stays the scroll container exactly as #722 made it.
+
+          Keeping it off the <pre> is deliberate: the <pre> still appears only
+          once there is output, so the callback ref and follow-mode below
+          attach exactly as they did (#1271) — nothing about when the scroll
+          listener registers has changed, only the box it sits in. */}
+      <div
+        data-testid={`log-reserve-${phase}`}
+        className={reserve ? 'fine:min-h-[70vh]' : undefined}
+      >
+        {!log ? (
+          loading ? (
+            <div className="p-6">
+              <LoadingSpinner />
+            </div>
+          ) : (
+            <div className="p-6 text-sm text-slate-500">{emptyMessage}</div>
+          )
+        ) : colorMode ? (
+          <pre
+            ref={setPre}
+            data-testid={`log-pre-${phase}`}
+            className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
+            dangerouslySetInnerHTML={{ __html: htmlContent }}
+          />
+        ) : (
+          <pre
+            ref={setPre}
+            data-testid={`log-pre-${phase}`}
+            className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
+          >
+            {plainContent}
+          </pre>
+        )}
+      </div>
 
     </div>
   )


### PR DESCRIPTION
Closes #1547.

While a phase is streaming, the run log pane is its final size from the first paint instead of growing into it. The empty state used to render no pane at all and the `<pre>` was only *capped* at 70vh, so every chunk reflowed it until it hit the cap and there was nowhere to scroll to in anticipation of the tail. Now the toolbar and a `fine:min-h-[70vh]` wrapper render immediately, with the spinner or "no output yet" inside, so the page layout is final before any output arrives.

**Constraints kept**
- **#722** — the reservation is `fine:` only. On touch the wrapper has no height and the page stays the scroll container.
- **#1271** — the height is on the wrapper, not the `<pre>`. The `<pre>` still appears only once there is output, so the callback ref and follow-mode attach exactly as before; `log-follow.spec.ts` exercises that path unchanged.

**Scope** — only while streaming. A finished short log shrinks to fit, and a phase that never runs (e.g. the apply tab of a plan-only run) keeps its one-line empty state. The Download button is hidden until there is a log, now that the toolbar shows during the wait.

**Tests**
- `e2e/tests/log-reserve.spec.ts` (desktop): a streaming pane is ≥70vh before output and the same height (±2px) once output arrives; a finished short log is under half the viewport.
- `e2e/tests/responsive.spec.ts` (Pixel 7, `pointer: coarse`): no reserved height, no inner scroll, no horizontal page scroll.

**Verified locally:** `tsc`, lint, and both i18n guards pass (no new strings). The e2e type-check shows only the pre-existing missing-Node-types errors across 16 files, none on added lines. `next build` and the e2e suite run in PR CI.

**Reviewed live** on terrapod.local against a plan streaming slowly for ten minutes: the pane was full height while streaming and did not grow as lines arrived.
