### PR TITLE
docs(1571): capture the Pulumi CLI's secondary commands against Terrapod

### DIFF
--- a/docs/pulumi-cli-surface.md
+++ b/docs/pulumi-cli-surface.md
@@ -159,14 +159,11 @@ further — the same method as the four protocol captures before it.
 | POST | `/api/stacks/{stack}/update/{updateID}/complete` | end it — `{"status":"succeeded"}` |
 | POST | `/api/stacks/{stack}/update/{updateID}/renew_lease` | extend the lease |
 
-**Three of those rows were not exercised by the capture** and are listed from the
-CLI's behaviour rather than observed traffic — treat their shapes as unconfirmed:
+**Three of those rows were not exercised by this first capture.** #1571 has since exercised two of them; see [the secondary commands](#the-secondary-commands-1571):
 
-* `renew_lease` — the runs were too short to need it, but the CLI holds a lease
-  for the life of an update.
-* `decrypt` and `batch-decrypt` — the captured program had no secret *config* to
-  read back. `encrypt` was called six times during an ordinary `up`, so the
-  provider obligation itself is confirmed; only the read direction is not.
+* `renew_lease` — **now observed**, with body `{"token": "", "duration": 300}` part-way through a long update. The CLI adopts the token in the response, and Terrapod's renewal returns none, which breaks every long update (#1562).
+* `batch-decrypt` — **now observed**. Every state command and every read of a deployment with secrets calls it, and Terrapod's map-shaped response works.
+* `decrypt` (the single-value form) — still not observed.
 
 ## Who may call what
 
@@ -378,11 +375,48 @@ That capture predates #1535: `stack init` now refuses, and the workspace is
 created in Terrapod first with `stack select` in its place. The rest of the
 cycle — which is what this section is about — is unchanged.
 
+## The secondary commands (#1571)
+
+The main lifecycle above was captured in #1502. This section covers the rest of what a Pulumi user runs day to day. It was captured with `scripts/pulumi-secondary-capture.py` against CLI v3.262.0, in two passes:
+
+- **Stub pass:** a recording stub, which shows what the CLI sends.
+- **Live pass:** a real Terrapod behind its BFF, which shows what Terrapod answers.
+
+"Live" statuses are the ones Terrapod returned on a Tilt stack.
+
+| Command | What the CLI sends | What Terrapod answers today | What it should answer |
+|---|---|---|---|
+| `stack history` | `GET …/updates?pageSize=10&page=1` | **404** — the command fails | The workspace's runs and updates, newest first |
+| `stack tag set` / `tag rm` | `PATCH …/tags`, whose body is the **complete** tag map, including `pulumi:project` and `pulumi:runtime` — it replaces, it does not merge | **404** | A decision on how stack tags relate to workspace labels, then a route |
+| `stack tag ls` | nothing new — it reads `tags` from `GET` on the stack | works (labels are returned as tags) | — |
+| `stack rename` | `POST …/rename` with `{"newName", "newProject"}` | **404** | A rename of the workspace to `newProject::newName`, subject to the same validation as any rename |
+| `state protect`, `unprotect`, `delete`, `edit` | `GET …/export` → `batch-decrypt` → `encrypt` → `POST …/import` → poll `GET …/update/{id}` | **works** — all four round-trip through export and import | — |
+| `change-secrets-provider passphrase` | export → `batch-decrypt` → import | **works** | — |
+| `change-secrets-provider default` (back to the service) | `encrypt`, then export → import | **fails**: `encrypt` returns 500 (see below), and the stack is left on the passphrase provider | Byte-safe encryption |
+| `change-secrets-provider awskms://…` | a KMS call made **by the CLI itself**; the service only sees `GET` on the stack | nothing to serve | Nothing: KMS credentials belong wherever the CLI runs |
+| lease renewal | `POST …/update/{id}/renew_lease` with `{"token": "", "duration": 300}`, part-way through an update of a few minutes | **200 `{}` — no token** | `{"token": "<lease>"}`, and the stack lock extended to match |
+| `cancel` | `GET` on the stack, to read its `activeUpdate`; then `POST …/update/{activeUpdate}/cancel` with an empty body | the CLI stops at "stack has never been updated": `GET` on the stack never reports an `activeUpdate` | `activeUpdate` while an update runs, and the cancel route |
+
+**Three findings the table understates.**
+
+- **Every update longer than a few minutes fails.** The CLI renews its lease part-way through and uses the token in the response. Terrapod's renewal returns none, so every call after it carries an empty lease and gets a 401. The update then ends with "this command requires logging in". Its `complete` never lands, so the stack lock stays held until the lease runs out: 30 minutes in which the next update is refused with a 409. The live pass hit exactly this on a 200-second update.
+- **`encrypt` is not byte-safe.** The CLI encrypts binary values, not only text. Terrapod decodes the plaintext as UTF-8 with `surrogateescape`, and the encryption layer then fails to encode it. The result is a 500 (`UnicodeEncodeError`) that the CLI retries four times at the start of every `up`, and a hard failure when moving a stack back to the service's own secrets provider. `decrypt` has the mirror-image problem.
+- **A Pulumi workspace cannot be deleted through the native API.** `DELETE /api/v1/workspaces/{id}` still goes through the Terraform-only lookup, so it answers 404. That is how the live pass's cleanup failed. It is the delete half of #1554.
+
+The passphrase and cloud-KMS providers can no longer be chosen at `stack init`, which refuses (#1535). They are reached with `change-secrets-provider` on a workspace that already exists, and the rows above cover that path.
+
 ## Reproducing the service capture
 
 ```sh
-python3 scripts/pulumi-service-capture.py
+python3 scripts/pulumi-service-capture.py                 # the main lifecycle
+python3 scripts/pulumi-secondary-capture.py               # the secondary commands, against a stub
+python3 scripts/pulumi-secondary-capture.py \
+  --backend https://terrapod.local --token "$TOKEN"       # …and what a real Terrapod answers
 ```
+
+The live pass creates the workspace `proj::capture` through the native API and
+tries to delete it afterwards. Until the native delete serves Pulumi workspaces,
+that clean-up fails and the workspace has to be removed by hand.
 
 Requires Docker. Re-run it against a new CLI rather than assuming this still
 holds; that is what the script is for.

--- a/scripts/pulumi-secondary-capture.py
+++ b/scripts/pulumi-secondary-capture.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Capture the Pulumi CLI's secondary commands, against a stub and a real Terrapod (#1571).
+
+`pulumi-service-capture.py` recorded the main lifecycle: login, stack init,
+preview, up, refresh, export, import, destroy and stack rm. This covers the rest:
+
+    stack history, stack tag set/ls/rm, stack rename, pulumi cancel,
+    stack change-secrets-provider (passphrase, back to the service, awskms),
+    state protect/unprotect/delete/edit, and lease renewal on a long update.
+
+Two passes, because they answer different questions:
+
+* **stub** (default): a permissive recording stub. Any route it does not know
+  answers 200 `{}`, so the CLI carries on and every request it would make is
+  logged. The start-update response carries a short `tokenExpiration`, which is
+  what makes the CLI renew its lease inside a short run. This is *what the CLI
+  sends*.
+* **live** (`--backend https://terrapod.local --token …`): a logging reverse
+  proxy in front of a real deployment. The traffic still goes through the
+  deployment's own front door (the BFF), and every request is recorded with the
+  status Terrapod actually returned. This is *what Terrapod answers*. The
+  workspace `proj::capture` is created through the native API first — the CLI
+  cannot create one (#1535) — and deleted afterwards.
+
+    python3 scripts/pulumi-secondary-capture.py
+    python3 scripts/pulumi-secondary-capture.py --backend https://terrapod.local --token "$TOKEN"
+
+Requires Docker (the `pulumi/pulumi-python` image); stdlib only otherwise. For a
+backend with a private CA (mkcert on a dev stack), pass `--cafile`, or it is
+looked up with `mkcert -CAROOT`.
+
+Findings are written up in `docs/pulumi-cli-surface.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import http.client
+import json
+import pathlib
+import re
+import shutil
+import ssl
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = 8812
+PREFIX = "/api/v1/pulumi"
+IMAGE = "pulumi/pulumi-python:latest"
+CONTAINER_HOST = "host.containers.internal"
+PROJECT = "proj"
+
+#: (step, method, path, status) in arrival order. A marker request
+#: (`GET /__step/<name>`) opens each step, so every call is attributed to the
+#: command that made it.
+LOG: list[tuple[str, str, str, int]] = []
+#: Request bodies of the secondary routes, whose shapes are the point of the capture.
+BODIES: list[tuple[str, str, str, str]] = []
+STEP = ["setup"]
+LOCK = threading.Lock()
+
+# ── the stub ──────────────────────────────────────────────────────────────────
+
+STACKS: dict[str, dict] = {}
+#: The update each stack has in flight, reported as `activeUpdate` so `pulumi cancel` has something to cancel.
+ACTIVE: dict[str, str] = {}
+DEPLOYMENTS: dict[str, object] = {}
+
+
+def _stub(method: str, path: str, body: dict) -> tuple[int, object]:
+    p = path.split("?")[0]
+    p = p[len(PREFIX) :] if p.startswith(PREFIX) else p
+    if p == "/api/user":
+        return 200, {
+            "githubLogin": "capture",
+            "name": "Capture",
+            "organizations": [{"githubLogin": "spike", "name": "spike"}],
+        }
+    if p == "/api/capabilities":
+        return 200, {"capabilities": []}
+    if p.startswith("/api/user/organizations/"):
+        return 200, {"githubLogin": "spike", "name": "spike"}
+    if p == "/api/user/stacks":
+        return 200, {"stacks": list(STACKS.values())}
+    parts = [x for x in p.split("/") if x]
+    if len(parts) == 4 and parts[:2] == ["api", "stacks"] and method == "POST":
+        name = body.get("stackName", "capture")
+        STACKS[f"{parts[2]}/{parts[3]}/{name}"] = {
+            "orgName": parts[2],
+            "projectName": parts[3],
+            "stackName": name,
+            "tags": body.get("tags", {}),
+            "version": 1,
+        }
+        return 200, {}
+    if len(parts) < 5 or parts[:2] != ["api", "stacks"]:
+        return 404, {"message": "not found"}
+    key, tail = "/".join(parts[2:5]), "/".join(parts[5:])
+    if tail == "" and method == "GET":
+        if key not in STACKS:
+            return 404, {"message": "stack not found"}
+        return 200, {**STACKS[key], "activeUpdate": ACTIVE.get(key, "")}
+    if tail == "" and method == "DELETE":
+        STACKS.pop(key, None)
+        return 200, {}
+    if tail == "rename" and method == "POST":
+        new = body.get("newName", "")
+        if new and key in STACKS:
+            org, proj, _ = key.split("/")
+            s = STACKS.pop(key)
+            s["stackName"] = new
+            STACKS[f"{org}/{proj}/{new}"] = s
+            DEPLOYMENTS[f"{org}/{proj}/{new}"] = DEPLOYMENTS.pop(key, None)
+        return 200, {}
+    if tail == "export":
+        return 200, {"version": 3, "deployment": DEPLOYMENTS.get(key)}
+    if tail == "import":
+        DEPLOYMENTS[key] = body.get("deployment")
+        return 200, {"updateID": "u-import"}
+    # Plaintexts arrive base64 and may be raw bytes, not text: the CLI encrypts
+    # binary. Wrap the decoded bytes, and hand them back base64.
+    if tail == "encrypt":
+        raw = base64.b64decode(body.get("plaintext", ""))
+        return 200, {"ciphertext": base64.b64encode(b"enc:" + raw).decode()}
+    if tail == "decrypt":
+        raw = base64.b64decode(body.get("ciphertext", "")).removeprefix(b"enc:")
+        return 200, {"plaintext": base64.b64encode(raw).decode()}
+    if tail == "batch-decrypt":
+        # A map from ciphertext to base64 plaintext, not a list: the CLI decodes
+        # `plaintexts` as map[string][]byte and fails the whole deployment read
+        # on an array.
+        return 200, {
+            "plaintexts": {
+                c: base64.b64encode(base64.b64decode(c).removeprefix(b"enc:")).decode()
+                for c in body.get("ciphertexts", [])
+            }
+        }
+    if tail in ("preview", "update", "refresh", "destroy") and method == "POST":
+        return 200, {"updateID": "u1", "requiredPolicies": []}
+    seg = tail.split("/")
+    if len(seg) >= 2 and seg[0] in (
+        "preview",
+        "update",
+        "refresh",
+        "destroy",
+        "import",
+    ):
+        rest = "/".join(seg[2:])
+        if rest == "" and method == "POST":
+            ACTIVE[key] = seg[1]
+            # A short expiration is what makes the CLI renew inside a short run.
+            return 200, {"token": "lease-1", "tokenExpiration": int(time.time()) + 20}
+        if rest == "complete":
+            ACTIVE.pop(key, None)
+            return 200, {}
+        if rest == "renew_lease":
+            return 200, {"token": "lease-1", "tokenExpiration": int(time.time()) + 20}
+        if rest == "" and method == "GET":
+            return 200, {"status": "succeeded"}
+        if (
+            rest in ("checkpoint", "checkpointverbatim")
+            and isinstance(body, dict)
+            and "deployment" in body
+        ):
+            DEPLOYMENTS[key] = body["deployment"]
+        return 200, {}
+    if tail.startswith("updates"):
+        return 200, {"updates": []}
+    # Unknown to the stub: answer permissively so the CLI shows what comes next.
+    return 200, {}
+
+
+# ── the handler: stub, or a logging proxy in front of a real deployment ───────
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    upstream: urllib.parse.SplitResult | None = None
+    ssl_ctx: ssl.SSLContext | None = None
+
+    def _serve(self) -> None:
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n) if n else b""
+        if self.path.startswith("/__step/"):
+            with LOCK:
+                STEP[0] = self.path.removeprefix("/__step/")
+            self._send(200, b"{}", "application/json")
+            return
+        try:
+            plain = (
+                gzip.decompress(raw)
+                if self.headers.get("Content-Encoding") == "gzip"
+                else raw
+            )
+            body = json.loads(plain) if plain else {}
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            body = {}
+        tail = self.path.split("?")[0].rsplit("/", 1)[-1]
+        if (
+            tail in ("tags", "rename", "cancel", "renew_lease", "import", "updates")
+            or "cancel" in self.path
+        ):
+            with LOCK:
+                BODIES.append(
+                    (STEP[0], self.command, self.path, json.dumps(body)[:300])
+                )
+        if self.upstream is None:
+            status, payload = _stub(self.command, self.path, body)
+            blob, ctype = json.dumps(payload).encode(), "application/json"
+        else:
+            status, blob, ctype = self._forward(raw)
+        with LOCK:
+            LOG.append((STEP[0], self.command, self.path.split("?")[0], status))
+        self._send(status, blob, ctype)
+
+    def _forward(self, raw: bytes) -> tuple[int, bytes, str]:
+        up = self.upstream
+        assert up is not None
+        conn = (
+            http.client.HTTPSConnection(
+                up.hostname, up.port or 443, context=self.ssl_ctx, timeout=120
+            )
+            if up.scheme == "https"
+            else http.client.HTTPConnection(up.hostname, up.port or 80, timeout=120)
+        )
+        headers = {
+            k: v
+            for k, v in self.headers.items()
+            if k.lower()
+            in (
+                "authorization",
+                "content-type",
+                "content-encoding",
+                "accept",
+                "user-agent",
+                "accept-encoding",
+            )
+        }
+        conn.request(self.command, self.path, body=raw or None, headers=headers)
+        resp = conn.getresponse()
+        data = resp.read()
+        ctype = resp.getheader("Content-Type", "application/json")
+        enc = resp.getheader("Content-Encoding")
+        conn.close()
+        if enc:
+            # Pass the encoding through rather than decode: the CLI asked for it.
+            self._enc = enc
+        return resp.status, data, ctype
+
+    def _send(self, status: int, blob: bytes, ctype: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        if getattr(self, "_enc", None):
+            self.send_header("Content-Encoding", self._enc)
+            self._enc = None
+        self.send_header("Content-Length", str(len(blob)))
+        self.end_headers()
+        self.wfile.write(blob)
+
+    do_GET = do_POST = do_PATCH = do_PUT = do_DELETE = _serve
+
+    def log_message(self, *_a: object) -> None:
+        return
+
+
+# ── the CLI side ──────────────────────────────────────────────────────────────
+
+PROGRAM = """import os, time
+import pulumi
+import pulumi_random as random
+
+time.sleep(int(os.environ.get("CAPTURE_SLEEP", "0")))
+s = random.RandomString("s", length=8, special=False)
+d = random.RandomPet("d")
+pulumi.export("s", s.result)
+"""
+
+SCRIPT = r"""
+set -u
+cd /work/proj
+export PULUMI_HOME=/work/home PULUMI_SKIP_UPDATE_CHECK=true PULUMI_ACCESS_TOKEN="$PULUMI_TOKEN"
+export PULUMI_CONFIG_PASSPHRASE=capture
+python -m venv /work/venv >/dev/null 2>&1
+export PATH=/work/venv/bin:$PATH
+/work/venv/bin/pip install -q pulumi pulumi-random >/dev/null 2>&1
+mark() { python -c "import urllib.request;urllib.request.urlopen('$MARK/__step/$1')" >/dev/null 2>&1; echo "=== $1 ==="; }
+run() { "$@" --non-interactive > /work/out.txt 2>&1; rc=$?; tail -4 /work/out.txt | sed 's/^/    /'; echo "    exit=$rc"; }
+S="$ORG/$PROJECT/$STACK"
+URN="urn:pulumi:$STACK::$PROJECT"
+
+mark login;        run pulumi login "$BACKEND"
+mark select;       if [ "$MODE" = stub ]; then run pulumi stack init "$S"; else run pulumi stack select "$S"; fi
+mark up;           run pulumi up --yes
+mark up-long;      CAPTURE_SLEEP="$LONG" run pulumi up --yes --refresh
+mark history;      run pulumi stack history --json
+mark tag-set;      run pulumi stack tag set capture yes
+mark tag-ls;       run pulumi stack tag ls
+mark tag-rm;       run pulumi stack tag rm capture
+mark protect;      run pulumi state protect "$URN::random:index/randomString:RandomString::s" --yes
+mark unprotect;    run pulumi state unprotect "$URN::random:index/randomString:RandomString::s" --yes
+mark state-delete; run pulumi state delete "$URN::random:index/randomPet:RandomPet::d" --yes
+cat > /work/edit.sh <<'EOF'
+#!/bin/sh
+sed -i 's/"length": 8/"length": 8/' "$1"
+EOF
+chmod +x /work/edit.sh
+mark state-edit
+if command -v script >/dev/null; then
+  EDITOR=/work/edit.sh script -qec "pulumi state edit" /dev/null > /work/out.txt 2>&1; echo "    exit=$? (under a pty)"; tail -3 /work/out.txt | sed 's/^/    /'
+else
+  echo "    no pty available: state edit refuses non-interactive mode"
+fi
+mark secrets-passphrase; run pulumi stack change-secrets-provider passphrase
+mark secrets-service;    run pulumi stack change-secrets-provider default
+mark secrets-awskms;     run pulumi stack change-secrets-provider "awskms://alias/terrapod-capture?region=eu-west-1"
+mark rename;       run pulumi stack rename "$ORG/$PROJECT/${STACK}2"
+mark rename-back;  run pulumi stack rename "$ORG/$PROJECT/$STACK"
+mark cancel
+( CAPTURE_SLEEP=60 pulumi up --yes --non-interactive > /work/bg.txt 2>&1 ) &
+sleep 20
+run pulumi cancel --yes
+wait
+tail -3 /work/bg.txt | sed 's/^/    [bg up] /'
+mark destroy;      run pulumi destroy --yes
+mark done
+"""
+
+
+def _normalise(path: str) -> str:
+    p = path[len(PREFIX) :] if path.startswith(PREFIX) else path
+    p = re.sub(r"/api/stacks/[^/]+/[^/]+/[^/]+", "/api/stacks/{stack}", p)
+    p = re.sub(
+        r"/(update|preview|refresh|destroy|import)/[0-9a-zA-Z-]{8,}", r"/\1/{id}", p
+    )
+    return re.sub(r"/api/user/organizations/[^/]+", "/api/user/organizations/{org}", p)
+
+
+def _api(
+    base: str,
+    token: str,
+    ctx: ssl.SSLContext | None,
+    method: str,
+    path: str,
+    body: dict | None = None,
+) -> tuple[int, dict]:
+    req = urllib.request.Request(
+        base + path,
+        method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/vnd.api+json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as r:
+            raw = r.read()
+            return r.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": e.read().decode("utf-8", "replace")[:300]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--backend", default="", help="a live Terrapod base URL; omit for the stub"
+    )
+    ap.add_argument("--token", default="", help="a Terrapod API token for --backend")
+    ap.add_argument(
+        "--cafile", default="", help="CA bundle for --backend (default: mkcert -CAROOT)"
+    )
+    ap.add_argument(
+        "--long",
+        type=int,
+        default=0,
+        help="seconds the long update sleeps (stub: 45, live: 200)",
+    )
+    args = ap.parse_args()
+    if shutil.which("docker") is None:
+        print("docker is required", file=sys.stderr)
+        return 2
+
+    live = bool(args.backend)
+    ctx = None
+    ws_id = None
+    if live:
+        cafile = args.cafile
+        if not cafile and shutil.which("mkcert"):
+            root = subprocess.run(
+                ["mkcert", "-CAROOT"], capture_output=True, text=True, check=False
+            ).stdout.strip()
+            cafile = str(pathlib.Path(root) / "rootCA.pem")
+        ctx = ssl.create_default_context(cafile=cafile or None)
+        Handler.upstream = urllib.parse.urlsplit(args.backend.rstrip("/"))
+        Handler.ssl_ctx = ctx
+        st, doc = _api(
+            args.backend.rstrip("/"),
+            args.token,
+            ctx,
+            "POST",
+            "/api/v1/workspaces",
+            {
+                "data": {
+                    "type": "workspaces",
+                    "attributes": {"name": f"{PROJECT}::capture", "engine": "pulumi"},
+                }
+            },
+        )
+        if st != 201:
+            print(
+                f"could not create the capture workspace: {st} {doc}", file=sys.stderr
+            )
+            return 1
+        ws_id = doc["data"]["id"]
+        print(f"created workspace {PROJECT}::capture ({ws_id})")
+
+    srv = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    time.sleep(0.3)
+
+    work = pathlib.Path(tempfile.mkdtemp(prefix="pulumi-secondary-"))
+    (work / "proj").mkdir()
+    (work / "proj" / "Pulumi.yaml").write_text(f"name: {PROJECT}\nruntime: python\n")
+    (work / "proj" / "__main__.py").write_text(PROGRAM)
+    (work / "run.sh").write_text(SCRIPT)
+    base = f"http://{CONTAINER_HOST}:{PORT}"
+    env = {
+        "MODE": "live" if live else "stub",
+        "BACKEND": base + PREFIX,
+        "MARK": base,
+        "PULUMI_TOKEN": args.token if live else "pul-capture",
+        "ORG": "default" if live else "spike",
+        "PROJECT": PROJECT,
+        "STACK": "capture",
+        "LONG": str(args.long or 200),
+    }
+    cmd = ["docker", "run", "--rm", "-v", f"{work}:/work", "-w", "/work"]
+    for k, v in env.items():
+        cmd += ["-e", f"{k}={v}"]
+    proc = subprocess.run(
+        cmd + [IMAGE, "bash", "/work/run.sh"],
+        capture_output=True,
+        text=True,
+        timeout=3600,
+        check=False,
+    )
+    srv.shutdown()
+    print(proc.stdout)
+    if proc.returncode:
+        print(proc.stderr[-2000:], file=sys.stderr)
+
+    if live and ws_id:
+        st, _ = _api(
+            args.backend.rstrip("/"),
+            args.token,
+            ctx,
+            "DELETE",
+            f"/api/v1/workspaces/{ws_id}",
+        )
+        print(f"deleted capture workspace: {st}")
+
+    print(f"=== {'live' if live else 'stub'}: {len(LOG)} requests ===")
+    last = None
+    for step, method, path, status in LOG:
+        if step != last:
+            print(f"-- {step}")
+            last = step
+        print(f"   {method:6s} {_normalise(path):60s} {status}")
+    print("=== request bodies of the secondary routes ===")
+    for step, method, path, body in BODIES:
+        print(f"   [{step}] {method} {_normalise(path)}  {body}")
+    shutil.rmtree(work, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1571

This spike captures the Pulumi CLI's secondary commands against Terrapod. #1502 covered the main lifecycle; this covers the rest.

**What was captured:** stack history, stack tags, stack rename, `pulumi cancel`, `change-secrets-provider` (to passphrase, back to the service, and to cloud KMS), `state protect` / `unprotect` / `delete` / `edit`, and lease renewal on a long update.

**How.** `scripts/pulumi-secondary-capture.py` runs the real CLI (v3.262.0) in two passes:
- **Stub pass:** against a recording stub, to capture what the CLI sends.
- **Live pass:** against a real Terrapod, through a logging proxy that keeps the traffic on the deployment's BFF, to capture what Terrapod answers.

The findings are in `docs/pulumi-cli-surface.md` under "The secondary commands (#1571)": for each command, what the CLI sends, what Terrapod answers today, and what it should answer.

## What it found, and where each gap went

| Finding | Where |
|---|---|
| **Every update longer than a few minutes fails.** `renew_lease` returns no token, so every later call gets a 401, the update never completes, and the stack lock stays held for 30 minutes. | #1562 (comment) |
| `pulumi cancel` reads `activeUpdate` from the stack, which Terrapod never returns, then `POST …/update/{id}/cancel`, which Terrapod doesn't serve. | #1562 (comment) |
| `encrypt` isn't byte-safe. Every `up` starts with four 500s, and moving back to the service's secrets provider fails. | **#1573** (new) |
| The native `DELETE /api/v1/workspaces/{id}` is Terraform-only, so a Pulumi workspace can't be deleted through the API. | **#1574** (new) |
| `stack history` (`GET …/updates`), `stack tag` (`PATCH …/tags`, full-map replace) and `stack rename` (`POST …/rename`) all return 404. | #1564 (comment) |
| The state commands and the switch to a passphrase provider already work, through export and import. | recorded |

Two corrections to the earlier capture's notes: `renew_lease` and `batch-decrypt` are no longer "not exercised".

**This PR is docs and a capture script only; no product code changes.** I left the product fixes to the issues above so each can get its own tests. The live pass leaves one workspace on the dev stack it ran against. The native delete can't remove it until #1574 lands, and the doc says so.
