### PR TITLE
fix(1581): every state write keeps the break-glass state index current

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -10,7 +10,15 @@ When Terrapod is unavailable (database down, API unreachable, cluster failure), 
 
 ## State Index
 
-Terrapod maintains a `state/index.yaml` file in object storage that maps workspace names to their latest state file paths. This index is updated on every state upload, workspace rename, and workspace deletion.
+Terrapod maintains a `state/index.yaml` file in object storage that maps workspace names to their latest state file paths. It is updated whenever a state version is written:
+- a Terraform or OpenTofu agent run's apply;
+- a CLI state upload in local mode;
+- a Pulumi update, in either mode;
+- a manual upload;
+- a rollback;
+- a workspace restore.
+
+It is also updated on a workspace rename and deletion. Writers from every API replica take a short lock before updating it, so concurrent writes do not drop each other's entries.
 
 Example index contents:
 
@@ -157,7 +165,9 @@ During break-glass recovery with a local backend, there is no state locking. Coo
 
 ### Index Accuracy
 
-The state index is best-effort — it is updated on every state upload but failures are swallowed to avoid blocking state operations. In rare cases, the index may be slightly out of date. If you cannot find a workspace in the index, state files are stored at `state/<workspace_uuid>/<state_version_uuid>.tfstate` — list the workspace's directory to find the latest file by timestamp.
+The state index is best-effort. It is updated on every state write, but a failure to update it is logged rather than failing the write. A failed read of the index never replaces it: the index is only rewritten after a successful read, or when it does not exist yet. In rare cases, the index may be slightly out of date.
+
+Releases before #1581 did not update the index on agent-run applies, so on an older deployment it may name an older state version for agent-mode workspaces. If you cannot find a workspace in the index, state files are stored at `state/<workspace_uuid>/<state_version_uuid>.tfstate` — list the workspace's directory to find the latest file by timestamp.
 
 ## Routine Backup & Restore
 

--- a/services/terrapod/api/routers/pulumi_service.py
+++ b/services/terrapod/api/routers/pulumi_service.py
@@ -560,6 +560,13 @@ async def _write_deployment(
     await discard_stale_plans_for_state_change(db, ws.id, serial)
     await db.commit()
 
+    # The break-glass index names every workspace's latest state (#1581).
+    from terrapod.services import state_index_service
+
+    await state_index_service.record_latest_state(
+        workspace_name=ws.name, workspace_id=ws.id, state_version_id=sv.id, serial=serial
+    )
+
 
 @router.get("/api/stacks/{org}/{project}/{stack}/export")
 async def export_stack(

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -723,6 +723,18 @@ async def _persist_runner_state(
 
     await publish_workspace_event(str(run.workspace_id), "state_version_created")
 
+    # Keep the break-glass index current (#1581): an agent-run apply is how most
+    # workspaces' state changes, and this path used to leave the index stale.
+    from terrapod.services import state_index_service
+
+    if ws is not None:
+        await state_index_service.record_latest_state(
+            workspace_name=ws.name,
+            workspace_id=run.workspace_id,
+            state_version_id=sv.id,
+            serial=serial,
+        )
+
     return Response(status_code=204)
 
 
@@ -975,6 +987,12 @@ async def upload_pulumi_deployment(
     from terrapod.redis.client import publish_workspace_event
 
     await publish_workspace_event(str(ws.id), "state_version_created")
+
+    from terrapod.services import state_index_service
+
+    await state_index_service.record_latest_state(
+        workspace_name=ws.name, workspace_id=ws.id, state_version_id=sv.id, serial=sv.serial
+    )
     return Response(status_code=204)
 
 

--- a/services/terrapod/api/routers/state_management.py
+++ b/services/terrapod/api/routers/state_management.py
@@ -219,6 +219,16 @@ async def rollback_state_version(
     await db.commit()
     await db.refresh(new_sv)
 
+    # The break-glass index names every workspace's latest state (#1581).
+    from terrapod.services import state_index_service
+
+    await state_index_service.record_latest_state(
+        workspace_name=ws.name,
+        workspace_id=sv.workspace_id,
+        state_version_id=new_sv.id,
+        serial=new_serial,
+    )
+
     logger.info(
         "state_version_rolled_back",
         workspace=ws.name,
@@ -328,6 +338,13 @@ async def upload_state_manual(
             await asyncio.to_thread(os.unlink, tmp_path)
         except OSError:
             pass
+
+    # The break-glass index names every workspace's latest state (#1581).
+    from terrapod.services import state_index_service
+
+    await state_index_service.record_latest_state(
+        workspace_name=ws.name, workspace_id=ws.id, state_version_id=sv.id, serial=new_serial
+    )
 
     logger.info(
         "state_version_uploaded_manually",

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -81,7 +81,7 @@ from terrapod.services.workspace_rbac_service import (
     resolve_workspace_capabilities_for,
 )
 from terrapod.storage import get_storage
-from terrapod.storage.keys import state_index_key, state_key
+from terrapod.storage.keys import state_key
 
 router = APIRouter(tags=["tfe-v2"])
 
@@ -381,77 +381,6 @@ def _parse_plan_expiry(value) -> int | None:
     if seconds < 0:
         raise HTTPException(status_code=422, detail="plan-expiry-seconds must not be negative")
     return seconds or None
-
-
-async def _update_state_index(
-    workspace_name: str,
-    workspace_id: str,
-    sv_key: str,
-    serial: int,
-) -> None:
-    """Best-effort update of state/index.yaml with the latest state path.
-
-    This index enables break-glass DR recovery: operators can download
-    the index from object storage to find state files by workspace name
-    without needing PostgreSQL access.
-
-    Failures are logged and swallowed — index updates must never break
-    state uploads.
-    """
-    try:
-        import yaml
-
-        storage = get_storage()
-        idx_key = state_index_key()
-
-        # Read existing index (or start fresh)
-        try:
-            raw = await storage.get(idx_key)
-            index = yaml.safe_load(raw) or {}
-        except Exception:
-            index = {}
-
-        index[workspace_name] = {
-            "workspace_id": workspace_id,
-            "state_key": sv_key,
-            "serial": serial,
-            "updated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        }
-
-        await storage.put(
-            idx_key,
-            yaml.dump(index, default_flow_style=False).encode(),
-            content_type="application/x-yaml",
-        )
-    except Exception:
-        logger.warning("Failed to update state index", workspace=workspace_name, exc_info=True)
-
-
-async def _remove_state_index_entry(workspace_name: str) -> None:
-    """Best-effort remove a workspace entry from state/index.yaml."""
-    try:
-        import yaml
-
-        storage = get_storage()
-        idx_key = state_index_key()
-
-        try:
-            raw = await storage.get(idx_key)
-            index = yaml.safe_load(raw) or {}
-        except Exception:
-            return  # No index to update
-
-        if workspace_name in index:
-            del index[workspace_name]
-            await storage.put(
-                idx_key,
-                yaml.dump(index, default_flow_style=False).encode(),
-                content_type="application/x-yaml",
-            )
-    except Exception:
-        logger.warning(
-            "Failed to remove state index entry", workspace=workspace_name, exc_info=True
-        )
 
 
 @router.get("/ping")
@@ -2109,7 +2038,9 @@ async def update_workspace(
 
     # Update state index on rename
     if old_name is not None:
-        await _remove_state_index_entry(old_name)
+        from terrapod.services import state_index_service
+
+        await state_index_service.remove_workspace(old_name)
         latest_sv_result = await db.execute(
             select(StateVersion)
             .where(StateVersion.workspace_id == ws.id)
@@ -2118,8 +2049,11 @@ async def update_workspace(
         )
         sv = latest_sv_result.scalar_one_or_none()
         if sv:
-            await _update_state_index(
-                ws.name, str(ws.id), state_key(str(ws.id), str(sv.id)), sv.serial
+            await state_index_service.record_latest_state(
+                workspace_name=ws.name,
+                workspace_id=ws.id,
+                state_version_id=sv.id,
+                serial=sv.serial,
             )
         logger.info("Workspace renamed", old_name=old_name, new_name=ws.name)
 
@@ -2172,7 +2106,9 @@ async def delete_workspace(
     await dws.write_marker_best_effort(ws_id, marker)
 
     # Best-effort remove from DR state index
-    await _remove_state_index_entry(ws_name)
+    from terrapod.services import state_index_service
+
+    await state_index_service.remove_workspace(ws_name)
 
     return Response(status_code=204)
 
@@ -2631,9 +2567,13 @@ async def upload_state_content(
 
     await publish_workspace_event(str(sv.workspace_id), "state_version_created")
 
-    # Best-effort update the DR state index
+    # Best-effort update the DR state index (#1581)
     if ws:
-        await _update_state_index(ws.name, str(ws.id), key, sv.serial)
+        from terrapod.services import state_index_service
+
+        await state_index_service.record_latest_state(
+            workspace_name=ws.name, workspace_id=ws.id, state_version_id=sv.id, serial=sv.serial
+        )
 
     # Best-effort: enqueue an AI architecture critique for the new state (#1036
     # Part 2). The critic infers the architecture from this state version and

--- a/services/terrapod/services/deleted_workspace_service.py
+++ b/services/terrapod/services/deleted_workspace_service.py
@@ -535,6 +535,7 @@ async def restore_workspace(
 
     new_id = str(ws.id)
     seen_serials: set[int] = set()
+    latest_sv: StateVersion | None = None
     for key in keys:
         raw = await storage.get(key)
         try:
@@ -576,6 +577,22 @@ async def restore_workspace(
             content_type="application/json",
         )
         report["state_versions_restored"] += 1
+        if latest_sv is None or sv.serial > latest_sv.serial:
+            latest_sv = sv
+
+    # The restored workspace is a new id under (usually) the old name, so the
+    # break-glass index must point at it rather than at the deleted one (#1581).
+    # Recorded before the caller commits: the objects are already written, and
+    # an index naming stored state is still useful if the commit then fails.
+    if latest_sv is not None:
+        from terrapod.services import state_index_service
+
+        await state_index_service.record_latest_state(
+            workspace_name=ws.name,
+            workspace_id=ws.id,
+            state_version_id=latest_sv.id,
+            serial=latest_sv.serial,
+        )
 
     return ws, report
 

--- a/services/terrapod/services/state_index_service.py
+++ b/services/terrapod/services/state_index_service.py
@@ -1,0 +1,175 @@
+"""The break-glass state index: `state/index.yaml` in object storage (#1581).
+
+The index maps each workspace name to the object key of its latest state
+version, so an operator who has lost PostgreSQL can still find every
+workspace's state by downloading one file. It is only worth having if it is
+current: `blob_classes._resolve_state_index` says a stale index is worse than
+none, because it points at the wrong objects while looking authoritative.
+
+**Every path that writes a state version records it here.** Until #1581 only
+the CLI's local-mode upload and a workspace rename did, so the index named the
+last CLI upload — or nothing — for every agent-mode workspace, which is to say
+for every workspace run the normal way. A guard test now fails the build if a
+module constructs a `StateVersion` without calling `record_latest_state`.
+
+Three properties the old helper in `tfe_v2.py` lacked:
+
+- **A read error never wipes the index.** It treated any failure to read the
+  index as "no index yet" and wrote back a one-entry file, so a transient
+  storage error erased every other workspace. Only a genuine not-found starts a
+  fresh index now; any other failure leaves the object as it is.
+- **Writers are serialised.** The index is one object updated read-modify-write,
+  and every agent-run apply now writes it, from any API replica. A short Redis
+  lock stops two writers each dropping the other's entry. If the lock cannot be
+  had, the update proceeds anyway: a rare race costs one entry until that
+  workspace's next write, where skipping would cost it for certain.
+- **Parsing is off the event loop.** The index grows with the workspace count,
+  and a PyYAML parse of a large one would stall the replica (CLAUDE.md #13).
+
+Best-effort throughout, as before: an index failure is logged and never fails
+the state write that triggered it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from terrapod.logging_config import get_logger
+from terrapod.storage import get_storage
+from terrapod.storage.keys import state_index_key, state_key
+from terrapod.storage.protocol import ObjectNotFoundError
+
+logger = get_logger(__name__)
+
+#: Held while one replica rewrites the index.
+LOCK_KEY = "tp:state_index:lock"
+#: Long enough for a read, a parse and a write of a large index, and short
+#: enough that a replica dying mid-write does not stall the rest for long.
+LOCK_TTL_SECONDS = 30
+#: How long a writer waits for the lock before updating without it.
+LOCK_WAIT_SECONDS = 10.0
+_LOCK_POLL_SECONDS = 0.05
+
+
+def _load(raw: bytes) -> dict[str, Any]:
+    import yaml
+
+    data = yaml.safe_load(raw) if raw else None
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"the state index is a {type(data).__name__}, not a mapping")
+    return data
+
+
+def _dump(index: dict[str, Any]) -> bytes:
+    import yaml
+
+    return yaml.dump(index, default_flow_style=False).encode()
+
+
+async def _acquire_lock() -> tuple[Any, str | None]:
+    """Take the index lock. `(None, None)` means "carry on without it"."""
+    try:
+        from terrapod.redis.client import get_redis_client
+
+        redis = get_redis_client()
+    except Exception:  # noqa: BLE001 — no Redis is not a reason to skip the update
+        return None, None
+
+    token = secrets.token_hex(8)
+    deadline = time.monotonic() + LOCK_WAIT_SECONDS
+    while True:
+        try:
+            if await redis.set(LOCK_KEY, token, nx=True, ex=LOCK_TTL_SECONDS):
+                return redis, token
+        except Exception:  # noqa: BLE001
+            return None, None
+        if time.monotonic() >= deadline:
+            logger.warning("State index lock not acquired in time; updating without it")
+            return None, None
+        await asyncio.sleep(_LOCK_POLL_SECONDS)
+
+
+async def _release_lock(redis: Any, token: str | None) -> None:
+    if redis is None or token is None:
+        return
+    try:
+        held = await redis.get(LOCK_KEY)
+        if held in (token, token.encode()):
+            await redis.delete(LOCK_KEY)
+    except Exception:  # noqa: BLE001 — the TTL releases it regardless
+        pass
+
+
+async def _mutate(change: Callable[[dict[str, Any]], bool], *, action: str, workspace: str) -> None:
+    """Read the index, apply `change`, and write it back if `change` says so."""
+    redis, token = await _acquire_lock()
+    try:
+        storage = get_storage()
+        key = state_index_key()
+        try:
+            raw = await storage.get(key)
+        except ObjectNotFoundError:
+            raw = b""
+        index = await asyncio.to_thread(_load, raw)
+        if not change(index):
+            return
+        body = await asyncio.to_thread(_dump, index)
+        await storage.put(key, body, content_type="application/x-yaml")
+    except Exception:  # noqa: BLE001 — index updates must never break state writes
+        logger.warning("State index not updated", action=action, workspace=workspace, exc_info=True)
+    finally:
+        await _release_lock(redis, token)
+
+
+async def record_latest_state(
+    *,
+    workspace_name: str,
+    workspace_id: uuid.UUID | str,
+    state_version_id: uuid.UUID | str,
+    serial: int,
+) -> None:
+    """Record a workspace's latest state version in the index.
+
+    Called after the state version is committed. An entry already naming a
+    newer serial for the same workspace is left alone, so a slow writer cannot
+    roll the index back; an entry for a different workspace id under the same
+    name (a restore, or a name reused after a delete) is replaced.
+    """
+    ws_id = str(workspace_id)
+    entry = {
+        "workspace_id": ws_id,
+        "state_key": state_key(ws_id, str(state_version_id)),
+        "serial": serial,
+        "updated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    def change(index: dict[str, Any]) -> bool:
+        current = index.get(workspace_name)
+        if (
+            isinstance(current, dict)
+            and current.get("workspace_id") == ws_id
+            and isinstance(current.get("serial"), int)
+            and current["serial"] > serial
+        ):
+            return False
+        index[workspace_name] = entry
+        return True
+
+    await _mutate(change, action="record", workspace=workspace_name)
+
+
+async def remove_workspace(workspace_name: str) -> None:
+    """Drop a workspace from the index — a delete, or the old name on a rename."""
+
+    def change(index: dict[str, Any]) -> bool:
+        return index.pop(workspace_name, None) is not None
+
+    await _mutate(change, action="remove", workspace=workspace_name)

--- a/services/tests/api/test_pulumi_state_index.py
+++ b/services/tests/api/test_pulumi_state_index.py
@@ -1,0 +1,70 @@
+"""The Pulumi service's own state write records the break-glass index (#1581).
+
+`_write_deployment` is how local-mode Pulumi state lands — every checkpoint and
+every `stack import`. It used to leave `state/index.yaml` untouched.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _db(latest_serial: int | None) -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    if latest_serial is None:
+        result.scalar_one_or_none.return_value = None
+    else:
+        latest = MagicMock()
+        latest.serial = latest_serial
+        result.scalar_one_or_none.return_value = latest
+    db.execute.return_value = result
+    db.add = MagicMock()
+    return db
+
+
+async def _write(latest_serial: int | None, *, put_error: Exception | None = None) -> AsyncMock:
+    from terrapod.api.routers.pulumi_service import _write_deployment
+
+    ws = MagicMock()
+    ws.id = uuid.uuid4()
+    ws.name = "proj::dev"
+    storage = MagicMock()
+    storage.put = AsyncMock(side_effect=put_error)
+    record = AsyncMock()
+    with (
+        patch("terrapod.storage.get_storage", return_value=storage),
+        patch("terrapod.crypto.state.encrypt_state_bytes", AsyncMock(side_effect=lambda b: b)),
+        patch("terrapod.services.run_service.discard_stale_plans_for_state_change", AsyncMock()),
+        patch("terrapod.services.state_index_service.record_latest_state", record),
+    ):
+        if put_error is None:
+            await _write_deployment(ws, _db(latest_serial), {"resources": []})
+        else:
+            # The write fails before the index is touched, and says so.
+            with pytest.raises(type(put_error)):
+                await _write_deployment(ws, _db(latest_serial), {"resources": []})
+    return record
+
+
+async def test_a_checkpoint_is_recorded_as_the_latest_state() -> None:
+    record = await _write(latest_serial=1)
+    record.assert_awaited_once()
+    assert record.await_args.kwargs["serial"] == 2
+    assert record.await_args.kwargs["workspace_name"] == "proj::dev"
+
+
+async def test_the_first_write_is_recorded_too() -> None:
+    record = await _write(latest_serial=None)
+    assert record.await_args.kwargs["serial"] == 1
+
+
+async def test_nothing_is_recorded_when_the_state_never_landed() -> None:
+    """The index must never name an object that was not written."""
+    record = await _write(latest_serial=1, put_error=RuntimeError("storage down"))
+    record.assert_not_awaited()

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -154,14 +154,22 @@ class TestUploadStateDuplicateSerial:
         app = _make_app(_runner_user(run_id), mock_db)
 
         state_json = json.dumps({"version": 4, "serial": 9, "lineage": "abc"})
-        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            resp = await client.put(
-                f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
-                content=state_json,
-                headers={**_AUTH, "Content-Type": "application/json"},
-            )
+        with patch(
+            "terrapod.services.state_index_service.record_latest_state", new_callable=AsyncMock
+        ) as record:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+                resp = await client.put(
+                    f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
+                    content=state_json,
+                    headers={**_AUTH, "Content-Type": "application/json"},
+                )
 
         assert resp.status_code == 204
+        # The break-glass index names the new version (#1581): an agent-run apply
+        # is how most workspaces' state changes, and this path used to skip it.
+        record.assert_awaited_once()
+        assert record.await_args.kwargs["serial"] == 9
+        assert record.await_args.kwargs["workspace_id"] == ws_id
         mock_db.add.assert_called_once()
         # State is streamed from a PVC tempfile into storage (CLAUDE.md #14),
         # never buffered in RAM, so `put_stream` is the call — not `put`.

--- a/services/tests/api/test_run_artifacts_pulumi.py
+++ b/services/tests/api/test_run_artifacts_pulumi.py
@@ -114,6 +114,7 @@ class _Harness:
         self.storage.put = AsyncMock()
         self.discard = AsyncMock()
         self.publish = AsyncMock()
+        self.record = AsyncMock()
 
     def __enter__(self) -> _Harness:
         self._stack = ExitStack()
@@ -131,6 +132,7 @@ class _Harness:
                 "terrapod.services.run_service.discard_stale_plans_for_state_change", self.discard
             ),
             patch("terrapod.redis.client.publish_workspace_event", self.publish),
+            patch("terrapod.services.state_index_service.record_latest_state", self.record),
         ):
             self._stack.enter_context(target)
         app = create_app()
@@ -218,6 +220,10 @@ class TestUpload:
         assert stored["secrets_providers"] == STORED["secrets_providers"]
         h.discard.assert_awaited_once()
         h.publish.assert_awaited_once()
+        # The break-glass index names the new version (#1581).
+        h.record.assert_awaited_once()
+        assert h.record.await_args.kwargs["serial"] == 5
+        assert h.record.await_args.kwargs["workspace_name"] == "proj::dev"
 
     async def test_a_first_state_names_this_deployments_service(self) -> None:
         run = _run()
@@ -236,6 +242,7 @@ class TestUpload:
             resp = await h.client.put(h.url("?base-serial=4"), content=_export(x=1))
         assert resp.status_code == 409
         h.storage.put.assert_not_awaited()
+        h.record.assert_not_awaited()
 
     async def test_a_retry_of_a_landed_upload_succeeds(self) -> None:
         run = _run()

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -246,12 +246,19 @@ class TestRollbackStateVersion:
         app, _ = _make_app(user, mock_db)
 
         sv_id = f"sv-{sv.id}"
-        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            resp = await client.post(
-                f"/api/terrapod/v1/state-versions/{sv_id}/actions/rollback", headers=_AUTH
-            )
+        with patch(
+            "terrapod.services.state_index_service.record_latest_state", new_callable=AsyncMock
+        ) as record:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+                resp = await client.post(
+                    f"/api/terrapod/v1/state-versions/{sv_id}/actions/rollback", headers=_AUTH
+                )
 
         assert resp.status_code == 201
+        # A rollback makes a new latest version; the break-glass index follows (#1581).
+        record.assert_awaited_once()
+        assert record.await_args.kwargs["serial"] == 4
+        assert record.await_args.kwargs["workspace_name"] == ws.name
         mock_db.add.assert_called_once()
         mock_storage.put.assert_called_once()
         mock_counter.inc.assert_called_once()
@@ -340,14 +347,21 @@ class TestUploadState:
 
         state_json = json.dumps({"version": 4, "serial": 1, "lineage": "test-lineage"})
         ws_id_str = f"ws-{ws_id}"
-        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            resp = await client.post(
-                f"/api/terrapod/v1/workspaces/{ws_id_str}/state-versions/actions/upload",
-                content=state_json,
-                headers={**_AUTH, "Content-Type": "application/json"},
-            )
+        with patch(
+            "terrapod.services.state_index_service.record_latest_state", new_callable=AsyncMock
+        ) as record:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+                resp = await client.post(
+                    f"/api/terrapod/v1/workspaces/{ws_id_str}/state-versions/actions/upload",
+                    content=state_json,
+                    headers={**_AUTH, "Content-Type": "application/json"},
+                )
 
         assert resp.status_code == 201
+        # The break-glass index names the uploaded version (#1581).
+        record.assert_awaited_once()
+        assert record.await_args.kwargs["serial"] == 6
+        assert record.await_args.kwargs["workspace_id"] == ws.id
         mock_db.add.assert_called_once()
         # Manual state upload streams the body to a PVC tempfile, then
         # `put_stream`s it to storage — never buffers it in RAM (CLAUDE.md #14).

--- a/services/tests/integration/test_deleted_workspace_restore.py
+++ b/services/tests/integration/test_deleted_workspace_restore.py
@@ -126,6 +126,29 @@ class TestRestore:
         )
         assert json.loads(dl.content)["lineage"] == lineage
 
+    async def test_restore_points_the_state_index_at_the_new_workspace(self, app, client):
+        """The break-glass index must name the restored workspace's latest
+        state, not the deleted workspace's (#1581)."""
+        import yaml
+
+        from terrapod.storage.keys import state_index_key
+
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(
+            client, "restore-index", [1, 2], "11111111-2222-3333-4444-555555555555"
+        )
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore", headers=AUTH
+        )
+        assert resp.status_code == 201, resp.text
+
+        data = resp.json()["data"]
+        index = yaml.safe_load(await get_storage().get(state_index_key()))
+        entry = index[data["attributes"]["name"]]
+        assert entry["workspace_id"] == data["id"].removeprefix("ws-")
+        assert entry["serial"] == 2
+        assert entry["workspace_id"] != old_id
+
     async def test_restore_is_a_new_workspace_not_a_revival(self, app, client):
         """Restore produces a NEW id and leaves the original prefix alone.
 

--- a/services/tests/services/test_state_index_service.py
+++ b/services/tests/services/test_state_index_service.py
@@ -1,0 +1,259 @@
+"""The break-glass state index is current, and never lost to a bad read (#1581).
+
+`state/index.yaml` lets an operator without PostgreSQL find each workspace's
+latest state by name. It used to be written only by the CLI's local-mode upload
+and a rename, so it was stale for every agent-mode workspace, and a transient
+storage error while reading it wrote back a one-entry file that erased the rest.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+
+from terrapod.services import state_index_service as sis
+from terrapod.storage.keys import state_index_key, state_key
+from terrapod.storage.protocol import ObjectNotFoundError
+
+pytestmark = pytest.mark.asyncio
+
+KEY = state_index_key()
+
+
+class FakeStorage:
+    def __init__(self, index: dict | None = None, *, get_error=None, put_error=None) -> None:
+        self.objects: dict[str, bytes] = {}
+        if index is not None:
+            self.objects[KEY] = yaml.dump(index).encode()
+        self.get_error = get_error
+        self.put_error = put_error
+        self.puts = 0
+
+    async def get(self, key: str) -> bytes:
+        if self.get_error is not None:
+            raise self.get_error
+        if key not in self.objects:
+            raise ObjectNotFoundError(key)
+        return self.objects[key]
+
+    async def put(self, key: str, data: bytes, content_type: str | None = None) -> None:
+        if self.put_error is not None:
+            raise self.put_error
+        self.objects[key] = data
+        self.puts += 1
+
+    def index(self) -> dict:
+        return yaml.safe_load(self.objects[KEY]) or {}
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.acquired = 0
+
+    async def set(self, key, value, nx=False, ex=None):  # noqa: ANN001
+        if nx and key in self.values:
+            return None
+        self.values[key] = value
+        self.acquired += 1
+        return True
+
+    async def get(self, key):  # noqa: ANN001
+        return self.values.get(key)
+
+    async def delete(self, key):  # noqa: ANN001
+        self.values.pop(key, None)
+
+
+@pytest.fixture
+def redis():
+    fake = FakeRedis()
+    with patch("terrapod.redis.client.get_redis_client", return_value=fake):
+        yield fake
+
+
+def _use(storage: FakeStorage):
+    return patch.object(sis, "get_storage", return_value=storage)
+
+
+async def _record(name="app", ws_id=None, sv_id=None, serial=3) -> tuple[str, str]:
+    ws_id = ws_id or str(uuid.uuid4())
+    sv_id = sv_id or str(uuid.uuid4())
+    await sis.record_latest_state(
+        workspace_name=name, workspace_id=ws_id, state_version_id=sv_id, serial=serial
+    )
+    return ws_id, sv_id
+
+
+class TestRecording:
+    async def test_a_first_write_creates_the_index(self, redis) -> None:
+        storage = FakeStorage()
+        with _use(storage):
+            ws_id, sv_id = await _record()
+        entry = storage.index()["app"]
+        assert entry["workspace_id"] == ws_id
+        assert entry["state_key"] == state_key(ws_id, sv_id)
+        assert entry["serial"] == 3
+        assert entry["updated_at"].endswith("Z")
+
+    async def test_other_workspaces_are_kept(self, redis) -> None:
+        storage = FakeStorage({"other": {"workspace_id": "x", "state_key": "k", "serial": 1}})
+        with _use(storage):
+            await _record()
+        assert set(storage.index()) == {"app", "other"}
+
+    async def test_a_newer_serial_replaces_the_entry(self, redis) -> None:
+        storage = FakeStorage()
+        with _use(storage):
+            ws_id, _ = await _record(serial=3)
+            _, sv2 = await _record(ws_id=ws_id, serial=4)
+        assert storage.index()["app"]["state_key"] == state_key(ws_id, sv2)
+
+    async def test_a_slow_writer_cannot_roll_the_index_back(self, redis) -> None:
+        storage = FakeStorage()
+        with _use(storage):
+            ws_id, sv1 = await _record(serial=5)
+            await _record(ws_id=ws_id, serial=4)
+        assert storage.index()["app"]["serial"] == 5
+        assert storage.index()["app"]["state_key"] == state_key(ws_id, sv1)
+
+    async def test_a_new_workspace_under_the_same_name_replaces_it(self, redis) -> None:
+        """A restore is a new workspace id, usually under the old name; its
+        serials may be lower than the entry it replaces and must still win."""
+        storage = FakeStorage()
+        with _use(storage):
+            await _record(serial=9)
+            new_ws, _ = await _record(serial=2)
+        assert storage.index()["app"]["workspace_id"] == new_ws
+
+
+class TestRemoving:
+    async def test_the_entry_is_dropped(self, redis) -> None:
+        storage = FakeStorage({"app": {"serial": 1}, "other": {"serial": 1}})
+        with _use(storage):
+            await sis.remove_workspace("app")
+        assert set(storage.index()) == {"other"}
+
+    async def test_an_absent_entry_writes_nothing(self, redis) -> None:
+        storage = FakeStorage({"other": {"serial": 1}})
+        with _use(storage):
+            await sis.remove_workspace("app")
+        assert storage.puts == 0
+
+    async def test_no_index_at_all_writes_nothing(self, redis) -> None:
+        storage = FakeStorage()
+        with _use(storage):
+            await sis.remove_workspace("app")
+        assert KEY not in storage.objects
+
+
+class TestNeverDestructive:
+    async def test_a_transient_read_error_does_not_wipe_the_index(self, redis) -> None:
+        """The old helper read any failure as "no index" and wrote back a
+        one-entry file, erasing every other workspace."""
+        storage = FakeStorage({"other": {"serial": 1}}, get_error=TimeoutError("storage timed out"))
+        with _use(storage):
+            await _record()
+        assert storage.puts == 0
+        assert yaml.safe_load(storage.objects[KEY]) == {"other": {"serial": 1}}
+
+    async def test_a_corrupt_index_is_not_overwritten(self, redis) -> None:
+        storage = FakeStorage()
+        storage.objects[KEY] = b"- just\n- a list\n"
+        with _use(storage):
+            await _record()
+        assert storage.puts == 0
+
+    async def test_a_failed_write_never_reaches_the_caller(self, redis) -> None:
+        storage = FakeStorage(put_error=RuntimeError("storage down"))
+        with _use(storage):
+            await _record()  # does not raise
+
+    async def test_no_storage_at_all_never_reaches_the_caller(self, redis) -> None:
+        with patch.object(sis, "get_storage", side_effect=RuntimeError("not initialised")):
+            await _record()  # does not raise
+
+
+class TestTheLock:
+    async def test_the_lock_is_taken_and_released(self, redis) -> None:
+        with _use(FakeStorage()):
+            await _record()
+        assert redis.acquired == 1
+        assert sis.LOCK_KEY not in redis.values
+
+    async def test_it_is_released_even_when_the_update_fails(self, redis) -> None:
+        with _use(FakeStorage(put_error=RuntimeError("storage down"))):
+            await _record()
+        assert sis.LOCK_KEY not in redis.values
+
+    async def test_no_redis_still_updates(self) -> None:
+        storage = FakeStorage()
+        with (
+            patch("terrapod.redis.client.get_redis_client", side_effect=RuntimeError("no redis")),
+            _use(storage),
+        ):
+            await _record()
+        assert "app" in storage.index()
+
+    async def test_a_held_lock_is_waited_out_then_bypassed(self, redis) -> None:
+        """Skipping would leave the entry stale for certain; updating unlocked
+        risks it only on a rare race."""
+        redis.values[sis.LOCK_KEY] = "someone-else"
+        storage = FakeStorage()
+        with (
+            _use(storage),
+            patch.object(sis, "LOCK_WAIT_SECONDS", 0.0),
+            patch.object(sis.asyncio, "sleep", AsyncMock()),
+        ):
+            await _record()
+        assert "app" in storage.index()
+        # Another holder's lock is not released on its behalf.
+        assert redis.values[sis.LOCK_KEY] == "someone-else"
+
+
+class TestEveryStateWriteRecordsTheIndex:
+    """Source-introspection invariant (#1581), in the style of #647's.
+
+    Every module that constructs a `StateVersion` must also call
+    `state_index_service.record_latest_state`, or the break-glass index goes
+    stale for whatever that path writes. Before #1581 five of seven paths
+    skipped it, including every agent-run apply.
+    """
+
+    ROOT = pathlib.Path(sis.__file__).resolve().parent.parent
+
+    def _modules(self) -> list[pathlib.Path]:
+        return sorted((self.ROOT / "api" / "routers").glob("*.py")) + sorted(
+            (self.ROOT / "services").rglob("*.py")
+        )
+
+    def test_every_state_version_writer_records_the_index(self) -> None:
+        offenders = [
+            str(path.relative_to(self.ROOT))
+            for path in self._modules()
+            if "StateVersion(" in path.read_text()
+            and "state_index_service.record_latest_state" not in path.read_text()
+        ]
+        assert offenders == [], (
+            f"module(s) create a StateVersion without recording the state index: {offenders}"
+        )
+
+    def test_the_scan_finds_the_known_writers(self) -> None:
+        """A guard that scans the wrong directory passes vacuously."""
+        writers = {path.name for path in self._modules() if "StateVersion(" in path.read_text()}
+        assert {
+            "run_artifacts.py",
+            "tfe_v2.py",
+            "pulumi_service.py",
+            "state_management.py",
+            "deleted_workspace_service.py",
+        } <= writers
+
+    def test_there_is_one_index_writer(self) -> None:
+        tfe_v2 = (self.ROOT / "api" / "routers" / "tfe_v2.py").read_text()
+        assert "def _update_state_index" not in tfe_v2
+        assert "def _remove_state_index_entry" not in tfe_v2


### PR DESCRIPTION
Closes #1581.

The break-glass state index, `state/index.yaml`, lets an operator without PostgreSQL find each workspace's latest state by name. Until now it was written only by the CLI's local-mode upload and a workspace rename. Every agent-mode workspace, which is to say every workspace run the normal way, was indexed at its last CLI upload or not at all. Replication and DR reporting called the index healthy all the same, because they check only that it exists.

## What changes

- **One helper, `services/state_index_service.py`,** replaces the two in `tfe_v2.py`. Every path that writes a state version now calls it:
  - Terraform/OpenTofu agent-run applies;
  - Pulumi runner hand-backs (#1576);
  - Pulumi service checkpoints and imports;
  - manual upload;
  - rollback;
  - workspace restore;
  - the CLI upload and the rename and delete paths, which already did.
- **A read error no longer wipes the index.** The old helper treated any failure to read the index as "no index yet" and wrote back a one-entry file, so a transient storage error erased every other workspace. Only a genuine not-found starts a fresh index now. Any other read failure, or a corrupt index, leaves the object untouched.
- **Writers are serialised** with a short Redis lock. The index is one object updated read-modify-write, and every agent apply now writes it, from any replica. If the lock can't be had within 10s the update goes ahead anyway: a rare race costs one entry until that workspace's next write, where skipping would cost it for certain.
- **An entry never rolls back** to an older serial for the same workspace. An entry for a different workspace id under the same name, such as a restore, is still replaced.
- **YAML parse and dump run off the event loop.** The index grows with the workspace count.
- **Guard test.** Any module under `api/routers` or `services` that constructs a `StateVersion` must call `record_latest_state`. The build fails otherwise, in the style of the #647 guard. A companion test checks that the scan actually finds the known writers, so it cannot pass vacuously.
- **Docs.** `docs/disaster-recovery.md` said the index "is updated on every state upload". That wasn't true; it is now, and the page lists the paths.

## Tests

- Service tests cover:
  - create, keep other entries, replace, no rollback, restore replaces;
  - remove, and remove of an absent entry;
  - a transient read error and a corrupt index are both left alone;
  - write failures are swallowed;
  - the lock is taken and released, and the no-Redis and held-lock paths.
- Each write path asserts the index call: the runner upload, the Pulumi hand-back (and not on a refused one), the Pulumi service write (and not when the state never landed), rollback and manual upload. A restore integration test reads the index back from real storage.

Venv suite: 4752 passed. The only failures are the seven known venv-only ones (`test_api_opa` ×2, `test_vcs_rate_limit` ×5). PR CI is the gate.
